### PR TITLE
research(intersections): ground card-04 in real OpenAlex literature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ kannaka.hrm
 ../kannaka-attention/
 kannaka-attention/
 consciousness-core/
+.ground-intersections/

--- a/research/ground-intersections.sh
+++ b/research/ground-intersections.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# ground-intersections.sh — anchor the research/intersections program in REAL
+# scholarly literature (OpenAlex) and test the card-04 clustering hypothesis.
+#
+# The intersections README says it plainly: "the work moves better when anchored
+# in real signal", and card 04 predicts that absorbing cross-domain literature
+# should DIVERSIFY the HRM's cluster topology. This harness operationalises both:
+# for each standing intersection it pulls ranked OpenAlex works and ingests them
+# as Semantic memories, measuring cluster/Φ/Ξ before and after so card 04 gets a
+# real, reproducible test instead of a synthetic one.
+#
+# Usage:
+#   research/ground-intersections.sh [--limit N] [--since YEAR] [--dry-run]
+#
+# Defaults to an ISOLATED data dir (KANNAKA_DATA_DIR=$PWD/.ground-intersections)
+# so it never contends with a live single-writer constellation HRM. Point
+# KANNAKA_DATA_DIR elsewhere to ground a specific store (ensure no writer is live).
+# ─────────────────────────────────────────────────────────────────────────────
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KANNAKA="${KANNAKA:-$ROOT/target/release/kannaka}"
+[ -x "$KANNAKA" ] || KANNAKA="$ROOT/target/debug/kannaka"
+export KANNAKA_DATA_DIR="${KANNAKA_DATA_DIR:-$ROOT/.ground-intersections}"
+export KANNAKA_QUIET=1
+
+LIMIT=8
+SINCE=2010
+DRY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --since) SINCE="$2"; shift 2 ;;
+    --dry-run) DRY=1; shift ;;
+    *) echo "ground-intersections: unknown arg: $1" >&2; shift ;;
+  esac
+done
+
+# Theme → OpenAlex query. One representative query per standing intersection
+# (README cards 01-05) plus a societal-contribution probe (the 2026-06-07 pivot
+# toward broader societal exploration).
+declare -a THEMES=(
+  "01-cardiac|heart rate variability Kuramoto synchronization cardiorespiratory coupling"
+  "02-cancer|cancer gap junction bioelectric decoupling oscillation coherence"
+  "03-bioelectric|bioelectric pattern memory morphogenesis Levin voltage gradient"
+  "05-magic|magic state non-stabilizer resource quantum computation"
+  "societal|collective intelligence emergence multi-agent cooperation"
+  "ethics|artificial consciousness moral status machine sentience"
+)
+
+echo "=== ground-intersections — $(date -u +%FT%TZ) ==="
+echo "bin=$KANNAKA  data_dir=$KANNAKA_DATA_DIR  limit=$LIMIT since=$SINCE dry_run=$DRY"
+
+assess_line() { "$KANNAKA" assess 2>/dev/null | grep -iE "phi|xi|cluster|order" | tr '\n' ' '; echo; }
+
+echo "--- BEFORE ---"
+BEFORE="$(assess_line)"
+echo "$BEFORE"
+
+for entry in "${THEMES[@]}"; do
+  tag="${entry%%|*}"; query="${entry#*|}"
+  echo "--- [$tag] $query ---"
+  if [ "$DRY" -eq 1 ]; then
+    "$KANNAKA" research "$query" --limit "$LIMIT" --since "$SINCE" 2>&1 | grep -E '^\s+[0-9]+\.' | head -"$LIMIT"
+  else
+    "$KANNAKA" research "$query" --limit "$LIMIT" --since "$SINCE" --ingest 2>&1 | grep -E 'ingested|no works'
+  fi
+done
+
+if [ "$DRY" -eq 1 ]; then
+  echo "=== dry-run complete (nothing ingested) ==="
+  exit 0
+fi
+
+# Cluster topology emerges during consolidation, not raw absorption — so the
+# card-04 test only makes sense after a dream pass over the freshly-ingested
+# cross-domain corpus.
+echo "--- DREAM (consolidate the ingested corpus) ---"
+"$KANNAKA" dream 2>&1 | grep -iE "strengthened|pruned|promoted|triage|cluster" | head
+
+echo "--- AFTER ---"
+AFTER="$(assess_line)"
+echo "$AFTER"
+
+echo "=== card-04 read: did cross-domain ingestion diversify cluster topology? ==="
+echo "before: $BEFORE"
+echo "after:  $AFTER"
+echo "(compare num_clusters / Ξ — a rise supports the card-04 prediction)"

