### PR TITLE
ADR-0037 hotfix: rephase CLI + over-prune safety gate (prereq for belief activation)

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -2031,6 +2031,7 @@ fn main() {
         }
         "dream" => {
             let mut dream_mode = "deep".to_string();
+            let mut do_rephase = false;
             let mut chiral_perturbation: f32 = env::var("KANNAKA_CHIRAL_PERTURBATION")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -2044,6 +2045,9 @@ fn main() {
                     } else if args[i] == "--chiral" && i + 1 < args.len() {
                         chiral_perturbation = args[i + 1].parse().unwrap_or(0.05);
                         i += 2;
+                    } else if args[i] == "--rephase" {
+                        do_rephase = true;
+                        i += 1;
                     } else {
                         i += 1;
                     }
@@ -2097,6 +2101,23 @@ fn main() {
                     process::exit(0);
                 }
             };
+
+            // ADR-0037: optional belief re-phase before the dream — the one-time
+            // migration that desyncs an already-collapsed field (born phase only
+            // fixes NEW inserts). Gated on KANNAKA_BELIEF_PHASE so we never desync
+            // a field without the belief dynamics to maintain it. Persists inside
+            // rephase_belief; the dream then runs on the re-phased field.
+            if do_rephase {
+                let belief_on = env::var("KANNAKA_BELIEF_PHASE")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                if belief_on {
+                    let rn = sys.rephase_belief();
+                    eprintln!("[rephase] re-phased {} wavefronts from content (belief substrate)", rn);
+                } else {
+                    eprintln!("[rephase] skipped: KANNAKA_BELIEF_PHASE is off — set it on to re-phase");
+                }
+            }
 
             let dream_result = if dream_mode == "lite" {
                 sys.dream_lite()

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -1178,6 +1178,28 @@ impl HrmStore {
         report
     }
 
+    /// ADR-0037 belief substrate: re-phase every wavefront from its (mean-
+    /// centered) content, then persist. The one-time migration that desyncs an
+    /// already-collapsed field — born phase only fixes NEW inserts, so existing
+    /// wavefronts stuck at phase 0 need this. Phase-only (vectors/recall
+    /// untouched). Returns the number re-phased; chiral backend only.
+    pub fn rephase_belief(&mut self) -> usize {
+        let n = if let Some(ref mut chiral) = self.chiral {
+            chiral.rephase_from_content()
+        } else {
+            0
+        };
+        if n > 0 {
+            self.sync_medium_from_chiral();
+            self.rebuild_cache().ok();
+            self.mark_dirty();
+            if let Err(e) = self.save_medium() {
+                eprintln!("Warning: Failed to save after rephase: {}", e);
+            }
+        }
+        n
+    }
+
     /// Reset all wavefront energies to target value (bias voltage restoration).
     pub fn reset_energies(&mut self, target: f32) {
         self.medium.reset_energies(target);

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -714,6 +714,21 @@ impl KannakaMemorySystem {
         }
     }
 
+    /// ADR-0037 belief substrate: re-phase the field from content (the one-time
+    /// migration that desyncs an already-collapsed field — born phase only fixes
+    /// NEW inserts). Delegates to the HRM store; no-op on non-HRM backends.
+    pub fn rephase_belief(&mut self) -> usize {
+        match self
+            .engine
+            .store
+            .as_any_mut()
+            .downcast_mut::<crate::hrm_store::HrmStore>()
+        {
+            Some(hrm) => hrm.rephase_belief(),
+            None => 0,
+        }
+    }
+
     pub fn dream(&mut self) -> Result<DreamReport, SystemError> {
         let before = self.bridge.assess(&self.engine);
 
@@ -750,7 +765,23 @@ impl KannakaMemorySystem {
 
         // Phase 2: Consolidation engine (interference detection, skip links, pruning)
         // This uses the particle-based pipeline on the memory cache for topology effects.
-        let consol_report = self.dream_state.engine.consolidate(&mut self.engine, 0, 2);
+        //
+        // ADR-0037 SAFETY GATE: the belief re-phase scatters phases (order ~1.0 →
+        // ~0.13), which flips this classifier's similar-neighbour pairs from
+        // Constructive to Destructive (the bands meet at π/2 with no neutral gap),
+        // mass-ghosting the field; stage_compact_ghosts then HARD-DELETES those
+        // fresh ghosts in the SAME cycle because an old field's created_at predates
+        // the 7-day retain horizon (engine.delete → removes from the chiral
+        // hemispheres → persisted). That cost 295→88 memories on the first live
+        // re-phase. Skip the destructive particle pass under belief-phase — the
+        // belief wave dream is the consolidation; this is the ONLY mutating+persisting
+        // remover in the dream. Default/prod path (flag off) is byte-identical.
+        let consol_report = if crate::medium::chiral::belief_phase_enabled() {
+            eprintln!("[dream] belief-phase active: skipping legacy destructive particle consolidate(0,2) to protect the re-phased field");
+            crate::consolidation::ConsolidationReport::default()
+        } else {
+            self.dream_state.engine.consolidate(&mut self.engine, 0, 2)
+        };
 
         let total_strengthened = wave_report.wavefronts_strengthened + consol_report.memories_strengthened;
         let total_pruned = wave_report.wavefronts_dissolved + consol_report.memories_pruned;


### PR DESCRIPTION
## Over-prune safety gate + `rephase` go-live tooling

Prerequisite before *anyone* activates the belief substrate's re-phase. The merged substrate (#422) is default-off/dormant, so this is not an emergency — but re-phasing an existing field on the current code **destroys memories**, found live (295 → 88) and recovered from backup.

### The bug (diagnosed precisely)
The belief re-phase scatters phases (order ~1.0 → ~0.13). That flips the **legacy particle `consolidate(0,2)`** classifier's similar-neighbour pairs from **Constructive → Destructive** at the π/2 boundary (no neutral gap, `consolidation.rs:231`), ghosting them (amplitude→0). Then `stage_compact_ghosts` **hard-deletes** those fresh ghosts *in the same cycle* — because `rebuild_cache` stamps `updated_at = created_at` and an old field's `created_at` is past the 7-day retain horizon → `engine.delete` → removed from the chiral hemispheres → persisted. (The `consolidate_resonance` dry-run removed nothing; the 88≈82 was coincidence — both pruners key off the same redundancy.)

### The fix
Gate the destructive particle pass **off when `belief_phase_enabled()`** (`openclaw.rs`). The belief wave dream *is* the consolidation. **Default/prod path (flag off) is byte-identical.**

### Tooling
`dream --rephase` — the one-time migration that re-phases existing wavefronts from content (born phase only fixes *new* inserts). Gated on the flag; uses the dream's write lock + save.

### Re-validated on the real field
`dream --rephase` → order 0.996 → **0.13 (66 cores)** AND **active_memories preserved (295/296, vs 88 pre-fix)**, with `[dream] belief-phase active: skipping legacy destructive particle consolidate(0,2)`.

### Known follow-ups (not blocking)
- This is a **safety amputation** — belief dreams also lose the *beneficial* particle consolidation (skip-links, kuramoto, strengthen) until a **phase-aware prune** is built.
- Deeper latent bug (dormant in default path): `stage_compact_ghosts` hard-deletes fresh ghosts (`updated_at=created_at`). Proper repair: neutral band `phase_alignment_threshold < π/2`, and/or stamp `updated_at=now` on ghosting, and/or `protect_established=true` in dream.
- Do **not** set `KANNAKA_CONSOLIDATE=on` with belief (separate `apply_consolidation` destructive path, not gated here).
- The stability probe should use the **full** `KannakaMemorySystem::dream`, not `ChiralMedium::dream` (which never reaches `consolidation.rs` — that's how the probe missed this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)