### PR TITLE
fix: open-issue backlog — #111, #112, #114, #116

### DIFF
--- a/src/bin/handlers/ops.rs
+++ b/src/bin/handlers/ops.rs
@@ -113,7 +113,7 @@ pub(crate) fn handle_config(cfg: &KannakaConfig, args: &[String]) {
                     eprintln!("Usage: kannaka config set <key> <value>");
                     eprintln!();
                     eprintln!("Keys: agent.id, agent.display_name, llm.provider, llm.model,");
-                    eprintln!("      llm.api_key, llm.base_url, swarm.enabled, swarm.nats_url,");
+                    eprintln!("      llm.api_key, llm.base_url, swarm.enabled, swarm.nats_url, swarm.role,");
                     eprintln!("      ghostsignals.enabled, ghostsignals.token, ghostsignals.hub_url,");
                     eprintln!("      constellation.radio_url, constellation.observatory_url,");
                     eprintln!("      hrm.path, hrm.wavefront_dim, updates.auto_check");
@@ -164,6 +164,17 @@ pub(crate) fn handle_config(cfg: &KannakaConfig, args: &[String]) {
                     }
                 }
                 "swarm.nats_url" => new_cfg.swarm.nats_url = value.clone(),
+                // #112: swarm.role was a settable-looking but unsettable field.
+                // It is read at swarm-connect time (announced to the constellation,
+                // see config.rs swarm connect log), so make it a real knob.
+                "swarm.role" => {
+                    let v = value.trim();
+                    if v.is_empty() {
+                        eprintln!("swarm.role must be a non-empty role label (e.g. queen, worker, witness)");
+                        process::exit(1);
+                    }
+                    new_cfg.swarm.role = v.to_string();
+                }
                 "ghostsignals.enabled" => {
                     match parse_bool(value) {
                         Ok(b) => new_cfg.ghostsignals.enabled = b,

--- a/src/bin/handlers/substrate.rs
+++ b/src/bin/handlers/substrate.rs
@@ -1030,3 +1030,131 @@ pub(crate) fn handle_substrate_init(
         seeded, failed, marker_path.display());
     eprintln!("[init] substrate is now class-structured; restart `kannaka substrate run` so absorbs flow into the seeded clusters");
 }
+
+/// #116 — `kannaka events gc [--corrupt-backs] [--older-than DAYS] [--dry-run]`.
+///
+/// When a `.hrm` fails to load, defensive recovery leaves `*.corrupt-bak-*`
+/// (and `*.v2-backup*`) sidecars next to it — ~10 MB each. Nothing ever
+/// reclaims them, so on small boxes (Oracle root is 30 GB) they accumulate
+/// into real disk pressure. This sweeps backup sidecars older than N days
+/// (default 7) from the HRM directory. Recent backups are retained so an
+/// operator can still attempt salvage after a fresh corruption.
+pub(crate) fn handle_events_gc(cfg: &KannakaConfig, args: &[String]) {
+    let mut older_than_days: u64 = 7;
+    let mut dry_run = false;
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            // --corrupt-backs is the (only, default) category today; accepted
+            // explicitly so the documented invocation works and to leave room
+            // for future categories without a breaking flag change.
+            "--corrupt-backs" => i += 1,
+            "--older-than" if i + 1 < args.len() => {
+                match args[i + 1].parse::<u64>() {
+                    Ok(d) => older_than_days = d,
+                    Err(_) => {
+                        eprintln!("--older-than expects a whole number of days, got: {}", args[i + 1]);
+                        process::exit(1);
+                    }
+                }
+                i += 2;
+            }
+            "--dry-run" => { dry_run = true; i += 1; }
+            other => { eprintln!("[gc] ignoring unknown flag: {other}"); i += 1; }
+        }
+    }
+
+    // Resolve the HRM directory the same way the main CLI resolves the store
+    // (cfg.hrm.path's parent when set, else the data dir).
+    let dd = data_dir();
+    let hrm_dir = if !cfg.hrm.path.is_empty() {
+        let p = std::path::PathBuf::from(&cfg.hrm.path);
+        let full = if p.file_name().is_some() {
+            if p.is_absolute() { p } else { dd.join(p) }
+        } else {
+            dd.join("kannaka.hrm")
+        };
+        full.parent().map(|p| p.to_path_buf()).unwrap_or_else(|| dd.clone())
+    } else {
+        dd.clone()
+    };
+
+    let entries = match std::fs::read_dir(&hrm_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("[gc] cannot read HRM dir {}: {}", hrm_dir.display(), e);
+            process::exit(1);
+        }
+    };
+
+    // A backup sidecar carries `.corrupt-bak` or `.v2-backup` in its name —
+    // never the live `kannaka.hrm` itself.
+    let is_backup = |name: &str| name.contains(".corrupt-bak") || name.contains(".v2-backup");
+
+    let cutoff = std::time::Duration::from_secs(older_than_days.saturating_mul(86_400));
+    let now = std::time::SystemTime::now();
+
+    let mut candidates: Vec<(std::path::PathBuf, u64)> = Vec::new(); // (path, bytes)
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !is_backup(&name) {
+            continue;
+        }
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let age_ok = meta
+            .modified()
+            .ok()
+            .and_then(|m| now.duration_since(m).ok())
+            .map(|age| age >= cutoff)
+            .unwrap_or(false);
+        if age_ok {
+            candidates.push((path, meta.len()));
+        }
+    }
+
+    if candidates.is_empty() {
+        eprintln!(
+            "[gc] no backup sidecars older than {} day(s) in {}",
+            older_than_days, hrm_dir.display()
+        );
+        return;
+    }
+
+    candidates.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut reclaimed: u64 = 0;
+    let mut removed = 0usize;
+    for (path, bytes) in &candidates {
+        if dry_run {
+            println!("[gc] would delete {} ({:.1} MB)", path.display(), *bytes as f64 / 1.0e6);
+        } else {
+            match std::fs::remove_file(path) {
+                Ok(()) => {
+                    println!("[gc] deleted {} ({:.1} MB)", path.display(), *bytes as f64 / 1.0e6);
+                    reclaimed += bytes;
+                    removed += 1;
+                }
+                Err(e) => eprintln!("[gc] failed to delete {}: {}", path.display(), e),
+            }
+        }
+    }
+
+    if dry_run {
+        let total: u64 = candidates.iter().map(|(_, b)| *b).sum();
+        eprintln!(
+            "[gc] dry-run: {} file(s), {:.1} MB reclaimable (re-run without --dry-run to delete)",
+            candidates.len(), total as f64 / 1.0e6
+        );
+    } else {
+        eprintln!("[gc] done — removed {} file(s), reclaimed {:.1} MB", removed, reclaimed as f64 / 1.0e6);
+    }
+}

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -30,6 +30,7 @@ use handlers_substrate::{
     handle_substrate_init, handle_substrate_status,
     handle_events_init, handle_events_snapshot,
     handle_events_list_snapshots, handle_events_restore,
+    handle_events_gc,
 };
 
 #[path = "handlers/chat.rs"]