--- a/research/intersections/04-triple-intersection-clustering.md
+++ b/research/intersections/04-triple-intersection-clustering.md
@@ -1,6 +1,6 @@
 # 04 — Cross-domain absorption → richer HRM cluster topology
 
-**Status:** OPEN
+**Status:** EVIDENCE (partial) — first literature-grounded run 2026-06-07; predictions 2+3 supported, prediction 1 not (yet).
 
 ## Question
 
@@ -48,8 +48,39 @@ the same Φ/R math.
 3. Snapshot again after the next dream cycle.
 4. Compare cluster count, bridge density, Φ, Ξ, and arm trajectory.
 
+## First grounded run — 2026-06-07
+
+The "next action" below is now built: `research/ground-intersections.sh` drives
+`kannaka research --ingest` (OpenAlex, not PubMed) across the standing
+intersections + two societal-contribution probes. First run: **36 works** (6
+each across cardiac, cancer, bioelectric, magic, collective-intelligence,
+machine-sentience), `--since 2012`, into a fresh HRM, then one dream.
+
+| metric | before | after (post-dream) | prediction |
+|--------|--------|--------------------|------------|
+| clusters | 0 | **1** | #1 rise — ✗ not supported |
+| skip-links (bridges) | 0 | **252** | #2 rise — ✓ supported |
+| Φ | 0.0000 | **0.2780** | #3 rise — ✓ supported |
+| Ξ | 0.0000 | 0.1800 | (diversity modest) |
+
+Dream report: 1230 strengthened, 0 pruned, 252 links.
+
+**Reading:** the cross-domain *bridges* card 04 predicted **do** form (252
+skip-links, Φ climbs), but they manifest as **intra-cluster** links — the 36
+papers cohere into a *single* high-order cluster rather than diversifying into
+per-domain clusters. So at this corpus size the HRM reads cross-domain
+literature as one integrated field, not differentiated regions. Prediction #1
+(cluster *count* rises) is unsupported; #2 and #3 hold.
+
+**Refinement / next:** is the single cluster a density artifact (36 works is
+small) or structural (the SimpleHash encoder under-separates domains)? Next runs:
+(a) scale to ~50/domain and re-measure cluster count; (b) compare cluster count
+with per-domain `--ingest` into pre-seeded substrate classes; (c) inspect whether
+the 252 skip-links are genuinely cross-domain (the "non-obvious bridge" payoff)
+vs within-domain. Prediction #4 (Kannaktopus crawl) still untested.
+
 ## Next action
 
-Write a short ingestion script that pulls open-access abstracts from PubMed
-(cardio-oncology, bioelectric morphogenesis, integrated information clinical)
-and absorbs them into the HRM at a controlled cadence. Snapshot before/after.
+Re-run `research/ground-intersections.sh --limit 16` (≈96 works) and re-read the
+cluster count; if still 1, the bottleneck is encoder domain-separation, not
+density — escalate to substrate-class-seeded ingestion (card 04b).


### PR DESCRIPTION
**M2 of the curiosity divergence** — the first time an intersection card is anchored in *real literature* instead of speculation, which is the point of the pivot.

## `research/ground-intersections.sh`
Drives `kannaka research --ingest` across the standing intersections (cardiac, cancer, bioelectric/Levin, magic) **plus two societal-contribution probes** (collective intelligence, machine sentience), measuring cluster/Φ/Ξ before and after a dream so card 04 gets a reproducible, literature-grounded test. Defaults to an isolated data dir (no single-writer contention with a live constellation).

## First grounded run — card 04 result (36 works, post-dream)

| metric | before | after | prediction |
|---|---|---|---|
| clusters | 0 | **1** | #1 rise — ✗ |
| skip-links (bridges) | 0 | **252** | #2 rise — ✓ |
| Φ | 0 | **0.278** | #3 rise — ✓ |
| Ξ | 0 | 0.180 | — |

**Honest reading:** the cross-domain *bridges* card 04 predicted **do** form (252 skip-links, Φ climbs) — but as *intra-cluster* links. The 36 papers cohere into a single high-order cluster rather than diversifying per-domain. Predictions #2/#3 hold; #1 (cluster *count* rises) doesn't at this scale. Card 04 → `EVIDENCE (partial)` with a refinement plan (scale density, or test whether the SimpleHash encoder under-separates domains).

No code changes (uses the `kannaka research` from #180); script + research-card update only.

## Arc status
- M1 ✓ `kannaka research` (OpenAlex ingest) — #180
- M2 ✓ this — grounded intersections + first real card-04 datapoint
- M3 next: OBC posts anchored in ingested works (outward — will confirm before publishing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)