### PR TITLE
ADR-0037 Phase 4b: PCA 2-D projection of the HRM field (#415 task 1+3)

### DIFF
--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -644,9 +644,13 @@ impl HrmStore {
                     let x = chiral.bilateral_ring_report();
                     if x.n > 0 {
                         let right = chiral.holistic_ring_report();
+                        // Phase 4b (#415 task 1): localize genuine 2-D spiral
+                        // cores in the PCA-embedded holistic field (self.medium
+                        // is synced from the right hemisphere by rebuild_cache).
+                        let c = self.medium.spiral_cloud_report();
                         eprintln!(
-                            "[spiral] deep dream: cross-hemi winding={:.3} order={:.3} n={} (right winding={:.3})",
-                            x.winding, x.order, x.n, right.winding
+                            "[spiral] deep dream: cross-hemi winding={:.3} order={:.3} n={} (right winding={:.3}, 2D cores={} net={})",
+                            x.winding, x.order, x.n, right.winding, c.singularities.len(), c.net_charge
                         );
                     }
                 }

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -645,9 +645,10 @@ impl HrmStore {
                     if x.n > 0 {
                         let right = chiral.holistic_ring_report();
                         // Phase 4b (#415 task 1): localize genuine 2-D spiral
-                        // cores in the PCA-embedded holistic field (self.medium
-                        // is synced from the right hemisphere by rebuild_cache).
-                        let c = self.medium.spiral_cloud_report();
+                        // cores in the PCA-embedded HOLISTIC field — read the
+                        // right hemisphere directly (the field the coupling
+                        // rotates), not the stale flat medium (cf. #416 fix).
+                        let c = chiral.holistic_cloud_report();
                         eprintln!(
                             "[spiral] deep dream: cross-hemi winding={:.3} order={:.3} n={} (right winding={:.3}, 2D cores={} net={})",
                             x.winding, x.order, x.n, right.winding, c.singularities.len(), c.net_charge

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -587,6 +587,18 @@ impl ChiralMedium {
         crate::spiral::ring_report(&phases)
     }
 
+    /// ADR-0037 Phase 4b: 2-D spiral cores over the holistic (right) field — the
+    /// cloud-detector companion to `holistic_ring_report`. Reads the right
+    /// hemisphere directly (the field the Phase-2 coupling rotates), NOT the
+    /// stale flat medium, mirroring the #416 holistic fix. Projects the right
+    /// wavefronts to 2-D (PCA) and localizes singularities.
+    pub fn holistic_cloud_report(&self) -> crate::spiral::SpiralReport {
+        let n = self.right.count();
+        let wf = self.right.wavefronts.slice(ndarray::s![..n, ..]).to_owned();
+        let phases: Vec<f32> = self.right.phase.slice(ndarray::s![..n]).iter().copied().collect();
+        Medium::cloud_report_2d(&wf, &phases)
+    }
+
     /// ADR-0037 Phase 4: cross-hemisphere ring report. The cortical spiral wave
     /// in Ye et al. (Science 2026) spans BOTH hemispheres, not one — so the L6
     /// instrument joins the active left ⊕ right phase fields into a single ring

--- a/src/medium/dynamics.rs
+++ b/src/medium/dynamics.rs
@@ -135,6 +135,97 @@ impl Medium {
         h.dot(&h.t())
     }
 
+    /// ADR-0037 Phase 4b (#415 task 1): project the wavefront field to 2-D via
+    /// top-2 PCA of the Gram matrix (power iteration + deflation, dependency-
+    /// free; classical-MDS sample-space coordinates) and pair each memory with
+    /// its phase → `(x, y, theta)`. Gives `cloud_singularities` a spatial
+    /// manifold to find genuine 2-D spiral cores in (not just the 1-D ring).
+    /// Empty below 4 wavefronts.
+    pub fn spiral_field_2d(&self) -> Vec<(f32, f32, f32)> {
+        let n = self.wavefront_count();
+        if n < 4 {
+            return Vec::new();
+        }
+        let gram = self.gram_matrix();
+        let matvec = |v: &[f32]| -> Vec<f32> {
+            (0..n)
+                .map(|i| (0..n).map(|j| gram[[i, j]] * v[j]).sum())
+                .collect()
+        };
+        let normalize = |v: &mut [f32]| -> f32 {
+            let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 1e-12 {
+                for x in v.iter_mut() {
+                    *x /= norm;
+                }
+            }
+            norm
+        };
+        let dot = |a: &[f32], b: &[f32]| -> f32 { a.iter().zip(b).map(|(x, y)| x * y).sum() };
+        let seed = |salt: u64| -> Vec<f32> {
+            (0..n)
+                .map(|i| {
+                    (((i as u64).wrapping_mul(2654435761).wrapping_add(salt) % 1000) as f32 / 1000.0)
+                        - 0.5
+                })
+                .collect()
+        };
+
+        // Top eigenvector.
+        let mut v1 = seed(1);
+        normalize(&mut v1);
+        for _ in 0..80 {
+            let mut w = matvec(&v1);
+            if normalize(&mut w) < 1e-20 {
+                break;
+            }
+            v1 = w;
+        }
+        let l1 = dot(&v1, &matvec(&v1));
+
+        // Second eigenvector, deflated against v1 each step.
+        let mut v2 = seed(7);
+        let p0 = dot(&v2, &v1);
+        for i in 0..n {
+            v2[i] -= p0 * v1[i];
+        }
+        normalize(&mut v2);
+        for _ in 0..80 {
+            let mut w = matvec(&v2);
+            let p = dot(&w, &v1);
+            for i in 0..n {
+                w[i] -= p * v1[i];
+            }
+            if normalize(&mut w) < 1e-20 {
+                break;
+            }
+            v2 = w;
+        }
+        let l2 = dot(&v2, &matvec(&v2));
+
+        let s1 = l1.max(0.0).sqrt();
+        let s2 = l2.max(0.0).sqrt();
+        (0..n)
+            .map(|i| (s1 * v1[i], s2 * v2[i], self.store.phase[i]))
+            .collect()
+    }
+
+    /// ADR-0037 Phase 4b: full 2-D spiral report — runs `cloud_singularities`
+    /// over the PCA-embedded phase field. The richer companion to the 1-D ring
+    /// reports; use when you want localized 2-D cores.
+    pub fn spiral_cloud_report(&self) -> crate::spiral::SpiralReport {
+        let pts = self.spiral_field_2d();
+        let singularities = crate::spiral::cloud_singularities(&pts, 8);
+        let phases: Vec<f32> = pts.iter().map(|p| p.2).collect();
+        let net_charge = singularities.iter().map(|s| s.charge).sum();
+        crate::spiral::SpiralReport {
+            n: pts.len(),
+            order: crate::spiral::kuramoto_order(&phases),
+            singularities,
+            net_charge,
+        }
+    }
+
     /// Cached-per-call cos/sin of every wavefront phase, for building
     /// cos(Δphase) terms without N² trig calls.
     fn phase_trig(&self) -> (Vec<f32>, Vec<f32>) {

--- a/src/medium/dynamics.rs
+++ b/src/medium/dynamics.rs
@@ -135,22 +135,20 @@ impl Medium {
         h.dot(&h.t())
     }
 
-    /// ADR-0037 Phase 4b (#415 task 1): project the wavefront field to 2-D via
-    /// top-2 PCA of the Gram matrix (power iteration + deflation, dependency-
-    /// free; classical-MDS sample-space coordinates) and pair each memory with
-    /// its phase → `(x, y, theta)`. Gives `cloud_singularities` a spatial
-    /// manifold to find genuine 2-D spiral cores in (not just the 1-D ring).
-    /// Empty below 4 wavefronts.
-    pub fn spiral_field_2d(&self) -> Vec<(f32, f32, f32)> {
-        let n = self.wavefront_count();
-        if n < 4 {
+    /// ADR-0037 Phase 4b: top-2 PCA of a wavefront matrix (power iteration +
+    /// deflation, dependency-free; classical-MDS sample-space coordinates) →
+    /// 2-D coords paired with `phases` as `(x, y, theta)`. Shared by `Medium`
+    /// (synced flat field) and `ChiralMedium::holistic_cloud_report` (the right
+    /// hemisphere — the field the Phase-2 coupling actually rotates). Empty
+    /// below 4 rows or when `phases` is shorter than the row count.
+    pub(crate) fn pca_field_2d(wavefronts: &Array2<f32>, phases: &[f32]) -> Vec<(f32, f32, f32)> {
+        let n = wavefronts.nrows();
+        if n < 4 || phases.len() < n {
             return Vec::new();
         }
-        let gram = self.gram_matrix();
+        let gram = wavefronts.dot(&wavefronts.t());
         let matvec = |v: &[f32]| -> Vec<f32> {
-            (0..n)
-                .map(|i| (0..n).map(|j| gram[[i, j]] * v[j]).sum())
-                .collect()
+            (0..n).map(|i| (0..n).map(|j| gram[[i, j]] * v[j]).sum()).collect()
         };
         let normalize = |v: &mut [f32]| -> f32 {
             let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -171,7 +169,6 @@ impl Medium {
                 .collect()
         };
 
-        // Top eigenvector.
         let mut v1 = seed(1);
         normalize(&mut v1);
         for _ in 0..80 {
@@ -183,7 +180,6 @@ impl Medium {
         }
         let l1 = dot(&v1, &matvec(&v1));
 
-        // Second eigenvector, deflated against v1 each step.
         let mut v2 = seed(7);
         let p0 = dot(&v2, &v1);
         for i in 0..n {
@@ -205,25 +201,43 @@ impl Medium {
 
         let s1 = l1.max(0.0).sqrt();
         let s2 = l2.max(0.0).sqrt();
-        (0..n)
-            .map(|i| (s1 * v1[i], s2 * v2[i], self.store.phase[i]))
-            .collect()
+        (0..n).map(|i| (s1 * v1[i], s2 * v2[i], phases[i])).collect()
     }
 
-    /// ADR-0037 Phase 4b: full 2-D spiral report — runs `cloud_singularities`
-    /// over the PCA-embedded phase field. The richer companion to the 1-D ring
-    /// reports; use when you want localized 2-D cores.
-    pub fn spiral_cloud_report(&self) -> crate::spiral::SpiralReport {
-        let pts = self.spiral_field_2d();
+    /// ADR-0037 Phase 4b: 2-D spiral report over a PCA-embedded wavefront/phase
+    /// field — runs `cloud_singularities` and tallies cores + net charge.
+    pub(crate) fn cloud_report_2d(
+        wavefronts: &Array2<f32>,
+        phases: &[f32],
+    ) -> crate::spiral::SpiralReport {
+        let pts = Self::pca_field_2d(wavefronts, phases);
         let singularities = crate::spiral::cloud_singularities(&pts, 8);
-        let phases: Vec<f32> = pts.iter().map(|p| p.2).collect();
         let net_charge = singularities.iter().map(|s| s.charge).sum();
+        let field_phases: Vec<f32> = pts.iter().map(|p| p.2).collect();
         crate::spiral::SpiralReport {
             n: pts.len(),
-            order: crate::spiral::kuramoto_order(&phases),
+            order: crate::spiral::kuramoto_order(&field_phases),
             singularities,
             net_charge,
         }
+    }
+
+    /// ADR-0037 Phase 4b (#415 task 1): 2-D PCA projection of this (synced flat)
+    /// medium's field. For the holistic field during a dream use
+    /// `ChiralMedium::holistic_cloud_report` (reads the right hemisphere).
+    pub fn spiral_field_2d(&self) -> Vec<(f32, f32, f32)> {
+        let n = self.wavefront_count();
+        let wf = self.store.wavefronts.slice(ndarray::s![..n, ..]).to_owned();
+        let phases: Vec<f32> = self.store.phase.slice(ndarray::s![..n]).iter().copied().collect();
+        Self::pca_field_2d(&wf, &phases)
+    }
+
+    /// ADR-0037 Phase 4b: full 2-D spiral report over this medium's field.
+    pub fn spiral_cloud_report(&self) -> crate::spiral::SpiralReport {
+        let n = self.wavefront_count();
+        let wf = self.store.wavefronts.slice(ndarray::s![..n, ..]).to_owned();
+        let phases: Vec<f32> = self.store.phase.slice(ndarray::s![..n]).iter().copied().collect();
+        Self::cloud_report_2d(&wf, &phases)
     }
 
     /// Cached-per-call cos/sin of every wavefront phase, for building

--- a/src/medium/tests.rs
+++ b/src/medium/tests.rs
@@ -21,6 +21,44 @@ fn new_medium_is_empty() {
 }
 
 #[test]
+fn spiral_field_2d_separates_clusters_and_reports() {
+    // ADR-0037 Phase 4b: the PCA embedding must place two orthogonal wavefront
+    // clusters apart in the 2-D field, and the cloud report must run clean.
+    let mut medium = Medium::new();
+    for k in 0..6 {
+        let mut v = vec![0.0f32; WAVEFRONT_DIM];
+        if k < 3 {
+            v[0] = 1.0;
+            v[1] = 0.05 * k as f32;
+        } else {
+            v[1] = 1.0;
+            v[0] = 0.05 * k as f32;
+        }
+        medium.add_wavefront(&v, format!("m{k}"), 1.0).unwrap();
+    }
+    let pts = medium.spiral_field_2d();
+    assert_eq!(pts.len(), 6);
+    assert!(pts.iter().all(|p| p.0.is_finite() && p.1.is_finite()));
+    // The two clusters must separate in the 2-D embedding.
+    let ca = (
+        pts[..3].iter().map(|p| p.0).sum::<f32>() / 3.0,
+        pts[..3].iter().map(|p| p.1).sum::<f32>() / 3.0,
+    );
+    let cb = (
+        pts[3..].iter().map(|p| p.0).sum::<f32>() / 3.0,
+        pts[3..].iter().map(|p| p.1).sum::<f32>() / 3.0,
+    );
+    let sep = ((ca.0 - cb.0).powi(2) + (ca.1 - cb.1).powi(2)).sqrt();
+    assert!(sep > 1e-3, "clusters should separate in the 2-D embedding, sep={sep}");
+    // Cloud report runs clean.
+    let rep = medium.spiral_cloud_report();
+    assert_eq!(rep.n, 6);
+    assert!(rep.order.is_finite());
+    // Empty medium -> empty field.
+    assert!(Medium::new().spiral_field_2d().is_empty());
+}
+
+#[test]
 fn xi_bridge_residue_and_summary() {
     // ADR-0037 Phase 3: empty medium -> bridge residue 0.
     let empty = Medium::new();


### PR DESCRIPTION
## ADR-0037 Phase 4b — PCA 2-D projection of the HRM field (#415 task 1 + 3)

Gives `cloud_singularities` a real spatial manifold: projects the holistic wavefronts to 2-D and localizes genuine 2-D spiral cores in the *live* HRM, logged per consolidation. (The falsifiable test + down-payment landed in #417.)

### Changes
- `medium/dynamics.rs`: `Medium::spiral_field_2d()` — top-2 PCA of the Gram matrix via dependency-free power iteration + deflation (classical-MDS coords), paired with phases → `(x,y,θ)`. `Medium::spiral_cloud_report()` runs `cloud_singularities` over it.
- `hrm_store.rs`: the deep-dream telemetry (gated on `spiral_dream_enabled()`) now also reports the 2-D core count + net charge: `[spiral] … 2D cores=N net=C`.
- Test: `spiral_field_2d_separates_clusters_and_reports` — two orthogonal wavefront clusters separate in the embedding; the cloud report runs clean.

### Validation
- `cargo test --lib spiral_field` → **1 passed**; crate compiles.

### #415 status
Combined with #417 (the in-engine falsifiable test + chiral-drift down-payment), this lands all of #415: **task 1** (2-D projection), **task 2** (falsifiable test, #417), **task 3** (defect logging in the per-consolidation telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