@@ -1997,7 +1998,7 @@ fn main() {
             //   snapshot  — capture + publish a gzipped HRM snapshot (Phase 2).
             //               --interval N runs as a daemon at N-second cadence.
             if args.len() < command_start + 2 {
-                eprintln!("Usage: kannaka events <init|snapshot [--interval SECS]|list-snapshots [--agent ID] [--json]|restore [--agent ID] [--from PATH|--from-url URL] [--dry-run]>");
+                eprintln!("Usage: kannaka events <init|snapshot [--interval SECS]|list-snapshots [--agent ID] [--json]|restore [--agent ID] [--from PATH|--from-url URL] [--dry-run]|gc [--corrupt-backs] [--older-than DAYS] [--dry-run]>");
                 process::exit(1);
             }
             match args[command_start + 1].as_str() {
@@ -2013,9 +2014,12 @@ fn main() {
                 "restore" => {
                     handle_events_restore(&cfg, &args[command_start..]);
                 }
+                "gc" => {
+                    handle_events_gc(&cfg, &args[command_start..]);
+                }
                 other => {
                     eprintln!("Unknown events command: {other}");
-                    eprintln!("Usage: kannaka events <init|snapshot [--interval SECS]|list-snapshots [--agent ID] [--json]|restore [--agent ID] [--from PATH|--from-url URL] [--dry-run]>");
+                    eprintln!("Usage: kannaka events <init|snapshot [--interval SECS]|list-snapshots [--agent ID] [--json]|restore [--agent ID] [--from PATH|--from-url URL] [--dry-run]|gc [--corrupt-backs] [--older-than DAYS] [--dry-run]>");
                     process::exit(1);
                 }
             }
@@ -2067,11 +2071,54 @@ fn main() {
                     handle_attention_serve(&mut sys, &cfg, &args[command_start..]);
                 }
                 "stats" => {
-                    // One-shot stats — the serve loop holds the live beam in
-                    // memory, so this mostly prints zeros unless the daemon is
-                    // co-located. Reserved for the future shared-memory or
-                    // file-handoff path.
-                    println!("{{\"beam_size\":0,\"recency_len\":0,\"lookback_len\":0,\"landmarks_len\":0,\"observations\":0,\"note\":\"stats are live only inside the serve process; this CLI is a stub for now\"}}");
+                    // #114: real cross-process stats. The serve loop dumps live
+                    // beam state to KANNAKA_ATTENTION_BEAM_FILE every iteration;
+                    // read+reflect it here instead of a hardcoded zero stub. If
+                    // no serve process has written the file, say so plainly
+                    // (exit 0 — "offline" is a truthful answer) rather than
+                    // reporting fake zeroes as if a live beam existed.
+                    let dump_path = std::env::var("KANNAKA_ATTENTION_BEAM_FILE")
+                        .unwrap_or_else(|_| {
+                            if cfg!(windows) {
+                                "C:\\Users\\Public\\kannaka-attention-beam.json".to_string()
+                            } else {
+                                "/tmp/kannaka-attention-beam.json".to_string()
+                            }
+                        });
+                    match std::fs::read_to_string(&dump_path) {
+                        Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
+                            Ok(dump) => {
+                                let st = dump.get("stats").cloned().unwrap_or_else(|| serde_json::json!({}));
+                                let u = |k: &str| st.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
+                                let out = serde_json::json!({
+                                    "beam_size": u("beam_size"),
+                                    "recency_len": u("recency_len"),
+                                    "lookback_len": u("lookback_len"),
+                                    "landmarks_len": u("landmarks_len"),
+                                    "observations": u("observations"),
+                                    "candidates": dump.get("candidates").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0),
+                                    "ts": dump.get("ts").and_then(|v| v.as_str()).unwrap_or(""),
+                                    "source": dump_path,
+                                });
+                                println!("{}", out);
+                            }
+                            Err(e) => {
+                                let out = serde_json::json!({
+                                    "error": format!("failed to parse beam dump: {e}"),
+                                    "source": dump_path,
+                                });
+                                println!("{}", out);
+                            }
+                        },
+                        Err(_) => {
+                            let out = serde_json::json!({
+                                "beam_size": 0, "recency_len": 0, "lookback_len": 0,
+                                "landmarks_len": 0, "observations": 0,
+                                "note": format!("no attention serve process has written {dump_path} — beam offline"),
+                            });
+                            println!("{}", out);
+                        }
+                    }
                 }
                 other => {
                     eprintln!("Unknown attention command: {other}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1670,9 +1670,18 @@ fn register_ghostsignals(hub_url: &str, agent_id: &str, display_name: &str, kind
     let json: serde_json::Value = resp.into_json()
         .map_err(|e| format!("failed to parse response: {e}"))?;
 
-    let token = json["token"].as_str()
-        .unwrap_or("")
-        .to_string();
+    // #111: a 200 OK with a missing/empty `token` is NOT success. Returning
+    // an empty token here let the installer persist `ghostsignals.enabled = true`
+    // with a blank token and print "Registered", leaving a silently-broken
+    // identity that only fails much later on the first authenticated call.
+    let token = json["token"].as_str().unwrap_or("").to_string();
+    if token.trim().is_empty() {
+        let body = serde_json::to_string(&json).unwrap_or_default();
+        let preview: String = body.chars().take(200).collect();
+        return Err(format!(
+            "registration response missing/empty 'token' field (body: {preview})"
+        ));
+    }
 
     Ok(token)
 }
@@ -3304,5 +3313,29 @@ pub fn offer_tui_launch() {
         }
     } else {
         eprintln!("  TUI not found. Build with: cargo build --features tui --bin kannaka-tui");
+    }
+}
+
+#[cfg(test)]
+mod config_field_tests {
+    use super::*;
+
+    // #112: swarm.role used to be a dead field — defined with a default but
+    // never settable and never read. These guard that it stays a real,
+    // round-trippable knob (it is now settable via `config set swarm.role`
+    // and surfaced at swarm-connect time).
+    #[test]
+    fn swarm_role_default_is_queen() {
+        let cfg = KannakaConfig::default();
+        assert_eq!(cfg.swarm.role, "queen");
+    }
+
+    #[test]
+    fn swarm_role_survives_toml_roundtrip() {
+        let mut cfg = KannakaConfig::default();
+        cfg.swarm.role = "witness".to_string();
+        let toml = toml::to_string(&cfg).expect("serialize config");
+        let back: KannakaConfig = toml::from_str(&toml).expect("deserialize config");
+        assert_eq!(back.swarm.role, "witness");
     }
 }


