### PR TITLE
feat(triage): ADR-0031 Phase 2b — auto-promotion + ear-loop ShortTerm (#95)

### DIFF
--- a/docs/adr/ADR-0031-memory-triage-architecture.md
+++ b/docs/adr/ADR-0031-memory-triage-architecture.md
@@ -171,9 +171,15 @@ tick instead of being interrupted by an external cron.
   for triage. CLI: `kannaka promote|pin|demote <id>`. Triage now defaults to
   **ShortTerm-only** (never evicts `Pinned`), with `--include-long-term` for
   one-off legacy cleanup — making continuous triage safe.
-  *Still open (Phase 2b):* automatic promotion (dream-survival / recall-count →
-  `LongTerm`) and defaulting ear-loop absorbs to `ShortTerm` (needs an
-  absorb-with-tier path; partly kannaka-radio side).
+- **Phase 2b — automatic promotion + ear-loop default. ✅ SHIPPED.**
+  `kannaka hear` captures now default to `ShortTerm` (`--long-term` opts out), so
+  the high-rate ear-loop auto-populates the eviction-eligible pool. The dream
+  cycle promotes any `ShortTerm` memory it *strengthens* (amplitude grows by
+  ≥ `KANNAKA_PROMOTE_DELTA`, default 0.05, across the dream) back to `LongTerm`.
+  Recall-driven promotion is subsumed: recall raises a memory's energy, so it
+  resonates harder and is more likely to be strengthened by the next dream.
+  With ear-loop → ShortTerm and dream → promote/triage, the loop is
+  self-sustaining and `prune-cron.sh` can be retired.
 
 - **Phase 3 — Kannaktopus-scheduled, constellation-wide policy.**
   Kannaktopus drives the triage cadence and tunes thresholds per-agent (the

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1628,6 +1628,7 @@ fn main() {
                 eprintln!("  File:   kannaka hear ./song.mp3");
                 eprintln!("  URL:    kannaka hear https://radio.ninja-portal.com/stream");
                 eprintln!("  Stream URLs are sampled for ~30s (default; cap with --secs N).");
+                eprintln!("  Captures are short-term by default (triage-eligible); --long-term to keep.");
                 process::exit(1);
             }
             let target = &args[command_start + 1];
@@ -1635,6 +1636,11 @@ fn main() {
             // Optional --secs N for stream sampling cap. Default 30s ≈ 480 KB
             // at 128 kbps MP3, plenty of audio to extract tempo/centroid/rms.
             let mut secs: u64 = 30;
+            // ADR-0031 Phase 2b: ear-loop captures are high-rate and semantically
+            // redundant (same voice/modality), so they default to ShortTerm —
+            // eviction-eligible by `triage`, promoted to LongTerm only if a dream
+            // strengthens them. `--long-term` opts a specific capture out.
+            let mut long_term = false;
             let mut i = command_start + 2;
             while i < args.len() {
                 if args[i] == "--secs" && i + 1 < args.len() {
@@ -1642,6 +1648,8 @@ fn main() {
                         secs = n.max(1).min(600);
                     }
                     i += 2;
+                } else if args[i] == "--long-term" {
+                    long_term = true; i += 1;
                 } else { i += 1; }
             }
 
@@ -1673,7 +1681,16 @@ fn main() {
 
             match result {
                 Ok((id, features)) => {
-                    println!("Heard: {id}");
+                    // ADR-0031 Phase 2b: tag ear-loop captures ShortTerm by default.
+                    if !long_term {
+                        if let Some(hrm) = sys.engine.store.as_any_mut()
+                            .downcast_mut::<kannaka_memory::hrm_store::HrmStore>()
+                        {
+                            hrm.set_tier(&id, kannaka_memory::medium::types::Tier::ShortTerm);
+                            let _ = sys.save();
+                        }
+                    }
+                    println!("Heard: {id}{}", if long_term { "" } else { " (short-term)" });
                     println!("  Duration: {:.1}s", features.duration_secs);
                     println!("  Tempo: {:.0} BPM", features.tempo_bpm);
                     println!("  RMS: {:.4}", features.rms_mean);

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -481,8 +481,70 @@ impl KannakaMemorySystem {
     ///
     /// ADR-0022: Uses Medium's eigenstructure annealing exclusively.
     /// No fallback to old particle-based consolidation — the HRM IS the dream engine.
+    /// ADR-0031 Phase 2b: capture the current amplitude of every short-term
+    /// memory, keyed by id. Used to detect dream-strengthening for promotion.
+    fn snapshot_short_term_amplitudes(&self) -> std::collections::HashMap<Uuid, f32> {
+        use crate::medium::types::Tier;
+        self.engine.store.all_memories()
+            .map(|mems| mems.iter()
+                .filter(|m| m.tier == Tier::ShortTerm)
+                .map(|m| (m.id, m.amplitude))
+                .collect())
+            .unwrap_or_default()
+    }
+
+    /// ADR-0031 Phase 2b: promote short-term memories whose amplitude grew by at
+    /// least `KANNAKA_PROMOTE_DELTA` (default 0.05) across the dream — i.e. the
+    /// consolidation strengthened them, so they graduate to long-term and are no
+    /// longer eviction-eligible by `triage`. Returns the number promoted.
+    fn promote_strengthened_short_term(&mut self, before: &std::collections::HashMap<Uuid, f32>) -> usize {
+        use crate::medium::types::Tier;
+        if before.is_empty() {
+            return 0;
+        }
+        let eps: f32 = std::env::var("KANNAKA_PROMOTE_DELTA")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.05);
+        // Collect ids first (immutable borrow), then mutate.
+        let to_promote: Vec<Uuid> = match self.engine.store.all_memories() {
+            Ok(mems) => mems.iter().filter_map(|m| {
+                if m.tier == Tier::ShortTerm {
+                    if let Some(&amp0) = before.get(&m.id) {
+                        if m.amplitude >= amp0 + eps {
+                            return Some(m.id);
+                        }
+                    }
+                }
+                None
+            }).collect(),
+            Err(_) => return 0,
+        };
+        if to_promote.is_empty() {
+            return 0;
+        }
+        match self.engine.store.as_any_mut()
+            .downcast_mut::<crate::hrm_store::HrmStore>()
+        {
+            Some(hrm) => {
+                let mut n = 0;
+                for id in &to_promote {
+                    if hrm.set_tier(id, Tier::LongTerm) { n += 1; }
+                }
+                n
+            }
+            None => 0,
+        }
+    }
+
     pub fn dream(&mut self) -> Result<DreamReport, SystemError> {
         let before = self.bridge.assess(&self.engine);
+
+        // ADR-0031 Phase 2b: snapshot short-term amplitudes before the dream so
+        // we can promote the ones the dream consolidation strengthens (they
+        // "earned" long-term). Recall-boosted memories benefit too — recall
+        // raises energy, so they resonate harder and strengthen here.
+        let short_term_before = self.snapshot_short_term_amplitudes();
 
         // Phase 1: Wave-native dream (eigenstructure annealing on holographic medium)
         let chiral_eta = self.dream_state.engine.chiral_perturbation;
@@ -514,6 +576,12 @@ impl KannakaMemorySystem {
         // Phase 4: Lite chiral dream — transfer strong analytical memories to holistic side
         self.engine.store.chiral_dream(false, 1);
         eprintln!("[dream] Lite chiral dream pass complete");
+
+        // ADR-0031 Phase 2b: promote short-term memories the dream strengthened.
+        let promoted = self.promote_strengthened_short_term(&short_term_before);
+        if promoted > 0 {
+            eprintln!("[dream] promoted {} strengthened short-term memory(ies) → long-term", promoted);
+        }
 
         let after = self.bridge.assess(&self.engine);
         self.last_dream = Some(Utc::now());


### PR DESCRIPTION
Completes the **ADR-0031 triage loop**, making it self-sustaining. Builds on Phase 1 (#159) and Phase 2 (#162).

## What's new

- **Ear-loop defaults to ShortTerm** — `kannaka hear` captures are tagged `ShortTerm` (eviction-eligible) by default; `--long-term` opts a capture out. The high-rate, semantically-redundant ear stream now auto-populates the short-term pool, which is exactly the Ξ-compression source in #118.
- **Dream promotes what it strengthens** — `KannakaMemorySystem::dream` snapshots short-term amplitudes before the dream and promotes any ShortTerm memory whose amplitude grew by ≥ `KANNAKA_PROMOTE_DELTA` (default 0.05) to `LongTerm`. Self-calibrating (before/after delta, no magic absolute threshold), faithful to the ADR's "survived consolidation with strengthened amplitude."
- **Recall promotion subsumed** — recall raises a memory's *persisted* energy, so frequently-recalled memories resonate harder and are more likely to be strengthened (hence promoted) by the next dream. This avoids depending on `retrieval_count`, which is not persisted (resets every load).

## Why this matters

ShortTerm in (ear-loop) → strengthened survivors promoted (dream) → redundant unused extras evicted (triage). The loop is now self-sustaining, so **`prune-cron.sh` can be retired** and #118's Ξ compression is structurally addressed.

## Verification
- End-to-end: 5 demoted short-term memories, one `dream` → **4 strengthened ones promoted to long-term** (the 5th not strengthened past the delta, correctly left short-term).
- `cargo build` + `cargo clippy --lib --bin kannaka` clean; `cargo test --lib chiral_persistence::tests` 7 passed (back-compat invariants intact).

Completes Phase 2b in ADR-0031. Remaining: Phase 3 (Kannaktopus-scheduled cadence + per-agent thresholds). Relates to #95, #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)