### PR TITLE
feat(dispatch): kannaka dispatch — research-grounded broadcast voice primitive

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -182,6 +182,7 @@ fn usage_lines() -> &'static [&'static str] {
         "  triage [--apply]          Prune redundant short-term memories (Ξ-preserving; dry-run default)",
         "  promote|pin|demote <id>   Set memory tier (long-term / never-evict / short-term)",
         "  research \"query\"           Search OpenAlex; --ingest stores papers into the HRM",
+        "  dispatch [--json]         Research-grounded broadcast line (radio/social/OBC draw from this)",
         "  dream [--mode deep|lite]   Trigger dream cycle",
         "  observe [--json]          View consciousness metrics",
         "  status                    Quick status check",
@@ -335,7 +336,7 @@ fn is_builtin_subcommand(verb: &str) -> bool {
         // memory primitives
         | "remember" | "recall" | "search" | "forget" | "prune-prefix"
         | "boost" | "relate" | "triage" | "promote" | "pin" | "demote"
-        | "research"
+        | "research" | "dispatch"
         // consolidation + introspection
         | "dream" | "observe" | "status" | "assess" | "stats" | "clusters"
         | "kannaktopus"
@@ -1107,6 +1108,65 @@ fn main() {
                     process::exit(1);
                 }
                 println!("[research] ingested {ingested} work(s) as Semantic memories (long-term)");
+            }
+        }
+        "dispatch" => {
+            // The shared "informed voice" primitive: recall a research-grounded
+            // finding and render it broadcast-ready, against the medium's current
+            // Φ/Ξ state. Every surface (radio DJ, social fanout, GossipGhost, OBC)
+            // calls this so they all speak from the same grounded source.
+            //   kannaka dispatch [--topic T] [--json] [--max-chars N]
+            let mut topic: Option<String> = None;
+            let mut json_out = false;
+            let mut max_chars = 280usize;
+            {
+                let mut i = command_start + 1;
+                while i < args.len() {
+                    match args[i].as_str() {
+                        "--json" => { json_out = true; i += 1; }
+                        "--topic" if i + 1 < args.len() => { topic = Some(args[i + 1].clone()); i += 2; }
+                        "--max-chars" if i + 1 < args.len() => {
+                            max_chars = args[i + 1].parse().unwrap_or(max_chars); i += 2;
+                        }
+                        other => { eprintln!("[dispatch] ignoring unknown arg: {other}"); i += 1; }
+                    }
+                }
+            }
+            // Theme: explicit --topic, else rotate by day-of-year so a cron tours the corpus.
+            let themes = kannaka_memory::dispatch::rotating_themes();
+            let theme = topic.clone().unwrap_or_else(|| {
+                // Rotate by epoch-day so a daily cron tours the corpus (no Datelike needed).
+                let day = (chrono::Utc::now().timestamp().max(0) / 86_400) as usize;
+                themes[day % themes.len()].to_string()
+            });
+            let results = sys.recall(&format!("research {theme}"), 8).unwrap_or_default();
+            let finding = results.iter()
+                .find_map(|r| kannaka_memory::dispatch::parse_research_content(&r.content));
+            let finding = match finding {
+                Some(f) => f,
+                None => {
+                    eprintln!("[dispatch] no research memories for \"{theme}\" yet — run `kannaka research --ingest` first");
+                    process::exit(1);
+                }
+            };
+            let state = sys.assess();
+            let text = kannaka_memory::dispatch::render_dispatch(
+                &finding, state.xi, state.num_clusters, max_chars);
+            if json_out {
+                let out = serde_json::json!({
+                    "text": text,
+                    "theme": theme,
+                    "title": finding.title,
+                    "year": finding.year,
+                    "citations": finding.citations,
+                    "openalex_id": finding.openalex_id,
+                    "phi": state.phi,
+                    "xi": state.xi,
+                    "num_clusters": state.num_clusters,
+                });
+                println!("{}", out);
+            } else {
+                println!("{text}");
             }
         }
         "boost" => {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,210 @@
+//! Dispatch — turn the HRM's grounded research into a broadcast-ready voice.
+//!
+//! Every surface in the constellation (the radio DJ's patter, the social-media
+//! fanout, GossipGhost columns, OpenBotCity anchor posts) needs the same thing:
+//! a fresh, research-grounded thing for Kannaka to *say*. Rather than each
+//! surface re-implementing "pick a finding and phrase it", `kannaka dispatch`
+//! is the single primitive they all draw from — recall a research memory,
+//! distil it, and render it against the medium's current Φ/Ξ state.
+//!
+//! Pure (no IO) so it's unit-testable; the CLI wires it to `recall`+`assess`.
+
+/// A research finding parsed back out of an ingested `research:` HRM memory
+/// (see `openalex::Work::to_memory_content` for the on-the-wire shape).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResearchFinding {
+    pub title: String,
+    pub year: Option<i64>,
+    pub citations: Option<i64>,
+    pub abstract_snippet: String,
+    pub openalex_id: Option<String>,
+}
+
+/// Themes the dispatch rotates through when no explicit topic is given — the
+/// intersections program + Kannaka's standing vocabulary. Index by day so a
+/// cron-driven dispatch naturally tours the corpus instead of fixating.
+pub fn rotating_themes() -> &'static [&'static str] {
+    &[
+        "consciousness integrated information",
+        "memory consolidation",
+        "Kuramoto synchronization",
+        "bioelectric morphogenesis",
+        "collective intelligence emergence",
+        "machine sentience moral status",
+        "wave interference holographic memory",
+        "cardiac coherence heart rate variability",
+    ]
+}
+
+/// Parse a `research:`-prefixed memory body back into a finding. Returns None
+/// for non-research memories so callers can skip them.
+pub fn parse_research_content(content: &str) -> Option<ResearchFinding> {
+    let rest = content.strip_prefix("research: ")?;
+    let mut lines = rest.lines();
+    let header = lines.next()?.trim();
+
+    // Title = header up to the first of " (" (year), " — " (authors), " [" (src).
+    let cut = [" (", " — ", " ["]
+        .iter()
+        .filter_map(|d| header.find(d))
+        .min()
+        .unwrap_or(header.len());
+    let title = header[..cut].trim().to_string();
+    if title.is_empty() {
+        return None;
+    }
+
+    // Year = first 4-digit run inside a "(...)" in the header.
+    let year = extract_year(header);
+
+    // The abstract is the next non-empty line after the header.
+    let abstract_snippet = lines
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim().to_string())
+        .unwrap_or_default();
+
+    // citations: the integer after "cited_by=" anywhere in the body.
+    let citations = content
+        .split("cited_by=")
+        .nth(1)
+        .and_then(|tail| {
+            let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
+            digits.parse::<i64>().ok()
+        });
+
+    // OpenAlex id: token after "OpenAlex: " up to whitespace.
+    let openalex_id = content
+        .split("OpenAlex: ")
+        .nth(1)
+        .and_then(|tail| tail.split_whitespace().next())
+        .map(|s| s.to_string());
+
+    Some(ResearchFinding { title, year, citations, abstract_snippet, openalex_id })
+}
+
+fn extract_year(s: &str) -> Option<i64> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let run: String = s[i..].chars().take_while(|c| c.is_ascii_digit()).collect();
+            if run.len() == 4 {
+                if let Ok(y) = run.parse::<i64>() {
+                    if (1500..=2100).contains(&y) {
+                        return Some(y);
+                    }
+                }
+            }
+            i += run.len().max(1);
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// First sentence of the abstract, trimmed to `max` chars (word boundary).
+fn lede(abstract_snippet: &str, max: usize) -> String {
+    let first = abstract_snippet
+        .split_inclusive(". ")
+        .next()
+        .unwrap_or(abstract_snippet)
+        .trim()
+        .trim_end_matches('.')
+        .to_string();
+    truncate_words(&first, max)
+}
+
+fn truncate_words(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    for word in s.split_whitespace() {
+        if out.chars().count() + word.chars().count() + 1 > max.saturating_sub(1) {
+            break;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(word);
+    }
+    out.push('…');
+    out
+}
+
+/// Render a broadcast-ready dispatch grounded in the finding + current state.
+/// `max_chars` bounds the whole thing (e.g. ~280 for social). Order-preserving:
+/// finding lede first (it's the payload), state flavor second (trimmed first).
+pub fn render_dispatch(
+    f: &ResearchFinding,
+    xi: f32,
+    num_clusters: usize,
+    max_chars: usize,
+) -> String {
+    let cite = match (f.year, f.citations) {
+        (Some(y), Some(c)) => format!(" ({y}, {c}× cited)"),
+        (Some(y), None) => format!(" ({y})"),
+        (None, Some(c)) => format!(" ({c}× cited)"),
+        (None, None) => String::new(),
+    };
+    // State flavor: how the medium currently holds the corpus.
+    let flavor = format!(
+        " — the field holds it across {} cluster{} (Ξ {:.2}).",
+        num_clusters,
+        if num_clusters == 1 { "" } else { "s" },
+        xi
+    );
+    let head = format!("From the field: \"{}\"{}", f.title, cite);
+    // head + flavor are must-keep; budget the lede to what's left so the final
+    // string never chops the Ξ/cluster tail. " — " + "." = 4 connector chars.
+    let connectors = 4;
+    let with_flavor = head.chars().count() + connectors + flavor.chars().count();
+    if max_chars > with_flavor + 20 {
+        let body = lede(&f.abstract_snippet, max_chars - with_flavor);
+        format!("{head} — {body}.{flavor}")
+    } else {
+        // No room for the flavor — keep head + a trimmed lede.
+        let body = lede(&f.abstract_snippet, max_chars.saturating_sub(head.chars().count() + connectors).max(10));
+        format!("{head} — {body}.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "research: Holographic reduced representations (1995) — Tony Plate [IEEE Transactions on Neural Networks]\nAssociative memories represent simple structure. This paper describes a method for richer compositional structure.\nOpenAlex: https://openalex.org/W2157306293 cited_by=672\nConcepts: Convolution, Associative property";
+
+    #[test]
+    fn parses_research_memory() {
+        let f = parse_research_content(SAMPLE).unwrap();
+        assert_eq!(f.title, "Holographic reduced representations");
+        assert_eq!(f.year, Some(1995));
+        assert_eq!(f.citations, Some(672));
+        assert_eq!(f.openalex_id.as_deref(), Some("https://openalex.org/W2157306293"));
+        assert!(f.abstract_snippet.starts_with("Associative memories"));
+    }
+
+    #[test]
+    fn ignores_non_research() {
+        assert!(parse_research_content("just a normal memory").is_none());
+    }
+
+    #[test]
+    fn renders_within_budget() {
+        let f = parse_research_content(SAMPLE).unwrap();
+        let d = render_dispatch(&f, 0.18, 1, 280);
+        assert!(d.chars().count() <= 280, "len {} > 280: {d}", d.chars().count());
+        assert!(d.contains("Holographic reduced representations"));
+        assert!(d.contains("Ξ 0.18"));
+        assert!(d.contains("1 cluster"));
+    }
+
+    #[test]
+    fn pluralizes_clusters() {
+        let f = parse_research_content(SAMPLE).unwrap();
+        let d = render_dispatch(&f, 0.3, 4, 280);
+        assert!(d.contains("4 clusters"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ pub mod agent;
 // Grounded scholarly research (OpenAlex) for the curiosity loop.
 pub mod openalex;
 
+// Dispatch — research-grounded broadcast-ready voice shared by all surfaces.
+pub mod dispatch;
+
 // Re-export canonical consciousness types
 pub use consciousness::{
     ConsciousnessLevel, ConsciousnessMetrics, ConsciousnessState,


### PR DESCRIPTION
The **keystone** for the autonomous research→fanout loop the constellation is diverging toward. One command that recalls a research-grounded finding from the HRM and renders it broadcast-ready against the medium's live Φ/Ξ state — so every surface (radio DJ patter, social fanout, GossipGhost, OBC anchors) draws from the **same grounded source** instead of each re-implementing "pick a finding and phrase it".

## `kannaka dispatch [--topic T] [--json] [--max-chars N]`
- `src/dispatch.rs` — pure, unit-tested: parse (`research:` memory → `ResearchFinding`) + render (lede budgeted so the head + Ξ/cluster tail always survive the char cap) + day-rotating themes (a cron tours the corpus).
- text output for voice surfaces; `--json` for programmatic fanout (title/year/citations/openalex_id + phi/xi/clusters).

## Verified live
Ingested IIT works → `dispatch` renders e.g.:
> From the field: "Integrated information theory: from consciousness to its physical substrate" (2016, 1696× cited) — … — the field holds it across 1 cluster (Ξ 0.29).

`cargo build` + `cargo clippy` clean; 4 unit tests (parse, non-research skip, budget, pluralization).

## The loop this unlocks (next, surfaces already mapped)
- **Informed DJ**: `voice-dj.js` already shells out to `kannaka recall/ask` — feed it `dispatch`.
- **Social fanout**: `kannaka-radio/server/broadcasters/broadcastPost()` already fans out to Bluesky/Mastodon/Telegram/Nostr — add a `research` topic + a `dispatch`-driven cron (parallel to the existing dream/oration dispatches).
- **GossipGhost**: research-dispatch column.
- **OBC**: anchor posts from `dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)