### PR DESCRIPTION
Triaged all 17 open issues against current `master` (v0.6.12). Most were filed against v0.3.x–v0.6.9; several are already resolved. This PR implements the still-relevant, safely-scoped ones.

## Implemented (Closes)

- **Closes #111** — `register_ghostsignals` treated a `200 OK` with missing/empty `token` as success (`Ok("")`), so the installer persisted `ghostsignals.enabled=true` with a blank token and printed "Registered". Now returns `Err` on empty token; install/setup surfaces the failure instead of a silently-broken identity.
- **Closes #112** — `swarm.role` was a dead field (default `"queen"`, read at swarm-connect but never settable). Added a validated `config set swarm.role` arm + help text, and two round-trip regression tests. It's now a real, settable knob surfaced at connect time.
- **Closes #114** — `kannaka attention stats` returned a hardcoded zero stub. The serve loop already dumps live beam state to `KANNAKA_ATTENTION_BEAM_FILE` each iteration; `stats` now reads + reflects it (real `beam_size`/`observations`/`candidates`/`ts`), or reports `beam offline` honestly when no daemon has written the file. (Issue's option 1 — real cross-process handoff.)
- **Closes #116** — added `kannaka events gc [--corrupt-backs] [--older-than DAYS] [--dry-run]` to reclaim `*.corrupt-bak-*` / `*.v2-backup*` sidecars older than N days (default 7) from the HRM directory, retaining recent backups for salvage. (Issue's offered subcommand alternative.)

