### PR TITLE
feat(recall): daemon-served recall over NATS (warm in-memory HRM)

### DIFF
--- a/src/bin/handlers/swarm.rs
+++ b/src/bin/handlers/swarm.rs
@@ -77,6 +77,22 @@ pub(crate) fn handle_swarm_serve(
     };
     let _ = bcast_sub.set_timeout(Some(Duration::from_secs(5)));
 
+    // Daemon-served recall (KANNAKA.recall.<agent_id>): the observatory, OBC
+    // pulses, and the radio DJ can recall against this agent's warm in-memory
+    // HRM instead of paying a 21 MB load + full xi-rerank per CLI call on the
+    // 1-vCPU box. Uses the attention-beam prefilter + recall_with_beam
+    // (O(beam), sub-second) — the same path the substrate responder uses. swarm
+    // serve runs KANNAKA_READONLY, so the observation mutation never persists.
+    let recall_subject = format!("KANNAKA.recall.{}", agent_id);
+    let recall_transport = kannaka_memory::nats::SwarmTransport::connect(&nats_url).ok();
+    let mut recall_sub = recall_transport
+        .as_ref()
+        .and_then(|t| t.subscribe(&recall_subject).ok());
+    match recall_sub.as_mut() {
+        Some(s) => { let _ = s.set_timeout(Some(Duration::from_secs(2))); eprintln!("[swarm serve] serving recall on {recall_subject}"); }
+        None => eprintln!("[swarm serve] WARN: recall responder unavailable (extra NATS connection failed)"),
+    }
+
     loop {
         // Round-robin: try directed first, then broadcast.
         if let Some(msg) = directed_sub.next_message() {
@@ -84,6 +100,35 @@ pub(crate) fn handle_swarm_serve(
         }
         if let Some(msg) = bcast_sub.next_message() {
             _handle_serve_msg(sys, cfg, &bcast_transport, &msg, /*is_broadcast*/ true, threshold);
+        }
+        // Daemon-served recall — reply with the agent's own memories (full content).
+        if let Some(ref mut rsub) = recall_sub {
+            if let Some(msg) = rsub.next_message() {
+                let reply_to = msg.reply_to.clone();
+                let req: serde_json::Value = serde_json::from_slice(&msg.payload).unwrap_or(serde_json::Value::Null);
+                let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8) as usize;
+                if let (false, Some(reply)) = (query.is_empty(), reply_to) {
+                    let beam = kannaka_memory::agent::attention_beam_for_prompt(
+                        sys, &query, kannaka_memory::agent::DEFAULT_ATTENTION_BEAM);
+                    let recall = if beam.is_empty() {
+                        sys.recall(&query, top_k)            // cold/small HRM fallback
+                    } else {
+                        sys.recall_with_beam(&beam, &query, top_k)
+                    };
+                    let results: Vec<serde_json::Value> = recall.map(|rs| rs.iter().map(|r| serde_json::json!({
+                        "id": r.id.to_string(),
+                        "content": r.content,
+                        "similarity": r.similarity,
+                        "strength": r.strength,
+                        "age_hours": r.age_hours,
+                    })).collect()).unwrap_or_default();
+                    if let Some(ref rt) = recall_transport {
+                        let payload = serde_json::json!({ "from": cfg.agent.id, "query": query, "results": results });
+                        let _ = rt.reply(&reply, payload.to_string().as_bytes());
+                    }
+                }
+            }
         }
     }
 }

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -770,11 +770,13 @@ fn main() {
         }
         "recall" => {
             if args.len() < command_start + 2 {
-                eprintln!("Usage: kannaka recall <query> [--top-k N] [--collective] [--timeout SECS]");
+                eprintln!("Usage: kannaka recall <query> [--top-k N] [--collective] [--remote] [--agent-id ID] [--timeout SECS]");
                 process::exit(1);
             }
             let mut top_k = 5usize;
             let mut collective = false;
+            let mut remote = false;
+            let mut agent_id_override: Option<String> = None;
             let mut timeout_secs: u64 = 8;
             let mut query_parts = Vec::new();
             let mut i = command_start + 1;
@@ -785,6 +787,12 @@ fn main() {
                 } else if args[i] == "--collective" {
                     collective = true;
                     i += 1;
+                } else if args[i] == "--remote" {
+                    remote = true;
+                    i += 1;
+                } else if args[i] == "--agent-id" && i + 1 < args.len() {
+                    agent_id_override = Some(args[i + 1].clone());
+                    i += 2;
                 } else if args[i] == "--timeout" && i + 1 < args.len() {
                     timeout_secs = args[i + 1].parse().unwrap_or(8);
                     i += 2;
@@ -827,6 +835,43 @@ fn main() {
             #[cfg(not(feature = "nats"))]
             if collective {
                 eprintln!("recall --collective requires the 'nats' feature");
+                process::exit(1);
+            }
+
+            // Daemon-served recall — route to this agent's `swarm serve` daemon,
+            // which recalls its WARM in-memory HRM (full content) and replies.
+            // Avoids the per-CLI 21 MB load + xi-rerank that makes recall slow on
+            // the 1-vCPU box. Prints the legacy results array so the observatory
+            // and OBC pulses consume it exactly like `recall --json`.
+            #[cfg(feature = "nats")]
+            if remote {
+                use std::time::Duration;
+                let nats_url = resolve_nats_url(&args[command_start..], 0, &cfg.swarm.nats_url);
+                let agent_id = agent_id_override.clone().unwrap_or_else(|| cfg.agent.id.clone());
+                let subject = format!("KANNAKA.recall.{}", agent_id);
+                let transport = match kannaka_memory::nats::SwarmTransport::connect(&nats_url) {
+                    Ok(t) => t,
+                    Err(e) => { eprintln!("remote recall: NATS connect failed: {}", e); process::exit(1); }
+                };
+                let req = serde_json::json!({ "query": query, "top_k": top_k });
+                match transport.request_one(&subject, req.to_string().as_bytes(), Duration::from_secs(timeout_secs)) {
+                    Ok(reply) => {
+                        let parsed: serde_json::Value = serde_json::from_slice(&reply)
+                            .unwrap_or(serde_json::Value::Null);
+                        let results = parsed.get("results").cloned().unwrap_or_else(|| serde_json::json!([]));
+                        println!("{}", results);
+                    }
+                    Err(e) => {
+                        eprintln!("remote recall: no reply within {}s ({})", timeout_secs, e);
+                        eprintln!("hint: is `kannaka swarm serve` alive (serving KANNAKA.recall.{})?", agent_id);
+                        process::exit(2);
+                    }
+                }
+                return;
+            }
+            #[cfg(not(feature = "nats"))]
+            if remote {
+                eprintln!("recall --remote requires the 'nats' feature");
                 process::exit(1);
             }
 


### PR DESCRIPTION
Removes the recall-timeout root cause on the 1-vCPU box. `swarm serve` holds the HRM warm; this adds a `KANNAKA.recall.<agent_id>` responder (beam prefilter + recall_with_beam, sub-second — the substrate's fast path) and a `recall --remote` client that prints the legacy results array. Observatory/pulses get fast recall with no code-shape change. `cargo check --features nats` clean.