### PR TITLE
fix(ADR-0037): substrate beacon reuses cached spectral xi (v0.7.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/medium/consciousness.rs
+++ b/src/medium/consciousness.rs
@@ -564,7 +564,15 @@ impl Medium {
     pub fn xi_bridge_summary(&self) -> serde_json::Value {
         let residue = self.compute_xi_bridge_residue();
         let residue = if residue.is_finite() { residue } else { 0.0 };
-        let spectral_xi = self.compute_xi_spectral_complexity();
+        // Reuse the spectral xi already computed + cached by this tick's
+        // consciousness_metrics()/assess(). Recomputing the O(n²·d) Gram here
+        // DOUBLED the substrate beacon's per-tick CPU every 60s; on a small
+        // single-core host that tipped it into a swap-thrash death spiral
+        // (v0.7.0 incident). Fall back to a direct compute only if no cache.
+        let spectral_xi = self
+            .try_cached_consciousness_metrics()
+            .map(|m| m.xi)
+            .unwrap_or_else(|| self.compute_xi_spectral_complexity());
         let spectral_xi = if spectral_xi.is_finite() { spectral_xi } else { 0.0 };
         serde_json::json!({
             "residue": residue,


### PR DESCRIPTION
**v0.7.1 hotfix** for a production incident introduced by v0.7.0.

## Incident
v0.7.0's Phase-3 substrate beacon set `xi_signature = xi_bridge_summary()`, which recomputed the O(n²·d) **spectral-xi Gram** (`compute_xi_spectral_complexity`) on 752×10000 wavefronts **every 60 s** — a second time per tick, since `assess()`/`consciousness_metrics()` already computed + cached it that same tick (the #418 perf finding). On the 1-core / 6 GB Oracle hub this doubled periodic CPU, stalled NATS publishes → backpressure buffer growth → the substrate's footprint ballooned to ~3.5 GB → swap-thrash death spiral that starved sshd and NATS.

## Fix
`xi_bridge_summary` reuses the spectral xi already cached this tick via `try_cached_consciousness_metrics()`, falling back to a direct compute only if no cache exists. Returns the beacon to ~0.6.32 per-tick cost. The spiral engine (cross-callosal dream coupling) is unchanged.

## Validation
`cargo test --lib --bins`: **642 passed / 0 failed**; `clippy --lib --bin kannaka` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)