### PR TITLE
[auto-maintainer] refactor(codebook): extract box_muller() helper to deduplicate N(0,1) sampling

### DIFF
--- a/src/codebook.rs
+++ b/src/codebook.rs
@@ -15,6 +15,14 @@ pub struct Codebook {
     seed: u64,
 }
 
+/// Draw one sample from N(0, 1) using the Box-Muller transform.
+/// Guards u1 against log(0) by clamping to 1e-10.
+fn box_muller(rng: &mut impl Rng) -> f32 {
+    let u1: f32 = rng.gen::<f32>().max(1e-10);
+    let u2: f32 = rng.gen();
+    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
+}
+
 impl Codebook {
     /// Create a new codebook with a seeded random projection matrix.
     /// Each element is drawn from N(0, 1/sqrt(output_dim)) for variance preservation.
@@ -24,11 +32,7 @@ impl Codebook {
         let len = input_dim * output_dim;
         let mut matrix = Vec::with_capacity(len);
         for _ in 0..len {
-            // Box-Muller for normal distribution
-            let u1: f32 = rng.gen::<f32>().max(1e-10);
-            let u2: f32 = rng.gen();
-            let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
-            matrix.push(z * scale);
+            matrix.push(box_muller(&mut rng) * scale);
         }
         Self { matrix, input_dim, output_dim, seed }
     }
@@ -56,11 +60,7 @@ impl Codebook {
     pub fn random_vector(&self) -> Vec<f32> {
         // Use a derived seed so it's deterministic but different from matrix generation
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(0xCAFE));
-        let mut v: Vec<f32> = (0..self.output_dim).map(|_| {
-            let u1: f32 = rng.gen::<f32>().max(1e-10);
-            let u2: f32 = rng.gen();
-            (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
-        }).collect();
+        let mut v: Vec<f32> = (0..self.output_dim).map(|_| box_muller(&mut rng)).collect();
         normalize(&mut v);
         v
     }


### PR DESCRIPTION
## What changed

One file, `src/codebook.rs`. The Box-Muller transform was copy-pasted verbatim in two places:

**`Codebook::new()`** (matrix generation loop):
```rust
for _ in 0..len {
    // Box-Muller for normal distribution
    let u1: f32 = rng.gen::<f32>().max(1e-10);
    let u2: f32 = rng.gen();
    let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
    matrix.push(z * scale);
}
```

**`Codebook::random_vector()`** (closure):
```rust
let mut v: Vec<f32> = (0..self.output_dim).map(|_| {
    let u1: f32 = rng.gen::<f32>().max(1e-10);
    let u2: f32 = rng.gen();
    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
}).collect();
```

Both use the identical 3-line formula with the same 1e-10 guard against `log(0)`.

**After** — a private `box_muller()` helper is extracted, both call sites become one-liners:

```rust
fn box_muller(rng: &mut impl Rng) -> f32 {
    let u1: f32 = rng.gen::<f32>().max(1e-10);
    let u2: f32 = rng.gen();
    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
}

// new():
matrix.push(box_muller(&mut rng) * scale);

// random_vector():
(0..self.output_dim).map(|_| box_muller(&mut rng)).collect()
```

The inline `// Box-Muller for normal distribution` comment in `new()` is removed — the function name carries that documentation more reliably.

## Why it's safe

- **No behaviour change.** Same RNG type (`ChaCha8Rng`), same formula, same argument order. The extracted helper is called with the same `&mut rng` borrow at the same points in each method, producing bit-for-bit identical output.
- **Module-private.** `box_muller` is not `pub`, so no API surface changes.
- **No new imports.** `Rng` was already in scope (`use rand::Rng;`) for the `.gen()` calls; `impl Rng` in the helper signature requires nothing new.
- **No lockfile, no dependency changes, no workflow files touched.**

## Verification

This is a Rust crate with a local-path dependency (`consciousness-core`) that isn't cloned in this remote execution environment, so `cargo check` can't run locally. Soundness argument by structural review:

- The extracted function is identical to both inlined copies — verified character-by-character.
- `impl Rng` bound is satisfied by `ChaCha8Rng` (it implements `rand::Rng`), the same type used at both call sites before this change.
- All four existing tests (`projected_vectors_are_unit_length`, `reproducible_with_same_seed`, `random_vector_is_unit_length`, `different_inputs_produce_different_vectors`) are preserved unchanged and exercise both `new()` and `random_vector()` paths.

**Not a duplicate** of open PRs #122 (`working_memory.rs` / `project_attention`) or #123 (`store.rs` / `xi_clusters`). This PR touches only `src/codebook.rs`.

## Runtime

~20 minutes wall-clock (startup jitter + in-flight detection across 6 repos + commit-timestamp fetches + default-branch age survey + backlog anti-noise checks + source survey across rhythm/wave/consciousness/xi_operator/memory/codebook + refactor + pre-PR duplicate check + PR).

---
_Generated by the kannaka constellation hourly maintainer_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Et9Uoh4Xp4aEfjgZd8cveb)_