## Already fixed on master — recommend closing as resolved

- **#69** — duplicated wavefront logic: already extracted to `src/medium/wavefront_store.rs` (`WavefrontStore`).
- **#70** — CI pipeline: `.github/workflows/ci.yml` already runs check/test/clippy (fmt intentionally deferred, documented inline).
- **#108** — `hrm.path` custom filenames: already honored verbatim in `kannaka.rs` (fixed under #100/#94).
- **#110** — `config set ghostsignals.hub_url`: arm already present in `handlers/ops.rs`.
- **#113** — `--version`: already sources `CONSCIOUSNESS_CORE_VERSION` (a real `env!()` build var), not the app version twice.

## Deferred (too large/risky for a drive-by — left open with rationale)

- **#107** recompute-encoding: a one-shot HRM data-migration tool. `#106` (its prereq) is closed, so it's now actionable, but the store API has no clean iterate-and-re-encode surface and getting fold/hemisphere re-encoding wrong would corrupt production HRMs. Needs its own focused PR + snapshot-gated rollout.
- **#118** absorb dedup: changes core absorb-commit semantics (could drop legitimate memories); needs validation against real Ξ dynamics, partly radio-side.
- **#65** CS-6 hemispheric routing: explicitly "needs prototype before committing" + Φ/Ξ measurement.
- **#95** memory-triage ADR: design doc / architecture decision.
- **#102 / #104 / #105** TUI MCP-client / trajectory-viewer / autocomplete: multi-phase features with cross-repo dependencies.

## Verification

- `cargo check --bin kannaka` ✓, `cargo check --bin research` ✓
- `cargo test --lib config_field_tests` ✓ (2 new tests pass)
- Smoke-tested against a temp data dir: `config set swarm.role` (accept/reject), `attention stats` (offline + live dump), `events gc --dry-run` (ages correctly, skips recent backup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)