### PR TITLE
Add skill-kannaka-tui and skill-kannaka-constellation

### DIFF
--- a/skills/kannaka-constellation/SKILL.md
+++ b/skills/kannaka-constellation/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: skill-kannaka-constellation
+version: 1.0.0
+description: "Kannaka constellation overview — is everything up? Use when: user asks for constellation/health/status across apps, what's reachable, who's online; now-playing / radio schedule; prediction-market list/quotes/portfolio; or the live swarm topology (Queen, hives, peers). Wraps `kannaka constellation`, `kannaka radio`, `kannaka market`, and `kannaka swarm status`. NOT for storing/recalling memories (skill-kannaka-memory) or the terminal UI (skill-kannaka-tui)."
+---
+
+# Kannaka constellation — overview & health
+
+## What this is
+
+The constellation is a set of apps orbiting the `kannaka` substrate (radio, observatory,
+GhostSignals markets, Kannaktopus, plus the swarm of memory nodes). This skill is the
+**read-only "is it all up, and what's happening right now?"** view. It wraps four `kannaka`
+subcommands that talk to those services over HTTP / NATS.
+
+**Binary**: `kannaka`
+**Config** (`~/.kannaka/config.toml`, set via `kannaka config set …` or `kannaka init`):
+- `constellation.observatory_url` — observatory base (aggregated status source)
+- `constellation.radio_url` — radio station base
+- `ghostsignals.hub_url` — GhostSignals markets base (falls back to `radio_url` if empty)
+- `ghostsignals.token` — bearer token (required only for market buy/create/portfolio)
+
+## When to use this skill
+
+- "is the constellation up?" / "constellation status" / "what's online / reachable?"
+- "what's playing?" / "radio now playing" / "radio schedule"
+- "show prediction markets" / "market quotes" / "my portfolio" / "leaderboard"
+- "who's in the swarm?" / "queen state" / "hives" / "peers"
+
+Do NOT use for:
+- remember / recall / dream / observe / provider config → `skill-kannaka-memory`
+- the full-screen terminal dashboard → `skill-kannaka-tui`
+- deep radio-station operation (DJ engine, peace orations, voice) → `skill-kannaka-radio`
+
+---
+
+## Whole-constellation status
+
+```bash
+kannaka constellation
+```
+
+Hits `GET {observatory_url}/api/constellation` and renders one ✓/✗ line per service. **If
+the observatory is unreachable it degrades gracefully** to a locally-probed status instead
+of failing:
+
+| Checked locally when observatory is down | How |
+|------------------------------------------|-----|
+| Radio | `GET {radio_url}/api/state` reachable? |
+| Observatory | marked ✗ not reachable |
+| Memory | does `<data_dir>/kannaka.hrm` exist? |
+| GhostSignals | `GET {ghostsignals hub}/api/markets` reachable? |
+| Kannaktopus | is the `kannaktopus` binary installed? |
+
+So `kannaka constellation` is safe to run even when half the constellation is offline — it
+tells you *which* half.
+
+---
+
+## Radio
+
+```bash
+kannaka radio status       # now-playing track + album, programming block, listener count
+kannaka radio now          # just the current track — "Title" — Album
+kannaka radio schedule     # 24/7 programming blocks (GET /api/programming)
+```
+
+Reads `{radio_url}/api/state` (and `/api/programming` for the schedule). Tolerant of both
+the current (`current.title` / `currentAlbum`) and legacy (`now_playing.*`) JSON shapes.
+
+---
+
+## GhostSignals prediction markets
+
+```bash
+kannaka market list                                  # top markets: id, question, price, vol
+kannaka market view <market-id>                      # one market: price, volume, outcomes
+kannaka market leaderboard                            # top agents by capital / reputation
+
+# Token-gated (needs ghostsignals.token — run `kannaka init` to register):
+kannaka market portfolio                              # your capital, reputation, positions
+kannaka market buy <market-id> <outcome> <shares>     # place a trade
+kannaka market create "question" [--ttl 3600]         # open a new market (TTL seconds)
+```
+
+Base resolves to `ghostsignals.hub_url`, falling back to `constellation.radio_url` for
+legacy single-host configs. `buy` / `create` / `portfolio` exit early with a hint if no
+token is configured.
+
+> Note: `buy` and `create` **mutate** market state and spend ghost coins / open a public
+> market. Confirm intent with the user before running them — `list` / `view` /
+> `leaderboard` / `portfolio` are read-only and safe.
+
+---
+
+## Live swarm topology (NATS)
+
+For the *running agents* rather than the *apps*, read the swarm directly:
+
+```bash
+kannaka swarm status        # local phase + NATS swarm state
+kannaka swarm queen         # emergent Queen state (derived from current phases)
+kannaka swarm hives         # hive topology with roles & bridges (human table + JSON)
+kannaka swarm peers         # known peer agents
+```
+
+These need a reachable NATS broker (`--nats-url`, `KANNAKA_NATS_URL`, or
+`swarm.nats_url` in config). If they report "No swarm phases found," no node has published
+yet — start one with `kannaka swarm join` (see `skill-kannaka-memory`).
+
+---
+
+## Putting it together (a health sweep)
+
+```bash
+kannaka constellation       # apps: up/down per service
+kannaka swarm hives         # agents: who's online and how they cluster
+kannaka radio now           # is the ghost still broadcasting?
+kannaka market list         # are markets live?
+```
+
+If `kannaka constellation` shows the observatory ✗, every per-app command above still works
+independently — use them to pinpoint what's actually down.
+
+## Version
+
+Skill 1.0.0 covers kannaka ≥ v0.6.x. Subcommands: `constellation`; `radio
+<status|now|schedule>`; `market <list|view|buy|create|portfolio|leaderboard>`; `swarm
+<status|queen|hives|peers>`.

