### PR TITLE
[auto-maintainer] refactor(rhythm): extract interval_lerp helper to deduplicate compute_interval

### DIFF
--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -178,29 +178,21 @@ impl RhythmEngine {
         eta
     }
 
+    // hi_ms at t=0, lo_ms at t=1 (higher arousal → lower t-parameter → longer interval).
+    fn interval_lerp(hi_ms: f64, lo_ms: f64, t: f64) -> u64 {
+        (hi_ms - t * (hi_ms - lo_ms)) as u64
+    }
+
     /// Map arousal to interval.
     fn compute_interval(&self) -> u64 {
         let a = self.state.arousal_level;
-        let ms = if a > 0.7 {
-            // 2-5 min: linear interpolation
-            let t = (a - 0.7) / 0.3; // 0..1
-            let min_ms = 120_000.0;
-            let max_ms = 300_000.0;
-            max_ms - t * (max_ms - min_ms)
+        if a > 0.7 {
+            Self::interval_lerp(300_000.0, 120_000.0, (a - 0.7) / 0.3) // 2-5 min
         } else if a > 0.3 {
-            // 5-15 min
-            let t = (a - 0.3) / 0.4;
-            let min_ms = 300_000.0;
-            let max_ms = 900_000.0;
-            max_ms - t * (max_ms - min_ms)
+            Self::interval_lerp(900_000.0, 300_000.0, (a - 0.3) / 0.4) // 5-15 min
         } else {
-            // 15-60 min
-            let t = a / 0.3;
-            let min_ms = 900_000.0;
-            let max_ms = 3_600_000.0;
-            max_ms - t * (max_ms - min_ms)
-        };
-        ms as u64
+            Self::interval_lerp(3_600_000.0, 900_000.0, a / 0.3)        // 15-60 min
+        }
     }
 
     /// Persist state to disk.


### PR DESCRIPTION
## What changed

One file, `src/rhythm.rs`, ~15-line diff inside `impl RhythmEngine`:

```diff
+    // hi_ms at t=0, lo_ms at t=1 (higher arousal → lower t-parameter → longer interval).
+    fn interval_lerp(hi_ms: f64, lo_ms: f64, t: f64) -> u64 {
+        (hi_ms - t * (hi_ms - lo_ms)) as u64
+    }
+
     /// Map arousal to interval.
     fn compute_interval(&self) -> u64 {
         let a = self.state.arousal_level;
-        let ms = if a > 0.7 {
-            // 2-5 min: linear interpolation
-            let t = (a - 0.7) / 0.3; // 0..1
-            let min_ms = 120_000.0;
-            let max_ms = 300_000.0;
-            max_ms - t * (max_ms - min_ms)
-        } else if a > 0.3 {
-            // 5-15 min
-            let t = (a - 0.3) / 0.4;
-            let min_ms = 300_000.0;
-            let max_ms = 900_000.0;
-            max_ms - t * (max_ms - min_ms)
-        } else {
-            // 15-60 min
-            let t = a / 0.3;
-            let min_ms = 900_000.0;
-            let max_ms = 3_600_000.0;
-            max_ms - t * (max_ms - min_ms)
-        };
-        ms as u64
+        if a > 0.7 {
+            Self::interval_lerp(300_000.0, 120_000.0, (a - 0.7) / 0.3) // 2-5 min
+        } else if a > 0.3 {
+            Self::interval_lerp(900_000.0, 300_000.0, (a - 0.3) / 0.4) // 5-15 min
+        } else {
+            Self::interval_lerp(3_600_000.0, 900_000.0, a / 0.3)        // 15-60 min
+        }
     }
```

## The problem

`compute_interval` had three branches, each computing `max_ms - t * (max_ms - min_ms)` with different constants. The formula was duplicated verbatim three times — a classic extract-helper pattern.

## Why it's safe

- **Algebraically identical.** `interval_lerp(hi, lo, t)` computes `hi - t*(hi - lo)`. Substituting `hi=max_ms`, `lo=min_ms` gives `max_ms - t*(max_ms - min_ms)` — identical to the original expression in every branch. No rounding difference: all values are `f64` throughout, cast to `u64` at the same point.
- **No behavior change.** The arousal thresholds (0.7, 0.3), the t-parameter normalization expressions, and the millisecond constants (120k, 300k, 900k, 3_600k) are all unchanged. Only the structure changed.
- **No new imports, no schema changes, no lockfile touches.**
- **Private helper.** `interval_lerp` is not `pub` — it's internal to `impl RhythmEngine` and has no effect on the public API.

## Verification

No `cargo` toolchain is available in this execution environment. Verification is structural:

1. **Formula equivalence** — proven algebraically above; straightforward substitution.
2. **Diff review** — each of the three branches maps 1-to-1 to a `Self::interval_lerp(hi, lo, t)` call with the same constants. The `let ms = ...` wrapper and the trailing `ms as u64` are eliminated because `interval_lerp` already returns `u64`.
3. **The helper is pure** — no `self` access, no side effects, deterministic for any `f64` input.

**Diff:**
```
src/rhythm.rs | ~15 lines changed
1 file changed
```

## Runtime

~25 minutes wall-clock (startup jitter + in-flight branch detection across 6 repos + commit timestamp verification + backlog scan + repo age survey + codebase exploration + fix + push + duplicate check + PR).

---
_Generated by the kannaka constellation hourly maintainer_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sza2kiRZvJJgqD2FRdFAxo)_