### PR TITLE
feat(triage): ADR-0031 Phase 1 online prune — kannaka triage (#95)

### DIFF
--- a/docs/adr/ADR-0031-memory-triage-architecture.md
+++ b/docs/adr/ADR-0031-memory-triage-architecture.md
@@ -1,8 +1,12 @@
 # ADR-0031 — Memory Triage Architecture (retire prune-cron as a bridge measure)
 
-Status: **Proposed**
+Status: **Accepted** (ratified 2026-06-06; Phase 1 shipped)
 Date: 2026-06-06
 Authors: Nick Flaukowski (vision), Claude (drafting)
+Note: the shipped CLI uses the flat command `kannaka triage` (consistent with the
+existing flat `prune-prefix` / `forget` / `boost` commands), not the `kannaka
+memory triage` group spelled tentatively below. `promote`/`pin` (Phase 2) will
+follow the same flat convention.
 Related: ADR-0020 (Holographic Resonance Medium), ADR-0021 (Chiral Mirror),
          ADR-0022 (Wave-Native Dreaming), ADR-0027 (Collective Substrate),
          ADR-0028 (Event-Sourced HRM Time Machine)
@@ -151,10 +155,13 @@ tick instead of being interrupted by an external cron.
 
 ## Phased rollout
 
-- **Phase 1 — online prune (replaces the cron).**
-  `kannaka memory triage [--dry-run] [--max-evict N]` running the §1 policy as an
-  in-process op behind `KANNAKA_TRIAGE=1`. Emits forget events. This alone lets
-  us delete `prune-cron.sh` and end the stream drops. Dry-run is the default.
+- **Phase 1 — online prune (replaces the cron). ✅ SHIPPED.**
+  `kannaka triage [--apply] [--max-evict N] [--redundancy R] [--min-amplitude A]
+  [--min-age-hours H]` runs the §1 policy as an in-process op (the invoking
+  process is the single writer, so it holds the lock it already owns — no
+  external offline mutation, no stream drop). **Dry-run is the default**;
+  `--apply` performs `forget`+atomic-save, and each eviction is a normal forget
+  (replayable via ADR-0028 events). This alone lets us delete `prune-cron.sh`.
 
 - **Phase 2 — the `tier` tag + promotion.**
   `WavefrontMeta.tier`, ear-loop absorbs default to `ShortTerm`, dream/recall

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -179,6 +179,7 @@ fn usage_lines() -> &'static [&'static str] {
         "  recall \"query\"             Recall memories (--top-k N)",
         "  search \"query\"             Literal text search (--limit N, --json)",
         "  forget <id>               Remove a memory",
+        "  triage [--apply]          Prune redundant low-value memories (Ξ-preserving; dry-run default)",
         "  dream [--mode deep|lite]   Trigger dream cycle",
         "  observe [--json]          View consciousness metrics",
         "  status                    Quick status check",
@@ -331,7 +332,7 @@ fn is_builtin_subcommand(verb: &str) -> bool {
         "init"
         // memory primitives
         | "remember" | "recall" | "search" | "forget" | "prune-prefix"
-        | "boost" | "relate"
+        | "boost" | "relate" | "triage"
         // consolidation + introspection
         | "dream" | "observe" | "status" | "assess" | "stats" | "clusters"
         | "kannaktopus"
@@ -912,6 +913,127 @@ fn main() {
                 process::exit(1);
             }
             println!("[prune-prefix] forgotten={ok} not_found={miss}");
+        }
+        "triage" => {
+            // ADR-0031 Phase 1 — value-based, Ξ-preserving online prune that
+            // replaces kannaka-radio/prune-cron.sh. A memory is eviction-eligible
+            // iff ALL hold: (a) older than --min-age-hours, (b) amplitude below
+            // --min-amplitude (protects boosted/high-value memories), and (c) it
+            // is a redundant *extra* — cosine ≥ --redundancy to an already-retained
+            // memory of the SAME modality. Greedy per-modality, strongest kept as
+            // the representative, so eviction RAISES representational diversity (Ξ)
+            // rather than lowering it (the #118 ear-loop failure mode).
+            //
+            // DRY-RUN BY DEFAULT. Pass --apply to actually forget+save. Each
+            // eviction is a normal forget (replayable via ADR-0028 events).
+            let mut apply = false;
+            let mut redundancy: f32 = 0.95;
+            let mut min_amplitude: f32 = 0.75;
+            let mut min_age_hours: i64 = 24;
+            let mut max_evict: usize = 100;
+            {
+                let mut i = command_start + 1;
+                while i < args.len() {
+                    match args[i].as_str() {
+                        "--apply" => { apply = true; i += 1; }
+                        "--dry-run" => { apply = false; i += 1; }
+                        "--redundancy" if i + 1 < args.len() => {
+                            redundancy = args[i + 1].parse().unwrap_or(redundancy); i += 2;
+                        }
+                        "--min-amplitude" if i + 1 < args.len() => {
+                            min_amplitude = args[i + 1].parse().unwrap_or(min_amplitude); i += 2;
+                        }
+                        "--min-age-hours" if i + 1 < args.len() => {
+                            min_age_hours = args[i + 1].parse().unwrap_or(min_age_hours); i += 2;
+                        }
+                        "--max-evict" if i + 1 < args.len() => {
+                            max_evict = args[i + 1].parse().unwrap_or(max_evict); i += 2;
+                        }
+                        other => { eprintln!("[triage] ignoring unknown arg: {other}"); i += 1; }
+                    }
+                }
+            }
+
+            // Phase 1: scan (immutable borrow). Group by modality, keep the
+            // strongest as representatives, collect redundant low-value extras.
+            let (to_forget, total, per_mod): (Vec<uuid::Uuid>, usize, Vec<(String, usize, usize)>) = {
+                let all = sys.engine.store.all_memories().unwrap_or_else(|e| {
+                    eprintln!("Error listing memories: {e}"); process::exit(1);
+                });
+                let total = all.len();
+                let now = chrono::Utc::now();
+
+                // Bucket memory references by modality label.
+                use std::collections::BTreeMap;
+                let mut buckets: BTreeMap<String, Vec<&kannaka_memory::memory::HyperMemory>> = BTreeMap::new();
+                for m in &all {
+                    buckets.entry(format!("{}", m.modality)).or_default().push(m);
+                }
+
+                let mut to_forget: Vec<uuid::Uuid> = Vec::new();
+                let mut per_mod: Vec<(String, usize, usize)> = Vec::new(); // (modality, total, evicted)
+                let mut evicted_total = 0usize;
+
+                for (modality, mut mems) in buckets {
+                    // Strongest first → they become the retained representatives,
+                    // so the weak redundant duplicates are the ones evicted.
+                    mems.sort_by(|a, b| b.amplitude.partial_cmp(&a.amplitude)
+                        .unwrap_or(std::cmp::Ordering::Equal));
+                    let mut retained: Vec<&kannaka_memory::memory::HyperMemory> = Vec::new();
+                    let mut evicted_here = 0usize;
+                    for m in mems {
+                        if evicted_total >= max_evict {
+                            retained.push(m);
+                            continue;
+                        }
+                        let age_hours = now.signed_duration_since(m.created_at).num_hours();
+                        let old_enough = age_hours >= min_age_hours;
+                        let low_value = m.amplitude < min_amplitude;
+                        // Redundant only against already-RETAINED same-modality
+                        // memories — guarantees at least one representative survives.
+                        let redundant = old_enough && low_value && retained.iter().any(|r| {
+                            kannaka_memory::wave::cosine_similarity(&m.vector, &r.vector) >= redundancy
+                        });
+                        if redundant {
+                            to_forget.push(m.id);
+                            evicted_here += 1;
+                            evicted_total += 1;
+                        } else {
+                            retained.push(m);
+                        }
+                    }
+                    if evicted_here > 0 {
+                        per_mod.push((modality, retained.len() + evicted_here, evicted_here));
+                    }
+                }
+                (to_forget, total, per_mod)
+            };
+
+            println!("[triage] policy: redundancy>={:.2} amplitude<{:.2} age>={}h max-evict={}",
+                redundancy, min_amplitude, min_age_hours, max_evict);
+            println!("[triage] {} of {} memories are redundant low-value extras{}",
+                to_forget.len(), total,
+                if apply { "" } else { " (dry-run — pass --apply to forget)" });
+            for (modality, mtotal, evicted) in &per_mod {
+                println!("[triage]   {:<10} {} eviction(s) of {} in-modality", modality, evicted, mtotal);
+            }
+            if !apply { return; }
+            if to_forget.is_empty() { return; }
+
+            // Phase 2: delete (mutable borrow), then persist atomically.
+            let mut ok = 0usize;
+            for id in &to_forget {
+                match sys.forget(id) {
+                    Ok(true) => ok += 1,
+                    Ok(false) => {}
+                    Err(e) => eprintln!("[triage] forget {id}: {e}"),
+                }
+            }
+            if let Err(e) = sys.save() {
+                eprintln!("Failed to persist HRM after triage: {e}");
+                process::exit(1);
+            }
+            println!("[triage] evicted={ok} (Ξ-preserving; representatives retained)");
         }
         "boost" => {
             if args.len() < command_start + 2 {


### PR DESCRIPTION
Implements **Phase 1 of ADR-0031** (ratified Proposed → Accepted in this PR): the value-based, Ξ-preserving online prune that retires `kannaka-radio/prune-cron.sh` and the radio stream-drops it causes.

## `kannaka triage [--apply] [--max-evict N] [--redundancy R] [--min-amplitude A] [--min-age-hours H]`

A memory is eviction-eligible iff **all** hold:
- older than `--min-age-hours` (default 24) — never touches what the current session just created
- amplitude below `--min-amplitude` (default 0.75) — protects boosted/high-value memories
- it is a **redundant extra**: cosine ≥ `--redundancy` (default 0.95) to an *already-retained* memory of the **same modality**

Greedy per modality, strongest kept as the representative — so eviction **raises** representational diversity (Ξ) instead of lowering it, directly countering the #118 ear-loop failure mode. `--max-evict` (default 100) caps a run.

### Safety
- **Dry-run is the default**; `--apply` performs `forget` + atomic save.
- The invoking process is the single writer (v0.6.10 model), so it holds the lock it already owns — **no external offline mutation, no stream drop** (the core fix vs prune-cron).
- Each eviction is a normal `forget`, replayable via ADR-0028 events.

### Why this matters
Phase 1 alone lets us delete `prune-cron.sh`. It's also the Ξ-management mechanism #118 needs.

## Verification
- `cargo build --bin kannaka` ✓, `cargo clippy --lib --bin kannaka` ✓
- Smoke test: 4 identical + 2 unique memories → 3 redundant extras flagged (dry-run), evicted (--apply), representative + uniques retained, idempotent on re-run.

## Follow-ups (per ADR-0031)
- Phase 2: `WavefrontMeta.tier` + `kannaka promote|pin` + dream/recall promotion
- Phase 3: Kannaktopus-scheduled, per-agent thresholds

Relates to #95 (Phase 1 of the ADR). Lays groundwork the #118 fix can build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)