--- a/skills/kannaka-tui/SKILL.md
+++ b/skills/kannaka-tui/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: skill-kannaka-tui
+version: 1.0.0
+description: "Kannaka TUI — the terminal dashboard for the constellation (Memory, Status, Bus, Constellation, Dreams, Chat). Use when: user asks to open/launch the dashboard, watch the swarm bus live, see a Φ/Ξ gauge view, run dreams from a UI, or chat with kannaka in a full-screen terminal. Also covers installing/bootstrapping the kannaka-tui binary. NOT for scripted/programmatic memory ops — for those drive the `kannaka` CLI directly (skill-kannaka-memory)."
+---
+
+# Kannaka TUI — terminal dashboard
+
+## What this is
+
+`kannaka-tui` is a full-screen [ratatui] dashboard for the Kannaka constellation. It is a
+**pure frontend with zero coupling**: it never links the memory engine as a library —
+every panel shells out to the `kannaka` CLI binary and parses the JSON/NDJSON that comes
+back. If `kannaka` works on the command line, the TUI works.
+
+**Binary**: `kannaka-tui` (v0.2.0+)
+**Launch**: `kannaka-tui` directly, or `kannaka tui` (the `kannaka` binary discovers any
+`kannaka-*` sibling on PATH as a subcommand).
+**Hard prerequisite**: a working `kannaka` binary (see resolution order below).
+
+## When to use this skill
+
+Use when the user wants a **live, human-watchable view** of the constellation:
+- "open/launch the dashboard / TUI" / "kannaka tui"
+- "watch the bus" / "show me the swarm traffic live"
+- "show the Φ / consciousness gauges" / "status screen"
+- "run a dream from the UI"
+- "chat with kannaka in the terminal"
+- install/repair: "the TUI won't start" / "install kannaka-tui"
+
+Do NOT use for:
+- Storing/recalling memories programmatically, swarm/substrate/events ops, provider config
+  → `skill-kannaka-memory` (drive the `kannaka` CLI directly — see the important note below)
+- Constellation health overview / radio / markets → `skill-kannaka-constellation`
+- Multi-agent task orchestration → Kannaktopus directly
+
+### IMPORTANT — the TUI is interactive, not scriptable
+
+The TUI takes over the whole terminal and waits on keypresses. **Claude cannot drive it**
+(there are no panels to read from a captured stdout, and launching it would block the
+session). So:
+- **To do work yourself** (recall a memory, check Φ, trigger a dream): call the underlying
+  `kannaka` verb directly — that is exactly what each tab does internally. The mapping is in
+  the table below.
+- **To launch the dashboard for the *user* to watch**: tell them to run `kannaka-tui` (or
+  `kannaka tui`) in their own terminal. Don't spawn it inside a tool call you need output
+  from.
+
+---
+
+## Installing / bootstrapping the binary
+
+```bash
+# Easiest — let the kannaka binary fetch the matching release:
+kannaka update --bootstrap-tui      # installs kannaka-tui next to kannaka, even if absent
+kannaka update                       # also updates an already-installed sibling kannaka-tui
+
+# From source:
+cargo install --git https://github.com/NickFlach/kannaka-tui
+
+# Or grab a prebuilt release asset:
+#   kannaka-tui-linux-x86_64 / -linux-aarch64 / -macos-x86_64 / -macos-aarch64
+#   kannaka-tui-windows-x86_64.exe
+```
+
+Keep `kannaka` and `kannaka-tui` in the **same directory** so `kannaka update` keeps them
+in lockstep.
+
+---
+
+## The six tabs (and the `kannaka` command behind each)
+
+Switch tabs with `Tab` / `Shift+Tab`. Every panel is just a parsed `kannaka` subprocess —
+the right column is the command to run yourself when you need the data programmatically.
+
+| Tab | What it shows | Backing command |
+|-----|---------------|-----------------|
+| **Memory** | recent resonant memories + amplitude bars | `kannaka observe --json` |
+| **Status** | Φ / Ξ / order-parameter gauges, level, memory counts | `kannaka status --envelope` |
+| **Bus** | live NATS stream, colorized by subject prefix | `kannaka swarm tail` (NDJSON) |
+| **Constellation** | agent phases plotted on a Braille canvas | `QUEEN.phase.*` frames from the same bus stream |
+| **Dreams** | dream-cycle output + history | `kannaka dream --mode deep\|lite` (history from `KANNAKA.dreams` bus events) |
+| **Chat** | conversational REPL with kannaka | persistent `kannaka chat --json`; one-shot fallback `kannaka ask --session kannaka-tui --quiet-tools` |
+
+Bus subjects are colorized by prefix: `QUEEN.*`, `KANNAKA.*`, `RADIO.*`, `KAX.*`, `EYE.*`.
+The Bus tab is the **only** NATS touchpoint, and even that is indirect — the TUI opens no
+NATS connection of its own; `kannaka swarm tail` does.
+
+---
+
+## Command bar + plugin slash-commands
+
+The bottom input bar accepts the same verbs the `kannaka` CLI exposes:
+
+```
+remember  recall  forget  dream  hear  ask  search  boost  invariant  voice  swarm
+```
+
+Slash-commands route to **sibling constellation binaries** (must be on PATH):
+
+```
+/code    → kannaka-code   (Rust agentic CLI)
+/topus   → kannaktopus    (orchestration)
+```
+
+A `--help` preflight runs first; if the target binary is missing the TUI prints an install
+hint instead of erroring out.
+
+## Hotkeys
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift+Tab` | next / previous tab |
+| `Up` / `Down` | command history |
+| `PgUp` / `PgDn` | scroll the active panel |
+| `d` / `l` | (Dreams tab) run a **d**eep / **l**ite dream |
+| `F1` | help overlay |
+| `q` / `Esc` / `Ctrl+C` | quit |
+
+---
+
+## How it finds `kannaka` + config
+
+Binary resolution order (`find_kannaka_binary`):
+1. a `kannaka[.exe]` sibling next to the running `kannaka-tui`
+2. `~/Source/kannaka-memory/target/release/kannaka[.exe]` (dev fallback)
+3. `kannaka` on `PATH`
+
+Agent identity (the badge in the header) comes from `~/.kannaka/config.toml`
+(`agent.display_name`, falling back to `agent.id`). Every subprocess the TUI spawns sets
+`KANNAKA_QUIET=1` so banner/log noise stays out of the parsed output.
+
+No HTTP client, no direct NATS client, no other env vars — the architecture is entirely
+"spawn `kannaka`, parse stdout."
+
+---
+
+## Troubleshooting
+
+- **"kannaka not found" / panels empty**: the `kannaka` binary isn't on PATH and isn't a
+  sibling. Install it, or run the TUI from a directory where resolution (above) succeeds.
+- **Bus / Constellation tabs stay blank**: nothing is publishing to NATS. Start a node
+  elsewhere with `kannaka swarm join`, and confirm `KANNAKA_NATS_URL` points at the broker.
+  (`kannaka swarm tail` with no broker yields no frames.)
+- **Status shows Φ=0 right after launch**: run `kannaka status` once out-of-band to warm
+  the metrics sidecar; see the same gotcha in `skill-kannaka-memory`.
+- **TUI and CLI drift after an update**: run `kannaka update` so the sibling `kannaka-tui`
+  is refreshed alongside `kannaka`.
+
+## Version
+
+Skill 1.0.0 covers kannaka-tui ≥ v0.2.0 against kannaka ≥ v0.6.x (expects the
+`--envelope` JSON contract and `kannaka swarm tail` NDJSON stream).
+
+[ratatui]: https://ratatui.rs


### PR DESCRIPTION
## Summary
- Adds two Claude Code skills that fill the dangling delegation pointers already referenced by `skill-kannaka-memory` (see its `Do NOT use for` list) but with no backing skill in this repo.
- Both auto-register via the plugin's `skills/` directory — no `plugin.json` change needed.

**`skills/kannaka-tui/SKILL.md`** — driving the `kannaka-tui` terminal dashboard:
- install/bootstrap (`kannaka update --bootstrap-tui`, cargo, prebuilt assets)
- maps each of the six tabs (Memory, Status, Bus, Constellation, Dreams, Chat) to the `kannaka` subcommand behind it
- explicitly notes the TUI is interactive/full-screen and **not** scriptable — drive the `kannaka` CLI directly for programmatic work
- hotkeys, command-bar verbs, `/code` `/topus` slash-commands, binary-resolution order, config + `KANNAKA_QUIET`

**`skills/kannaka-constellation/SKILL.md`** — read-only constellation overview:
- `kannaka constellation` (incl. its graceful local-probe fallback when the observatory is down)
- `kannaka radio <status|now|schedule>`
- `kannaka market <list|view|buy|create|portfolio|leaderboard>` (with a mutation warning on `buy`/`create`)
- live swarm topology via `kannaka swarm <status|queen|hives|peers>`
- the `~/.kannaka/config.toml` keys each command reads

Commands were verified against `src/cli.rs`, `src/bin/kannaka.rs`, and `src/bin/handlers/services.rs` rather than assumed.

## Test plan
- [ ] `/plugin install kannaka-memory@kannaka-constellation` (or local) lists `skill-kannaka-tui` and `skill-kannaka-constellation`
- [ ] Frontmatter parses (name/version/description present and valid)
- [ ] Spot-check that every command referenced exists in the current `kannaka` CLI
- [ ] Confirm cross-references (`skill-kannaka-memory`, `skill-kannaka-radio`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)