### PR TITLE
[auto-maintainer] refactor(xi_clusters): compute Kuramoto sc/ss once for mean_phase and order

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -473,16 +473,13 @@ impl ResonanceEngine {
                     .map(|m| m.phase)
                     .collect();
                 let n = phases.len() as f32;
-                let mean_phase = if n > 0.0 {
+                let (mean_phase, order) = if n > 0.0 {
                     let sc: f32 = phases.iter().map(|p| p.cos()).sum::<f32>() / n;
                     let ss: f32 = phases.iter().map(|p| p.sin()).sum::<f32>() / n;
-                    ss.atan2(sc)
-                } else { 0.0 };
-                let order = if n > 0.0 {
-                    let sc: f32 = phases.iter().map(|p| p.cos()).sum::<f32>() / n;
-                    let ss: f32 = phases.iter().map(|p| p.sin()).sum::<f32>() / n;
-                    (sc * sc + ss * ss).sqrt()
-                } else { 0.0 };
+                    (ss.atan2(sc), (sc * sc + ss * ss).sqrt())
+                } else {
+                    (0.0, 0.0)
+                };
                 MemoryCluster {
                     memory_ids: ids,
                     order_parameter: order,


### PR DESCRIPTION
## What changed

One method in `src/store.rs`: `ResonanceEngine::xi_clusters`.

### The redundancy

`xi_clusters` iterates over each bucket's `phases` vector to compute
the Kuramoto circular-mean components `sc` and `ss` in **two separate
`if n > 0.0` blocks**:

**Before (two passes):**
```rust
let mean_phase = if n > 0.0 {
    let sc: f32 = phases.iter().map(|p| p.cos()).sum::<f32>() / n;
    let ss: f32 = phases.iter().map(|p| p.sin()).sum::<f32>() / n;
    ss.atan2(sc)
} else { 0.0 };

let order = if n > 0.0 {
    let sc: f32 = phases.iter().map(|p| p.cos()).sum::<f32>() / n;   // ← second pass
    let ss: f32 = phases.iter().map(|p| p.sin()).sum::<f32>() / n;   // ← second pass
    (sc * sc + ss * ss).sqrt()
} else { 0.0 };
```

`n` is constant between the two blocks, and `phases` is immutable. Both
blocks therefore compute **identical** `sc` and `ss` values. The second
pass is dead work.

**After (one pass):**
```rust
let (mean_phase, order) = if n > 0.0 {
    let sc: f32 = phases.iter().map(|p| p.cos()).sum::<f32>() / n;
    let ss: f32 = phases.iter().map(|p| p.sin()).sum::<f32>() / n;
    (ss.atan2(sc), (sc * sc + ss * ss).sqrt())
} else {
    (0.0, 0.0)
};
```

`sc` and `ss` are computed once; `mean_phase` and `order` are
destructured from the same single branch. Net change: −8 lines, one
fewer pair of iterator passes per frequency-category bucket.

### Context

This is the same redundant-pass pattern that was fixed for
`project_attention` in `working_memory.rs` (PR #122). That fix merged
two `store.all_memories()` calls; this fix merges two `phases.iter()`
passes for the Kuramoto circular-mean inside `xi_clusters`.

## Why it's safe

- **Identical output.** `mean_phase` and `order` are derived from
  `ss.atan2(sc)` and `sqrt(sc² + ss²)` respectively. With the same
  `phases` and the same `n`, the computed `sc` and `ss` are
  bit-for-bit identical, so both outputs are unchanged.
- **No signature or type changes.** `xi_clusters()` still returns
  `Vec<MemoryCluster>` with the same fields populated the same way.
- **Not a duplicate of PR #122.** That PR touched `working_memory.rs`
  (`project_attention`). This PR touches `store.rs` (`xi_clusters`), a
  different function in a different file.

## Verification

```
git diff --stat
  src/store.rs | 13 +++++--------
  1 file changed, 5 insertions(+), 8 deletions(-)
```

Structural review confirms the change is syntactically valid Rust:
- `let (mean_phase, order) = if … { (expr, expr) } else { (0.0, 0.0) };`
  is standard tuple destructuring from an `if`/`else` expression.
- Both `mean_phase` and `order` remain in scope for the
  `MemoryCluster { order_parameter: order, mean_phase, coherence: order, … }`
  construction immediately below — unchanged.

`cargo check` was attempted but blocked by a missing local-path
dependency (`consciousness-core` at `../consciousness-core`), which is
not cloned in this remote execution context. The change is isolated to
an arithmetic expression with no new imports and no type changes; the
soundness argument is therefore by structural review, mirroring the
same reasoning used in PR #122.

## Runtime

~25 minutes wall-clock (startup jitter + in-flight detection across 6
repos + commit-timestamp fetch + 6-repo PR/issue anti-noise scan +
repo listing + source survey across 7 files + fix + cargo check attempt
+ push + pre-PR duplicate scan + PR).

---
_Generated by the kannaka constellation hourly maintainer_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKNBhCizwXdNVww5E2bYCW)_