### PR TITLE
feat(triage): ADR-0031 Phase 3 — config thresholds + dream auto-trigger (#95)

### DIFF
--- a/docs/adr/ADR-0031-memory-triage-architecture.md
+++ b/docs/adr/ADR-0031-memory-triage-architecture.md
@@ -181,11 +181,18 @@ tick instead of being interrupted by an external cron.
   With ear-loop → ShortTerm and dream → promote/triage, the loop is
   self-sustaining and `prune-cron.sh` can be retired.
 
-- **Phase 3 — Kannaktopus-scheduled, constellation-wide policy.**
-  Kannaktopus drives the triage cadence and tunes thresholds per-agent (the
-  witness, the substrate, and the radio have different redundancy profiles).
-  Per-segment / second-file separation revisited here *only if* the in-file tag
-  proves insufficient under load.
+- **Phase 3 — config-driven auto-trigger + per-agent thresholds. ✅ SHIPPED.**
+  A `[triage]` config section (per-agent tunable: `redundancy`, `min_amplitude`,
+  `min_age_hours`, `max_evict`, `xi_trigger`, `enabled`) drives both the CLI
+  defaults and the dream-cycle auto-trigger. When `triage.enabled` and post-dream
+  Ξ falls below `xi_trigger`, the dream self-heals by running a triage pass —
+  no external cron. Default `enabled=false` (opt-in, since it auto-deletes).
+  The triage policy is now a reusable library method (`triage_select`/
+  `triage_forget` on `KannakaMemorySystem`) shared by the CLI and the dream.
+  Kannaktopus may still *schedule* dream/triage cadence across the constellation,
+  but per-agent policy now lives in each agent's config — Kannaktopus does not own
+  it. Per-segment / second-file separation remains deferred (the in-file tag
+  holds under current load).
 
 ## Consequences
 

--- a/src/bin/handlers/ops.rs
+++ b/src/bin/handlers/ops.rs
@@ -116,7 +116,9 @@ pub(crate) fn handle_config(cfg: &KannakaConfig, args: &[String]) {
                     eprintln!("      llm.api_key, llm.base_url, swarm.enabled, swarm.nats_url, swarm.role,");
                     eprintln!("      ghostsignals.enabled, ghostsignals.token, ghostsignals.hub_url,");
                     eprintln!("      constellation.radio_url, constellation.observatory_url,");
-                    eprintln!("      hrm.path, hrm.wavefront_dim, updates.auto_check");
+                    eprintln!("      hrm.path, hrm.wavefront_dim, updates.auto_check,");
+                    eprintln!("      triage.enabled, triage.redundancy, triage.min_amplitude,");
+                    eprintln!("      triage.min_age_hours, triage.max_evict, triage.xi_trigger");
                     eprintln!();
                     eprintln!("Booleans accept: true/false, 1/0, yes/no, on/off (case-insensitive).");
                     process::exit(1);
@@ -210,6 +212,36 @@ pub(crate) fn handle_config(cfg: &KannakaConfig, args: &[String]) {
                         }
                     }
                 }
