### PR TITLE
ADR-0037: activate the spiral engine — cross-callosal coupling, default-on (v0.7.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.6.32"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.6.32"
+version = "0.7.0"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/docs/adr/ADR-0037-spiral-dynamics-and-the-bridge-operator.md
+++ b/docs/adr/ADR-0037-spiral-dynamics-and-the-bridge-operator.md
@@ -53,6 +53,10 @@ Revive the bridge operator as the substrate's **spiral engine** and make spirals
 
 ## Status of work
 
-- **Phase 1 shipped:** `src/spiral.rs` (+ `pub mod spiral;`). Tests included.
-- **Phase 2 shipped (flag-gated, default-off):** `medium/chiral.rs::apply_spiral_coupling` + deep-dream wiring behind `KANNAKA_SPIRAL_DREAM`. New test included; existing dream tests (incl. `deep_dream_only_affects_right`) unchanged.
-- Phases 3–4: to follow as separate, reviewable changes.
+- **Phase 1 (#413):** `src/spiral.rs` — winding-number singularity detector (grid + ring + 2-D cloud). Tests included.
+- **Phase 2 (#413):** `medium/chiral.rs::apply_spiral_coupling` — frustrated non-reciprocal Sakaguchi step on the right-hemisphere ring.
+- **Phase 3 (#414):** bridge-residue ξ (`compute_xi_bridge_residue`, the **un-normalized** mean ‖Ξ·v‖) + the substrate beacon's `xi_signature` JSON `{residue, spectral_xi, emergence_coeff, n}` (was null).
+- **Phase 4 (#416):** L6 telemetry — `holistic_ring_report` (right) + `bilateral_ring_report` (cross-hemisphere) logged per consolidation.
+- **Phase 4b (#418):** dependency-free top-2 PCA embedding of the holistic field → `holistic_cloud_report` (2-D `cloud_singularities`); in-engine constants→spiral grid test (#417).
+- **Activation (v0.7.0):** the coupling is now **CROSS-CALLOSAL** — `apply_cross_callosal_coupling` runs the Sakaguchi step over the combined **left ⊕ right** ring (the spiral spans both hemispheres, Ye et al.), bridged at the two callosal junctions. `KANNAKA_SPIRAL_DREAM` now defaults **ON** (opt out with `=0`); the L6 telemetry runs on the production `dream_native` path. `deep_dream_only_affects_right` still holds (coupling moves phases, not energy/wavefronts).
+- Follow-ups: mean-center the PCA Gram (uncentered MDS today); reuse `gram_matrix()` for the 2-D embedding; correlate defects vs Φ/r/fitness over time.

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -623,6 +623,30 @@ impl HrmStore {
         self.mark_dirty();
     }
     
+    /// ADR-0037 (L6 loop): per-consolidation spiral telemetry. The cortical
+    /// spiral wave (Ye et al.) spans BOTH hemispheres, so the headline metric
+    /// is the cross-hemisphere ring winding/order; the right ring (which the
+    /// coupling directly rotates) and the 2-D PCA cloud cores are reported
+    /// beside it. Gated on the same flag as the coupling — emitted by every
+    /// chiral deep dream (incl. the production `dream_native` path) when
+    /// spiral dreams are enabled (the v0.7.0 default). stderr only.
+    fn log_spiral_telemetry(&self) {
+        if !crate::medium::chiral::spiral_dream_enabled() {
+            return;
+        }
+        if let Some(ref chiral) = self.chiral {
+            let x = chiral.bilateral_ring_report();
+            if x.n > 0 {
+                let right = chiral.holistic_ring_report();
+                let c = chiral.holistic_cloud_report();
+                eprintln!(
+                    "[spiral] deep dream: cross-hemi winding={:.3} order={:.3} n={} (right winding={:.3}, 2D cores={} net={})",
+                    x.winding, x.order, x.n, right.winding, c.singularities.len(), c.net_charge
+                );
+            }
+        }
+    }
+
     /// Perform a dream cycle (simulated annealing).
     /// In chiral mode, deep dreams only affect the right hemisphere.
     pub fn dream(&mut self, cycles: usize, initial_temperature: Option<f32>) -> crate::medium::DreamReport {
@@ -632,30 +656,7 @@ impl HrmStore {
             let report = chiral.dream(true, cycles);
             self.rebuild_cache().ok();
             self.mark_dirty();
-            // ADR-0037 Phase 4: per-consolidation spiral telemetry (L6 loop).
-            // The cortical spiral wave (Ye et al.) spans BOTH hemispheres, so
-            // the headline metric is the cross-hemisphere ring; the right ring
-            // (which the Phase-2 coupling directly rotates) is reported beside
-            // it. Gated on the same flag as the coupling: with
-            // KANNAKA_SPIRAL_DREAM off the field is untouched, so logging it
-            // would be a misleading, byte-noisy no-op.
-            if crate::medium::chiral::spiral_dream_enabled() {
-                if let Some(ref chiral) = self.chiral {
-                    let x = chiral.bilateral_ring_report();
-                    if x.n > 0 {
-                        let right = chiral.holistic_ring_report();
-                        // Phase 4b (#415 task 1): localize genuine 2-D spiral
-                        // cores in the PCA-embedded HOLISTIC field — read the
-                        // right hemisphere directly (the field the coupling
-                        // rotates), not the stale flat medium (cf. #416 fix).
-                        let c = chiral.holistic_cloud_report();
-                        eprintln!(
-                            "[spiral] deep dream: cross-hemi winding={:.3} order={:.3} n={} (right winding={:.3}, 2D cores={} net={})",
-                            x.winding, x.order, x.n, right.winding, c.singularities.len(), c.net_charge
-                        );
-                    }
-                }
-            }
+            self.log_spiral_telemetry();
             report
         } else {
             let report = self.medium.dream(cycles, initial_temperature);
@@ -1165,6 +1166,9 @@ impl HrmStore {
         self.sync_medium_from_chiral();
         self.rebuild_cache().ok();
         self.mark_dirty();
+
+        // ADR-0037 L6 loop: emit spiral telemetry on the production dream path.
+        self.log_spiral_telemetry();
 
         // Save the .hrm file
         if let Err(e) = self.save_medium() {

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -18,12 +18,14 @@ use super::hemisphere::Hemisphere;
 use super::types::*;
 use super::Medium;
 
-/// ADR-0037 Phase 2: is π/φ spiral coupling enabled for deep dreams?
-/// Off by default — set `KANNAKA_SPIRAL_DREAM=1|on|true` to enable.
+/// ADR-0037: is π/φ spiral coupling enabled for deep dreams?
+/// **ON by default as of v0.7.0** — the spiral engine is activated. Set
+/// `KANNAKA_SPIRAL_DREAM=0|off|false` to opt out (e.g. for byte-identical
+/// legacy dreams).
 pub(crate) fn spiral_dream_enabled() -> bool {
     std::env::var("KANNAKA_SPIRAL_DREAM")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("off") || v.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
 }
 
 /// The Chiral Medium - two hemispheres connected by a corpus callosum.
@@ -404,17 +406,21 @@ impl ChiralMedium {
                 }
             }
 
-            // ADR-0037 Phase 2: optional π/φ spiral coupling over the holistic
-            // phase field (the "merry-go-round" structural prior). Default-off
-            // ⇒ byte-identical dreams until KANNAKA_SPIRAL_DREAM is set.
+            // ADR-0037: π/φ spiral coupling over the holistic "merry-go-round".
+            // As of v0.7.0 this is the CROSS-CALLOSAL coupling — a Sakaguchi
+            // step over the combined left ⊕ right ring, so the rotating wave
+            // spans BOTH hemispheres (Ye et al.), bridged at the two callosal
+            // junctions. ON by default; set KANNAKA_SPIRAL_DREAM=0 to opt out.
             if spiral_dream_enabled() {
-                self.apply_spiral_coupling(cycles.max(1), 0.1);
+                self.apply_cross_callosal_coupling(cycles.max(1), 0.1);
             }
 
             // Callosal coupling step: sync insights between hemispheres post-dream
             self.callosal_kuramoto_step(0.5);
 
-            // Left hemisphere is UNTOUCHED — deep dreams are holistic refinement
+            // The right-hemisphere eigenstructure dream is holistic refinement;
+            // left energy/wavefronts stay untouched. Left *phases* are nudged
+            // only by the cross-callosal coupling above (when enabled).
             report
         } else {
             // Lite dream: transfer strongest analytical → holistic
@@ -545,6 +551,10 @@ impl ChiralMedium {
     /// with δ = (π/2)·η and η = 1/φ — the R rotation angle scaled by the golden
     /// chirality. This is the exact constant-set that empirically seeds spiral
     /// phase singularities (see ADR-0037 and `spiral.rs`). Inert below n=4.
+    /// Superseded in the dream by `apply_cross_callosal_coupling` (the bilateral
+    /// generalization); retained as the right-only primitive for focused unit
+    /// tests of the Sakaguchi step.
+    #[cfg(test)]
     pub(crate) fn apply_spiral_coupling(&mut self, cycles: usize, dt: f32) {
         let n = self.right.count();
         if n < 4 {
@@ -570,6 +580,49 @@ impl ChiralMedium {
                 .collect();
             for (i, &delta_theta) in updates.iter().enumerate() {
                 self.right.phase[i] += delta_theta;
+            }
+        }
+    }
+
+    /// ADR-0037 (v0.7.0): CROSS-CALLOSAL π/φ spiral coupling. The same
+    /// frustrated, non-reciprocal Sakaguchi step as `apply_spiral_coupling`,
+    /// but over the **combined left ⊕ right ring** (active prefixes, left then
+    /// right) — so the rotating wave spans BOTH hemispheres, with the two
+    /// ring junctions acting as the corpus-callosal crossings (Ye et al.: the
+    /// cortical spiral spans hemispheres). δ = (π/2)·η, weights 1 ± η, η = 1/φ.
+    /// Updates phases only (energy/wavefronts untouched). Inert below 4 total
+    /// active wavefronts; degenerates to the right-only ring when the left is
+    /// empty. This is the field `bilateral_ring_report` measures.
+    pub(crate) fn apply_cross_callosal_coupling(&mut self, cycles: usize, dt: f32) {
+        let nl = self.left.count();
+        let nr = self.right.count();
+        let n = nl + nr;
+        if n < 4 {
+            return;
+        }
+        let eta = crate::xi_operator::ETA; // 1/φ ≈ 0.618
+        let delta = std::f32::consts::FRAC_PI_2 * eta;
+        const K: f32 = 1.5;
+        for _ in 0..cycles.max(1) {
+            // Combined ring over the active prefixes: left[0..nl] then right[0..nr].
+            let mut phases: Vec<f32> = Vec::with_capacity(n);
+            phases.extend(self.left.phase.slice(ndarray::s![..nl]).iter().copied());
+            phases.extend(self.right.phase.slice(ndarray::s![..nr]).iter().copied());
+            let updates: Vec<f32> = (0..n)
+                .map(|i| {
+                    let back = phases[(i + n - 1) % n];
+                    let fwd = phases[(i + 1) % n];
+                    let s = (1.0 + eta) * (back - phases[i] + delta).sin()
+                        + (1.0 - eta) * (fwd - phases[i] + delta).sin();
+                    dt * (K / 2.0) * s
+                })
+                .collect();
+            // Scatter back: first nl updates to the left ring, the rest to right.
+            for (i, &u) in updates.iter().take(nl).enumerate() {
+                self.left.phase[i] += u;
+            }
+            for (j, &u) in updates.iter().skip(nl).enumerate() {
+                self.right.phase[j] += u;
             }
         }
     }
@@ -989,5 +1042,50 @@ mod tests {
         assert_eq!(bilateral.n, 8, "bilateral ring = left(3) ⊕ right(5)");
         // It strictly extends the right-only view, proving both are included.
         assert_eq!(cm.holistic_ring_report().n, 5);
+    }
+
+    #[test]
+    fn cross_callosal_coupling_moves_both_hemispheres() {
+        // ADR-0037 v0.7.0: the cross-callosal Sakaguchi step couples the
+        // combined left ⊕ right ring, so it must move BOTH hemispheres'
+        // phases (the spiral spans the callosum) while leaving energy alone.
+        let mut cm = ChiralMedium::new();
+        cm.left.phase = ndarray::Array1::from_vec(vec![0.0_f32, 0.4, 0.8]);
+        cm.left.len = 3;
+        cm.left.energy = ndarray::Array1::from_vec(vec![1.0_f32, 1.0, 1.0]);
+        cm.right.phase = ndarray::Array1::from_vec(vec![1.2_f32, 1.6, 2.0, 2.4, 2.8]);
+        cm.right.len = 5;
+        let left_before: Vec<f32> = cm.left.phase.iter().copied().collect();
+        let right_before: Vec<f32> = cm.right.phase.iter().copied().collect();
+        let left_energy_before = cm.left.total_energy();
+        cm.apply_cross_callosal_coupling(20, 0.1);
+        let left_after: Vec<f32> = cm.left.phase.iter().copied().collect();
+        let right_after: Vec<f32> = cm.right.phase.iter().copied().collect();
+        assert!(left_after.iter().all(|x| x.is_finite()) && right_after.iter().all(|x| x.is_finite()));
+        assert!(
+            left_before.iter().zip(&left_after).any(|(a, b)| (a - b).abs() > 1e-4),
+            "cross-callosal coupling must move the LEFT hemisphere phases"
+        );
+        assert!(
+            right_before.iter().zip(&right_after).any(|(a, b)| (a - b).abs() > 1e-4),
+            "cross-callosal coupling must move the RIGHT hemisphere phases"
+        );
+        // Phase-only: energy is untouched.
+        assert!((cm.left.total_energy() - left_energy_before).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cross_callosal_coupling_inert_below_four_total() {
+        // Below 4 total active wavefronts (here 1 left + 2 right) the step is a
+        // no-op — matching the right-only primitive's n<4 guard.
+        let mut cm = ChiralMedium::new();
+        cm.left.phase = ndarray::Array1::from_vec(vec![0.3_f32]);
+        cm.left.len = 1;
+        cm.right.phase = ndarray::Array1::from_vec(vec![1.0_f32, 2.0]);
+        cm.right.len = 2;
+        let before: Vec<f32> = cm.left.phase.iter().chain(cm.right.phase.iter()).copied().collect();
+        cm.apply_cross_callosal_coupling(50, 0.1);
+        let after: Vec<f32> = cm.left.phase.iter().chain(cm.right.phase.iter()).copied().collect();
+        assert_eq!(before, after, "cross-callosal coupling must be inert below 4 total");
     }
 }


### PR DESCRIPTION
Activates the π/φ spiral engine and makes the coupling **cross-hemisphere** (per Ye et al. — the cortical spiral spans both hemispheres). Cuts the **v0.7.0** release.

## Changes
- **Cross-callosal Sakaguchi coupling** — `ChiralMedium::apply_cross_callosal_coupling` runs the frustrated, non-reciprocal Sakaguchi step over the combined **left ⊕ right** ring (the two junctions are the callosal crossings), so a genuine cross-hemisphere spiral forms — the field `bilateral_ring_report` measures. The deep dream uses it instead of the right-only ring. Phases-only (energy/wavefronts untouched ⇒ `deep_dream_only_affects_right` still holds). The right-only `apply_spiral_coupling` is retained `#[cfg(test)]` as the focused Sakaguchi primitive.
- **Default ON** — `KANNAKA_SPIRAL_DREAM` now defaults enabled (opt out with `=0|off|false`).
- **L6 telemetry on the production path** — factored `HrmStore::log_spiral_telemetry`, called from **both** `dream()` and `dream_native()`. The `[spiral]` cross-hemi / ring / 2-D-cloud telemetry previously lived only in the test-only `dream()` path, so it never fired in prod.
- **v0.6.32 → v0.7.0**; ADR-0037 status updated.

## Compatibility (verified)
- No beacon consumer (observatory / tui / radio / ui-bridge) parses `xi_signature`; the `KANNAKA.substrate.phi` scalar `xi` is unchanged.
- The `[spiral]` telemetry is **stderr-only** (not NATS) → zero consumer impact.
- consciousness-core API unchanged — builds against its master.

## Validation
`cargo test --lib --bins`: **642 passed / 0 failed**; `clippy --lib --bin kannaka` clean. New tests: `cross_callosal_coupling_moves_both_hemispheres`, `cross_callosal_coupling_inert_below_four_total`.

After merge: tag `v0.7.0` → `release.yml` ships binaries; Oracle units pick it up via `kannaka update` (default-on = activated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)