+                // ADR-0031 Phase 3 — per-agent triage policy.
+                "triage.enabled" => {
+                    match parse_bool(value) {
+                        Ok(b) => new_cfg.triage.enabled = b,
+                        Err(()) => {
+                            eprintln!("triage.enabled expects true/false/1/0/yes/no/on/off, got: {}", value);
+                            process::exit(1);
+                        }
+                    }
+                }
+                "triage.redundancy" => match value.parse::<f32>() {
+                    Ok(n) if (0.0..=1.0).contains(&n) => new_cfg.triage.redundancy = n,
+                    _ => { eprintln!("triage.redundancy expects a float in [0,1], got: {}", value); process::exit(1); }
+                },
+                "triage.min_amplitude" => match value.parse::<f32>() {
+                    Ok(n) if n >= 0.0 => new_cfg.triage.min_amplitude = n,
+                    _ => { eprintln!("triage.min_amplitude expects a non-negative float, got: {}", value); process::exit(1); }
+                },
+                "triage.min_age_hours" => match value.parse::<i64>() {
+                    Ok(n) if n >= 0 => new_cfg.triage.min_age_hours = n,
+                    _ => { eprintln!("triage.min_age_hours expects a non-negative integer, got: {}", value); process::exit(1); }
+                },
+                "triage.max_evict" => match value.parse::<usize>() {
+                    Ok(n) => new_cfg.triage.max_evict = n,
+                    _ => { eprintln!("triage.max_evict expects a non-negative integer, got: {}", value); process::exit(1); }
+                },
+                "triage.xi_trigger" => match value.parse::<f32>() {
+                    Ok(n) if (0.0..=1.0).contains(&n) => new_cfg.triage.xi_trigger = n,
+                    _ => { eprintln!("triage.xi_trigger expects a float in [0,1] (0 disables auto-trigger), got: {}", value); process::exit(1); }
+                },
                 other => {
                     eprintln!("Unknown config key: {}", other);
                     process::exit(1);

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -564,6 +564,21 @@ fn main() {
     // of falling back to env-only. Fixes km#77.
     sys.set_nats_url(resolve_nats_url(&args[command_start..], 0, &cfg.swarm.nats_url));
 
+    // ADR-0031 Phase 3: install the dream-cycle auto-triage policy from config
+    // (opt-in via `config set triage.enabled true`). When enabled with a
+    // non-zero xi_trigger, the dream cycle self-heals Ξ by shedding redundant
+    // short-term memories — no external cron needed.
+    if cfg.triage.enabled {
+        sys.set_triage_policy(kannaka_memory::openclaw::TriageParams {
+            redundancy: cfg.triage.redundancy,
+            min_amplitude: cfg.triage.min_amplitude,
+            min_age_hours: cfg.triage.min_age_hours,
+            max_evict: cfg.triage.max_evict,
+            include_long_term: false,
+            xi_trigger: cfg.triage.xi_trigger,
+        });
+    }
+
     match args[command_start].as_str() {
         "remember" => {
             if args.len() < command_start + 2 {
@@ -927,16 +942,19 @@ fn main() {
             //
             // DRY-RUN BY DEFAULT. Pass --apply to actually forget+save. Each
             // eviction is a normal forget (replayable via ADR-0028 events).
+            // Defaults come from `[triage]` config (per-agent tunable, Phase 3);
+            // flags override per-invocation. --include-long-term restores the
+            // Phase-1 reach (Pinned is never evicted either way).
             let mut apply = false;
-            let mut redundancy: f32 = 0.95;
-            let mut min_amplitude: f32 = 0.75;
-            let mut min_age_hours: i64 = 24;
-            let mut max_evict: usize = 100;
-            // ADR-0031 Phase 2: by default only ShortTerm memories are
-            // eviction-eligible (safe to run continuously). --include-long-term
-            // restores the Phase-1 behavior for one-off legacy cleanup. Pinned
-            // memories are NEVER evicted under either mode.
             let mut include_long_term = false;
+            let mut params = kannaka_memory::openclaw::TriageParams {
+                redundancy: cfg.triage.redundancy,
+                min_amplitude: cfg.triage.min_amplitude,
+                min_age_hours: cfg.triage.min_age_hours,
+                max_evict: cfg.triage.max_evict,
+                include_long_term: false,
+                xi_trigger: cfg.triage.xi_trigger,
+            };
             {
                 let mut i = command_start + 1;
                 while i < args.len() {
@@ -945,111 +963,39 @@ fn main() {
                         "--dry-run" => { apply = false; i += 1; }
                         "--include-long-term" => { include_long_term = true; i += 1; }
                         "--redundancy" if i + 1 < args.len() => {
-                            redundancy = args[i + 1].parse().unwrap_or(redundancy); i += 2;
+                            params.redundancy = args[i + 1].parse().unwrap_or(params.redundancy); i += 2;
                         }
                         "--min-amplitude" if i + 1 < args.len() => {
-                            min_amplitude = args[i + 1].parse().unwrap_or(min_amplitude); i += 2;
+                            params.min_amplitude = args[i + 1].parse().unwrap_or(params.min_amplitude); i += 2;
                         }
                         "--min-age-hours" if i + 1 < args.len() => {
-                            min_age_hours = args[i + 1].parse().unwrap_or(min_age_hours); i += 2;
+                            params.min_age_hours = args[i + 1].parse().unwrap_or(params.min_age_hours); i += 2;
                         }
                         "--max-evict" if i + 1 < args.len() => {
-                            max_evict = args[i + 1].parse().unwrap_or(max_evict); i += 2;
+                            params.max_evict = args[i + 1].parse().unwrap_or(params.max_evict); i += 2;
                         }
                         other => { eprintln!("[triage] ignoring unknown arg: {other}"); i += 1; }
                     }
                 }
             }
+            params.include_long_term = include_long_term;
 
-            // Phase 1: scan (immutable borrow). Group by modality, keep the
-            // strongest as representatives, collect redundant low-value extras.
-            let (to_forget, total, per_mod): (Vec<uuid::Uuid>, usize, Vec<(String, usize, usize)>) = {
-                let all = sys.engine.store.all_memories().unwrap_or_else(|e| {
-                    eprintln!("Error listing memories: {e}"); process::exit(1);
-                });
-                let total = all.len();
-                let now = chrono::Utc::now();
-
-                // Bucket memory references by modality label.
-                use std::collections::BTreeMap;
-                let mut buckets: BTreeMap<String, Vec<&kannaka_memory::memory::HyperMemory>> = BTreeMap::new();
-                for m in &all {
-                    buckets.entry(format!("{}", m.modality)).or_default().push(m);
-                }
-
-                let mut to_forget: Vec<uuid::Uuid> = Vec::new();
-                let mut per_mod: Vec<(String, usize, usize)> = Vec::new(); // (modality, total, evicted)
-                let mut evicted_total = 0usize;
-
-                for (modality, mut mems) in buckets {
-                    // Strongest first → they become the retained representatives,
-                    // so the weak redundant duplicates are the ones evicted.
-                    mems.sort_by(|a, b| b.amplitude.partial_cmp(&a.amplitude)
-                        .unwrap_or(std::cmp::Ordering::Equal));
-                    let mut retained: Vec<&kannaka_memory::memory::HyperMemory> = Vec::new();
-                    let mut evicted_here = 0usize;
-                    for m in mems {
-                        if evicted_total >= max_evict {
-                            retained.push(m);
-                            continue;
-                        }
-                        // Tier gate (ADR-0031 Phase 2): never evict Pinned;
-                        // only ShortTerm unless --include-long-term is set.
-                        use kannaka_memory::medium::types::Tier;
-                        let tier_evictable = match m.tier {
-                            Tier::Pinned => false,
-                            Tier::ShortTerm => true,
-                            Tier::LongTerm => include_long_term,
-                        };
-                        let age_hours = now.signed_duration_since(m.created_at).num_hours();
-                        let old_enough = age_hours >= min_age_hours;
-                        let low_value = m.amplitude < min_amplitude;
-                        // Redundant only against already-RETAINED same-modality
-                        // memories — guarantees at least one representative survives.
-                        let redundant = tier_evictable && old_enough && low_value && retained.iter().any(|r| {
-                            kannaka_memory::wave::cosine_similarity(&m.vector, &r.vector) >= redundancy
-                        });
-                        if redundant {
-                            to_forget.push(m.id);
-                            evicted_here += 1;
-                            evicted_total += 1;
-                        } else {
-                            retained.push(m);
-                        }
-                    }
-                    if evicted_here > 0 {
-                        per_mod.push((modality, retained.len() + evicted_here, evicted_here));
-                    }
-                }
-                (to_forget, total, per_mod)
-            };
-
+            let sel = sys.triage_select(&params);
             println!("[triage] policy: tier={} redundancy>={:.2} amplitude<{:.2} age>={}h max-evict={}",
                 if include_long_term { "short+long (pinned protected)" } else { "short-term only" },
-                redundancy, min_amplitude, min_age_hours, max_evict);
+                params.redundancy, params.min_amplitude, params.min_age_hours, params.max_evict);
             println!("[triage] {} of {} memories are redundant low-value extras{}",
-                to_forget.len(), total,
+                sel.to_forget.len(), sel.total,
                 if apply { "" } else { " (dry-run — pass --apply to forget)" });
-            for (modality, mtotal, evicted) in &per_mod {
+            for (modality, mtotal, evicted) in &sel.per_modality {
                 println!("[triage]   {:<10} {} eviction(s) of {} in-modality", modality, evicted, mtotal);
             }
-            if !apply { return; }
-            if to_forget.is_empty() { return; }
+            if !apply || sel.to_forget.is_empty() { return; }
 
-            // Phase 2: delete (mutable borrow), then persist atomically.
-            let mut ok = 0usize;
-            for id in &to_forget {
-                match sys.forget(id) {
-                    Ok(true) => ok += 1,
-                    Ok(false) => {}
-                    Err(e) => eprintln!("[triage] forget {id}: {e}"),
-                }
+            match sys.triage_forget(&sel.to_forget) {
+                Ok(n) => println!("[triage] evicted={n} (Ξ-preserving; representatives retained)"),
+                Err(e) => { eprintln!("Failed to persist HRM after triage: {e}"); process::exit(1); }
             }
-            if let Err(e) = sys.save() {
-                eprintln!("Failed to persist HRM after triage: {e}");
-                process::exit(1);
-            }
-            println!("[triage] evicted={ok} (Ξ-preserving; representatives retained)");
         }
         cmd @ ("promote" | "pin" | "demote") => {
             // ADR-0031 Phase 2 — explicit tier control.

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct KannakaConfig {
     pub hrm: HrmConfig,
     #[serde(default = "UpdatesConfig::default")]
     pub updates: UpdatesConfig,
+    #[serde(default = "TriageConfig::default")]
+    pub triage: TriageConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -96,6 +98,33 @@ pub struct UpdatesConfig {
     pub channel: String,
     #[serde(default)]
     pub last_checked: String,
+}
+
+/// ADR-0031 memory triage policy. Per-agent tunable — the witness, substrate,
+/// and radio have different redundancy profiles. `enabled` gates the dream-cycle
+/// auto-trigger (Phase 3); the explicit `kannaka triage` CLI works regardless.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageConfig {
+    /// Enable the dream-cycle auto-trigger (default false — opt-in, since it
+    /// auto-deletes redundant short-term memories).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Same-modality cosine at/above which a memory is a redundant extra.
+    #[serde(default = "default_triage_redundancy")]
+    pub redundancy: f32,
+    /// Only memories with amplitude below this are eviction-eligible.
+    #[serde(default = "default_triage_min_amplitude")]
+    pub min_amplitude: f32,
+    /// Only memories older than this (hours) are eviction-eligible.
+    #[serde(default = "default_triage_min_age_hours")]
+    pub min_age_hours: i64,
+    /// Cap on evictions per pass.
+    #[serde(default = "default_triage_max_evict")]
+    pub max_evict: usize,
+    /// Dream auto-triggers triage when post-dream Ξ falls below this. 0 disables
+    /// the auto-trigger even when `enabled` (explicit CLI triage still works).
+    #[serde(default = "default_triage_xi_trigger")]
+    pub xi_trigger: f32,
 }
 
 // ---------------------------------------------------------------------------
@@ -191,6 +220,25 @@ impl Default for UpdatesConfig {
     }
 }
 
+impl Default for TriageConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            redundancy: default_triage_redundancy(),
+            min_amplitude: default_triage_min_amplitude(),
+            min_age_hours: default_triage_min_age_hours(),
+            max_evict: default_triage_max_evict(),
+            xi_trigger: default_triage_xi_trigger(),
+        }
+    }
+}
+
+fn default_triage_redundancy() -> f32 { 0.95 }
+fn default_triage_min_amplitude() -> f32 { 0.75 }
+fn default_triage_min_age_hours() -> i64 { 24 }
+fn default_triage_max_evict() -> usize { 100 }
+fn default_triage_xi_trigger() -> f32 { 0.0 }
+
 impl Default for KannakaConfig {
     fn default() -> Self {
         Self {
@@ -201,6 +249,7 @@ impl Default for KannakaConfig {
             constellation: ConstellationConfig::default(),
             hrm: HrmConfig::default(),
             updates: UpdatesConfig::default(),
+            triage: TriageConfig::default(),
         }
     }
 }

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -163,6 +163,50 @@ pub struct KannakaMemorySystem {
     /// When None, the dream/consciousness publish helpers fall back to the
     /// legacy env-only resolution. Fixes km#77.
     nats_url: Option<String>,
+    /// ADR-0031 Phase 3 — when Some, the dream cycle auto-triggers a triage pass
+    /// if post-dream Ξ falls below `xi_trigger`. None = disabled (default). Set
+    /// by the bin via `set_triage_policy` from `[triage]` config.
+    triage_policy: Option<TriageParams>,
+}
+
+/// ADR-0031 triage policy parameters (Phase 1–3).
+#[derive(Debug, Clone, Copy)]
+pub struct TriageParams {
+    /// Same-modality cosine at/above which a memory counts as a redundant extra.
+    pub redundancy: f32,
+    /// Only memories with amplitude below this are eviction-eligible.
+    pub min_amplitude: f32,
+    /// Only memories older than this (hours) are eviction-eligible.
+    pub min_age_hours: i64,
+    /// Cap on evictions per pass.
+    pub max_evict: usize,
+    /// When true, LongTerm memories are also considered (Pinned never are).
+    pub include_long_term: bool,
+    /// Phase 3 auto-trigger: dream runs triage when post-dream Ξ is below this.
+    pub xi_trigger: f32,
+}
+
+impl Default for TriageParams {
+    fn default() -> Self {
+        Self {
+            redundancy: 0.95,
+            min_amplitude: 0.75,
+            min_age_hours: 24,
+            max_evict: 100,
+            include_long_term: false,
+            xi_trigger: 0.0,
+        }
+    }
+}
+
+/// Result of a triage selection pass (ADR-0031).
+pub struct TriageSelection {
+    /// Ids selected for eviction (redundant low-value short-term extras).
+    pub to_forget: Vec<Uuid>,
+    /// Total memories scanned.
+    pub total: usize,
+    /// (modality, in-modality total, evicted) for modalities with evictions.
+    pub per_modality: Vec<(String, usize, usize)>,
 }
 
 impl KannakaMemorySystem {
@@ -238,6 +282,7 @@ impl KannakaMemorySystem {
             attention,
             flux,
             nats_url: None,
+            triage_policy: None,
         })
     }
 
@@ -481,6 +526,88 @@ impl KannakaMemorySystem {
     ///
     /// ADR-0022: Uses Medium's eigenstructure annealing exclusively.
     /// No fallback to old particle-based consolidation — the HRM IS the dream engine.
+    /// ADR-0031 Phase 3: install the auto-triage policy (called by the bin from
+    /// `[triage]` config when triage is enabled). Dream then self-corrects Ξ.
+    pub fn set_triage_policy(&mut self, params: TriageParams) {
+        self.triage_policy = Some(params);
+    }
+
+    /// ADR-0031: select redundant low-value short-term extras for eviction.
+    /// Pure (immutable) — groups by modality, keeps the strongest as the
+    /// representative, and flags only redundant (cosine ≥ p.redundancy),
+    /// aged, low-amplitude, evictable-tier duplicates. Raising Ξ by removing
+    /// correlated content, never the last representative of a cluster.
+    pub fn triage_select(&self, p: &TriageParams) -> TriageSelection {
+        use crate::medium::types::Tier;
+        let all = match self.engine.store.all_memories() {
+            Ok(a) => a,
+            Err(_) => return TriageSelection { to_forget: Vec::new(), total: 0, per_modality: Vec::new() },
+        };
+        let total = all.len();
+        let now = Utc::now();
+
+        let mut buckets: std::collections::BTreeMap<String, Vec<&crate::memory::HyperMemory>> =
+            std::collections::BTreeMap::new();
+        for m in &all {
+            buckets.entry(format!("{}", m.modality)).or_default().push(m);
+        }
+
+        let mut to_forget: Vec<Uuid> = Vec::new();
+        let mut per_modality: Vec<(String, usize, usize)> = Vec::new();
+        let mut evicted_total = 0usize;
+
+        for (modality, mut mems) in buckets {
+            mems.sort_by(|a, b| b.amplitude.partial_cmp(&a.amplitude)
+                .unwrap_or(std::cmp::Ordering::Equal));
+            let mut retained: Vec<&crate::memory::HyperMemory> = Vec::new();
+            let mut evicted_here = 0usize;
+            for m in mems {
+                if evicted_total >= p.max_evict {
+                    retained.push(m);
+                    continue;
+                }
+                let tier_evictable = match m.tier {
+                    Tier::Pinned => false,
+                    Tier::ShortTerm => true,
+                    Tier::LongTerm => p.include_long_term,
+                };
+                let age_hours = now.signed_duration_since(m.created_at).num_hours();
+                let old_enough = age_hours >= p.min_age_hours;
+                let low_value = m.amplitude < p.min_amplitude;
+                let redundant = tier_evictable && old_enough && low_value && retained.iter().any(|r| {
+                    crate::wave::cosine_similarity(&m.vector, &r.vector) >= p.redundancy
+                });
+                if redundant {
+                    to_forget.push(m.id);
+                    evicted_here += 1;
+                    evicted_total += 1;
+                } else {
+                    retained.push(m);
+                }
+            }
+            if evicted_here > 0 {
+                per_modality.push((modality, retained.len() + evicted_here, evicted_here));
+            }
+        }
+        TriageSelection { to_forget, total, per_modality }
+    }
+
+    /// ADR-0031: forget a precomputed eviction set and persist. Returns the
+    /// count actually forgotten. Each eviction is a normal forget (replayable
+    /// via ADR-0028 events).
+    pub fn triage_forget(&mut self, ids: &[Uuid]) -> Result<usize, SystemError> {
+        let mut n = 0;
+        for id in ids {
+            if self.forget(id)? {
+                n += 1;
+            }
+        }
+        if n > 0 {
+            self.save()?;
+        }
+        Ok(n)
+    }
+
     /// ADR-0031 Phase 2b: capture the current amplitude of every short-term
     /// memory, keyed by id. Used to detect dream-strengthening for promotion.
     fn snapshot_short_term_amplitudes(&self) -> std::collections::HashMap<Uuid, f32> {
@@ -577,14 +704,38 @@ impl KannakaMemorySystem {
         self.engine.store.chiral_dream(false, 1);
         eprintln!("[dream] Lite chiral dream pass complete");
 
-        // ADR-0031 Phase 2b: promote short-term memories the dream strengthened.
+        let after = self.bridge.assess(&self.engine);
+        self.last_dream = Some(Utc::now());
+
+        // ADR-0031: order matters — triage BEFORE promote. Redundant short-term
+        // duplicates resonate strongly (they're near-identical), so the dream
+        // strengthens them; if we promoted first they'd be protected from triage
+        // and Ξ would never recover. So we shed the redundant extras first, then
+        // promote the strengthened *survivors*.
+        //
+        // Phase 3: auto-trigger triage when Ξ has dropped below the configured
+        // threshold — self-healing without an external cron.
+        if let Some(p) = self.triage_policy {
+            if p.xi_trigger > 0.0 && after.xi < p.xi_trigger {
+                let sel = self.triage_select(&p);
+                if !sel.to_forget.is_empty() {
+                    match self.triage_forget(&sel.to_forget) {
+                        Ok(n) if n > 0 => eprintln!(
+                            "[dream] Ξ={:.4} < {:.4} → triage evicted {} redundant short-term memory(ies)",
+                            after.xi, p.xi_trigger, n),
+                        Ok(_) => {}
+                        Err(e) => eprintln!("[dream] triage auto-trigger failed: {e}"),
+                    }
+                }
+            }
+        }
+
+        // ADR-0031 Phase 2b: promote the short-term survivors the dream
+        // strengthened (post-triage, so redundant extras are already gone).
         let promoted = self.promote_strengthened_short_term(&short_term_before);
         if promoted > 0 {
             eprintln!("[dream] promoted {} strengthened short-term memory(ies) → long-term", promoted);
         }
-
-        let after = self.bridge.assess(&self.engine);
-        self.last_dream = Some(Utc::now());
 
         let emerged = after.consciousness_level.ordinal() > before.consciousness_level.ordinal();
 


### PR DESCRIPTION
Completes **ADR-0031** (Phases 1, 2, 2b, 3): triage is now autonomous and per-agent tunable, closing #118's auto-trigger ask.

## What's new

- **`[triage]` config section** — `enabled`, `redundancy`, `min_amplitude`, `min_age_hours`, `max_evict`, `xi_trigger`. Per-agent tunable (witness/substrate/radio have different redundancy profiles). `config set triage.*` arms added. **Default `enabled=false`** — opt-in, since the auto-trigger auto-deletes.
- **Triage policy extracted to the library** — `triage_select` / `triage_forget` on `KannakaMemorySystem`, shared by the CLI and the dream cycle. The CLI `triage` now takes defaults from config (flags still override).
- **Dream auto-trigger** — when `triage.enabled` and post-dream Ξ < `xi_trigger`, the dream runs a triage pass. Self-healing Ξ with no external cron. The bin injects the policy via `set_triage_policy`.
- **Order fix (triage before promote)** — redundant duplicates resonate and get strengthened by the dream, so promoting first would protect them from triage and Ξ would never recover. Shedding redundant extras first, then promoting the survivor, is Ξ-correct.

## Verification
- End-to-end: 4 redundant + 1 distinct short-term memory, one `dream` with `xi_trigger=1.0` → **Ξ=0.78 < 1.0 → 3 redundant evicted, 1 survivor promoted** (count 5→2).
- `config set triage.*` round-trips (and validates ranges, e.g. rejects `redundancy 1.5`); CLI `triage` picks up config defaults.
- `cargo build` + `cargo clippy --lib --bin kannaka` clean; `config_field_tests` + `chiral_persistence::tests` green.

## The complete loop (ADR-0031, now fully autonomous)

```
ear-loop hear → ShortTerm ──┐
                            ▼  (dream cycle, Ξ-gated)
              triage sheds redundant extras  →  Ξ recovers
                            ▼
              promote strengthened survivors → LongTerm (kept)
```

`prune-cron.sh` can now be retired (that's a kannaka-radio-repo change). Relates to #95, #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)