### PR TITLE
feat(ADR-0037): L6 core-tracking — follow belief cores across dreams

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -192,16 +192,23 @@ fn append_l6_telemetry(
         Some(r) if r.n > 0 => r,
         _ => return, // not chiral / empty — nothing to record
     };
-    let cloud = hrm.and_then(|h| h.belief_cloud_report());
+    // One core snapshot (cores + frame-invariant fingerprints) serves BOTH the
+    // count in the time-series record AND the cross-dream tracking file — a single
+    // PCA pass rather than recomputing the cloud report separately.
+    let snapshot = hrm.map(|h| h.belief_core_snapshot()).unwrap_or_default();
+    let net_charge: i32 = snapshot.iter().map(|c| c.charge).sum();
     let cached = sys.engine.store.try_cached_consciousness_metrics();
     let memories = sys.engine.store.all_memories().map(|m| m.len()).unwrap_or(0);
+    let ts = chrono::Utc::now().to_rfc3339();
     let mut rec = serde_json::json!({
-        "ts": chrono::Utc::now().to_rfc3339(),
+        "ts": ts.clone(),
         "mode": mode,
         "rephased": rephased,
         "ring_order": ring.order,
         "ring_winding": ring.winding,
         "ring_n": ring.n,
+        "cores": snapshot.len(),
+        "net_charge": net_charge,
         "memories": memories,
         "strengthened": report.memories_strengthened,
         "pruned": report.memories_pruned,
@@ -211,29 +218,31 @@ fn append_l6_telemetry(
         "consciousness": report.consciousness_after,
         "emerged": report.emerged,
     });
-    if let Some(c) = &cloud {
-        rec["cores"] = serde_json::json!(c.singularities.len());
-        rec["net_charge"] = serde_json::json!(c.net_charge);
-    }
     if let Some(m) = &cached {
         rec["phi"] = serde_json::json!(m.phi);
         rec["xi"] = serde_json::json!(m.xi);
         rec["mean_order"] = serde_json::json!(m.order);
         rec["clusters"] = serde_json::json!(m.num_clusters);
     }
-    let path = data_dir().join("l6-telemetry.jsonl");
     use std::io::Write;
-    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
-        if writeln!(f, "{rec}").is_ok() {
-            eprintln!(
-                "[l6] recorded → {} (order={:.3} winding={:.1} cores={})",
-                path.display(),
-                ring.order,
-                ring.winding,
-                cloud.as_ref().map(|c| c.singularities.len()).unwrap_or(0)
-            );
-        }
+    let tpath = data_dir().join("l6-telemetry.jsonl");
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&tpath) {
+        let _ = writeln!(f, "{rec}");
     }
+    // Persist the core snapshot (cores + fingerprints) for cross-dream tracking
+    // via `kannaka belief cores` (crate::l6::build_tracks).
+    let cpath = data_dir().join("l6-cores.jsonl");
+    let crec = serde_json::json!({ "ts": ts, "cores": snapshot });
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&cpath) {
+        let _ = writeln!(f, "{crec}");
+    }
+    eprintln!(
+        "[l6] recorded → {} (order={:.3} winding={:.1} cores={})",
+        tpath.display(),
+        ring.order,
+        ring.winding,
+        snapshot.len()
+    );
 }
 
 /// ADR-0037 L6 instrument: `kannaka belief history [--last N] [--json]` — print the
@@ -289,6 +298,90 @@ fn handle_belief_history(args: &[String]) {
     println!(
         "\n{} records at {}  (--json for full rows, --last N to widen)",
         lines.len(),
+        path.display()
+    );
+}
+
+/// ADR-0037 L6 instrument: `kannaka belief cores [--last N] [--min-cos X] [--json]`
+/// — track spiral cores ACROSS dreams from `<data_dir>/l6-cores.jsonl`. Reads the
+/// per-dream snapshots, matches cores by frame-invariant fingerprint + charge
+/// (`crate::l6::build_tracks`), and reports each track's lifetime — a long-lived
+/// track is a persistent belief. Stateless (reads the file only, no HRM load).
+fn handle_belief_cores(args: &[String]) {
+    let last: usize = args
+        .iter()
+        .position(|a| a == "--last")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+    let min_cos: f32 = args
+        .iter()
+        .position(|a| a == "--min-cos")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0.85);
+    let raw = args.iter().any(|a| a == "--json");
+    let path = data_dir().join("l6-cores.jsonl");
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(_) => {
+            println!(
+                "no core snapshots yet at {} — run dreams with belief on to start.",
+                path.display()
+            );
+            return;
+        }
+    };
+    let mut snaps: Vec<Vec<kannaka_memory::l6::CoreObs>> = Vec::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if let Some(cores) = v.get("cores") {
+                if let Ok(obs) =
+                    serde_json::from_value::<Vec<kannaka_memory::l6::CoreObs>>(cores.clone())
+                {
+                    snaps.push(obs);
+                }
+            }
+        }
+    }
+    if snaps.is_empty() {
+        println!("no parseable core snapshots in {}", path.display());
+        return;
+    }
+    let start = snaps.len().saturating_sub(last);
+    let window = &snaps[start..];
+    let dreams = window.len();
+    let tracks = kannaka_memory::l6::build_tracks(window, min_cos);
+    if raw {
+        println!("{}", serde_json::to_string_pretty(&tracks).unwrap_or_default());
+        return;
+    }
+    println!(
+        "tracked {} cores across {} dreams (min_cos={:.2}):",
+        tracks.len(),
+        dreams,
+        min_cos
+    );
+    for t in tracks.iter().take(40) {
+        let stability = t.appearances as f32 / dreams.max(1) as f32;
+        let bar: String = "#".repeat((stability * 20.0).round() as usize);
+        println!(
+            "  id={:<4} charge={:+} appears={}/{} span={} stability={:.0}% {}",
+            t.id,
+            t.charge,
+            t.appearances,
+            dreams,
+            t.span,
+            stability * 100.0,
+            bar
+        );
+    }
+    let persistent = tracks.iter().filter(|t| t.appearances >= 2).count();
+    println!(
+        "\n{} persistent cores (>=2 dreams) of {} total; {} snapshots at {}",
+        persistent,
+        tracks.len(),
+        snaps.len(),
         path.display()
     );
 }
@@ -1085,6 +1178,7 @@ fn main() {
                 "on" | "enable" => { handle_belief_toggle(true); return; }
                 "off" | "disable" => { handle_belief_toggle(false); return; }
                 "history" | "log" => { handle_belief_history(&args[command_start..]); return; }
+                "cores" => { handle_belief_cores(&args[command_start..]); return; }
                 _ => { /* status / activate / help — fall through (needs HRM) */ }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,6 +266,8 @@ SUBCOMMANDS:
                        count-preservation guard (auto-restore on drop) → refuse-if-locked
   history [--last N]   the L6 instrument: per-dream order/winding/cores/Φ/stats time-series
                        (recorded to <data_dir>/l6-telemetry.jsonl on every dream); --json for raw rows
+  cores [--last N] [--min-cos X]   track spiral cores ACROSS dreams (fingerprint-matched) →
+                       per-core lifetime/stability; a long-lived core = a persistent belief
 
 FLAGS:
   --full                    status: also compute the heavier 2-D PCA spiral cores

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -662,6 +662,13 @@ impl HrmStore {
         self.chiral.as_ref().map(|c| c.holistic_cloud_report())
     }
 
+    /// ADR-0037 L6 instrument: per-dream belief-core snapshot (cores + frame-
+    /// invariant content fingerprints) for cross-dream tracking. Empty when not
+    /// in chiral mode.
+    pub fn belief_core_snapshot(&self) -> Vec<crate::l6::CoreObs> {
+        self.chiral.as_ref().map(|c| c.belief_core_snapshot()).unwrap_or_default()
+    }
+
     /// Perform a dream cycle (simulated annealing).
     /// In chiral mode, deep dreams only affect the right hemisphere.
     pub fn dream(&mut self, cycles: usize, initial_temperature: Option<f32>) -> crate::medium::DreamReport {

--- a/src/l6.rs
+++ b/src/l6.rs
@@ -1,0 +1,230 @@
+//! ADR-0037 L6 instrument — belief-core *identity* across dreams.
+//!
+//! The spiral telemetry counts cores per dream, but "a belief = a stabilized
+//! spiral core" is only falsifiable if we can follow an *individual* core over
+//! time (lifetime / position drift / content-correspondence). The hard part is
+//! that each dream rebuilds the 2-D PCA embedding from scratch, so a core's
+//! `(x, y)` is NOT comparable across dreams (sign/rotation ambiguity).
+//!
+//! The fix is a **frame-invariant content fingerprint**: a deterministic random
+//! projection of the core's neighbourhood centroid (a high-dim wavefront vector,
+//! which lives in the stable embedding space, not the unstable 2-D PCA). Cosine
+//! of two fingerprints is preserved under PCA flips, so cores can be matched by
+//! *what they organize* rather than *where they landed*. `build_tracks` chains
+//! per-dream observations into tracks; a long track = a persistent belief.
+
+use serde::{Deserialize, Serialize};
+
+/// One spiral core observed in a single dream. `fp` is the frame-invariant
+/// content fingerprint (see `fingerprint`); `(x, y)` is the per-dream 2-D
+/// position (only meaningful within that dream's embedding).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoreObs {
+    pub x: f32,
+    pub y: f32,
+    pub charge: i32,
+    pub fp: Vec<f32>,
+}
+
+/// Deterministic random projection of a content `vector` to `dims` (a compact,
+/// frame-invariant fingerprint). Cosine-preserving (Johnson–Lindenstrauss) so
+/// `cosine` on two fingerprints approximates cosine of the source vectors. The
+/// projection weights come from a SplitMix64 finalizer keyed by (dimension,
+/// index) — no stored matrix, identical across processes/runs. Output is L2-
+/// normalized so `cosine` reduces to a dot product.
+pub fn fingerprint(vector: &[f32], dims: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; dims.max(1)];
+    for (d, o) in out.iter_mut().enumerate() {
+        let seed = 0x9E37_79B9_7F4A_7C15u64.wrapping_add((d as u64).wrapping_mul(0xD1B5_4A32_D192_ED03));
+        let mut acc = 0.0f32;
+        for (i, &v) in vector.iter().enumerate() {
+            let mut h = seed ^ (i as u64).wrapping_mul(0x2545_F491_4F6C_DD1D);
+            h ^= h >> 30;
+            h = h.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            h ^= h >> 27;
+            h = h.wrapping_mul(0x94D0_49BB_1331_11EB);
+            h ^= h >> 31;
+            let w = (h as f32 / u64::MAX as f32) * 2.0 - 1.0; // ~[-1, 1)
+            acc += v * w;
+        }
+        *o = acc;
+    }
+    let norm = out.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for o in out.iter_mut() {
+            *o /= norm;
+        }
+    }
+    out
+}
+
+/// Cosine similarity of two fingerprints. Assumes L2-normalized inputs (as
+/// produced by `fingerprint`), so this is a dot product; falls back to 0 on a
+/// length mismatch.
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// A core followed across dreams: same charge + fingerprint-matched neighbours.
+#[derive(Debug, Clone, Serialize)]
+pub struct Track {
+    pub id: usize,
+    pub charge: i32,
+    /// Snapshot index where the track first appeared.
+    pub first: usize,
+    /// Snapshot index where it was last seen.
+    pub last: usize,
+    /// Number of snapshots (dreams) the core appeared in.
+    pub appearances: usize,
+    /// last_seen - first_seen + 1 (the span it was alive over).
+    pub span: usize,
+    /// Most recent 2-D position (frame-local; for a rough drift read only).
+    pub last_pos: (f32, f32),
+}
+
+struct ActiveTrack {
+    id: usize,
+    charge: i32,
+    fp: Vec<f32>,
+    first: usize,
+    last: usize,
+    appearances: usize,
+    last_pos: (f32, f32),
+}
+
+/// Chain per-dream core observations into tracks. Greedy bipartite match between
+/// each snapshot's cores and the running tracks: a (core, track) pair is eligible
+/// iff same `charge` and fingerprint cosine ≥ `min_cos`; pairs are assigned
+/// highest-cosine-first. Matched tracks extend (and adopt the latest fingerprint,
+/// to follow slow content drift); unmatched cores start new tracks. Tracks are
+/// never force-closed (a core may flicker between dreams), so `appearances`
+/// counts real sightings and `span` the birth→last range.
+pub fn build_tracks(snapshots: &[Vec<CoreObs>], min_cos: f32) -> Vec<Track> {
+    let mut active: Vec<ActiveTrack> = Vec::new();
+    let mut next_id = 0usize;
+
+    for (snap_idx, snap) in snapshots.iter().enumerate() {
+        // Candidate (cosine, core_idx, active_idx) pairs, eligible by charge+threshold.
+        let mut pairs: Vec<(f32, usize, usize)> = Vec::new();
+        for (ci, core) in snap.iter().enumerate() {
+            for (aj, at) in active.iter().enumerate() {
+                if at.charge != core.charge {
+                    continue;
+                }
+                let c = cosine(&core.fp, &at.fp);
+                if c >= min_cos {
+                    pairs.push((c, ci, aj));
+                }
+            }
+        }
+        pairs.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut core_used = vec![false; snap.len()];
+        let mut track_used = vec![false; active.len()];
+        for (_c, ci, aj) in pairs {
+            if core_used[ci] || track_used[aj] {
+                continue;
+            }
+            core_used[ci] = true;
+            track_used[aj] = true;
+            let core = &snap[ci];
+            active[aj].last = snap_idx;
+            active[aj].appearances += 1;
+            active[aj].last_pos = (core.x, core.y);
+            active[aj].fp = core.fp.clone(); // follow drift
+        }
+
+        for (ci, core) in snap.iter().enumerate() {
+            if !core_used[ci] {
+                active.push(ActiveTrack {
+                    id: next_id,
+                    charge: core.charge,
+                    fp: core.fp.clone(),
+                    first: snap_idx,
+                    last: snap_idx,
+                    appearances: 1,
+                    last_pos: (core.x, core.y),
+                });
+                next_id += 1;
+            }
+        }
+    }
+
+    let mut tracks: Vec<Track> = active
+        .into_iter()
+        .map(|a| Track {
+            id: a.id,
+            charge: a.charge,
+            first: a.first,
+            last: a.last,
+            appearances: a.appearances,
+            span: a.last - a.first + 1,
+            last_pos: a.last_pos,
+        })
+        .collect();
+    // Longest-lived first.
+    tracks.sort_by(|a, b| b.appearances.cmp(&a.appearances).then(b.span.cmp(&a.span)));
+    tracks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(charge: i32, fp: Vec<f32>) -> CoreObs {
+        CoreObs { x: 0.0, y: 0.0, charge, fp }
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic_and_normalized() {
+        let v = vec![0.3, -0.1, 0.7, 0.2, -0.5];
+        let a = fingerprint(&v, 16);
+        let b = fingerprint(&v, 16);
+        assert_eq!(a, b, "fingerprint must be deterministic");
+        let norm = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4 || norm == 0.0, "fingerprint must be normalized");
+    }
+
+    #[test]
+    fn fingerprint_preserves_similarity() {
+        // Similar source vectors → high fingerprint cosine; dissimilar → low.
+        let a = fingerprint(&[1.0, 0.0, 0.0, 0.0, 0.5, 0.2], 32);
+        let a2 = fingerprint(&[1.0, 0.05, 0.0, 0.0, 0.5, 0.18], 32);
+        let b = fingerprint(&[0.0, 0.0, 1.0, -0.8, 0.0, 0.0], 32);
+        assert!(cosine(&a, &a2) > 0.9, "near-identical content should match");
+        assert!(cosine(&a, &b) < cosine(&a, &a2), "different content should be less similar");
+    }
+
+    #[test]
+    fn build_tracks_follows_a_persistent_core() {
+        // A stable +1 core present in all 3 dreams, plus a one-off −1 core.
+        let stable = fingerprint(&[1.0, 0.2, -0.3, 0.4], 16);
+        let transient = fingerprint(&[-0.5, 0.9, 0.1, 0.0], 16);
+        let snaps = vec![
+            vec![obs(1, stable.clone())],
+            vec![obs(1, stable.clone()), obs(-1, transient.clone())],
+            vec![obs(1, stable.clone())],
+        ];
+        let tracks = build_tracks(&snaps, 0.85);
+        // The persistent core is the longest-lived track.
+        let top = &tracks[0];
+        assert_eq!(top.charge, 1);
+        assert_eq!(top.appearances, 3, "stable core seen in all 3 dreams");
+        assert_eq!(top.span, 3);
+        // The transient core is its own short track.
+        assert!(tracks.iter().any(|t| t.charge == -1 && t.appearances == 1));
+    }
+
+    #[test]
+    fn opposite_charges_never_match() {
+        let fp = fingerprint(&[1.0, 0.2, -0.3, 0.4], 16);
+        let snaps = vec![vec![obs(1, fp.clone())], vec![obs(-1, fp.clone())]];
+        let tracks = build_tracks(&snaps, 0.5);
+        // Same fingerprint but opposite charge ⇒ two distinct tracks, not one.
+        assert_eq!(tracks.len(), 2);
+        assert!(tracks.iter().all(|t| t.appearances == 1));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod consciousness;
 /// ADR-0037: spiral / phase-singularity detection (L6 instrument).
 pub mod spiral;
 
+pub mod l6;
+
 pub mod medium;
 
 pub mod hrm_store;

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -934,6 +934,55 @@ impl ChiralMedium {
         Medium::cloud_report_2d(&wf, &phases)
     }
 
+    /// ADR-0037 L6 instrument: per-dream belief-core snapshot — each detected core
+    /// paired with a frame-invariant content fingerprint (random projection of its
+    /// k-neighbourhood centroid in the stable wavefront space, NOT the unstable 2-D
+    /// PCA coords), for cross-dream tracking (see `crate::l6::build_tracks`).
+    /// Holistic (right) field; same O(n²) cost class as `holistic_cloud_report`.
+    pub fn belief_core_snapshot(&self) -> Vec<crate::l6::CoreObs> {
+        let n = self.right.count();
+        if n < 4 {
+            return Vec::new();
+        }
+        let wf = self.right.wavefronts.slice(ndarray::s![..n, ..]).to_owned();
+        let phases: Vec<f32> = self.right.phase.slice(ndarray::s![..n]).iter().copied().collect();
+        let pts = Medium::pca_field_2d(&wf, &phases);
+        let cores = crate::spiral::cloud_singularities(&pts, 8);
+        let dim = wf.ncols();
+        let k = 8usize.min(n);
+        cores
+            .iter()
+            .map(|c| {
+                // k nearest points to the core centre; their wavefront centroid is
+                // the (frame-invariant) content fingerprint of what the core organizes.
+                let mut idx: Vec<usize> = (0..n).collect();
+                idx.sort_by(|&a, &b| {
+                    let da = (pts[a].0 - c.x).powi(2) + (pts[a].1 - c.y).powi(2);
+                    let db = (pts[b].0 - c.x).powi(2) + (pts[b].1 - c.y).powi(2);
+                    da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let kk = k.min(idx.len());
+                let mut centroid = vec![0.0f32; dim];
+                for &j in &idx[..kk] {
+                    for (d, val) in wf.row(j).iter().enumerate() {
+                        centroid[d] += *val;
+                    }
+                }
+                if kk > 0 {
+                    for v in centroid.iter_mut() {
+                        *v /= kk as f32;
+                    }
+                }
+                crate::l6::CoreObs {
+                    x: c.x,
+                    y: c.y,
+                    charge: c.charge,
+                    fp: crate::l6::fingerprint(&centroid, 16),
+                }
+            })
+            .collect()
+    }
+
     /// ADR-0037 Phase 4: cross-hemisphere ring report. The cortical spiral wave
     /// in Ye et al. (Science 2026) spans BOTH hemispheres, not one — so the L6
     /// instrument joins the active left ⊕ right phase fields into a single ring


### PR DESCRIPTION
**Stacked on #428 (feat/l6-instrument)** — review/merge that first; this base retargets to master once #428 lands.

## What

Layer 2 of the L6 instrument. #428 records core *counts* over time; this gives cores **identity** across dreams, so "a belief = a stabilized spiral core" becomes a *per-core* lifetime/stability measurement — the thing the falsifiable claims (core stability ⇒ recall reliability; merge ⇒ consolidation) actually need.

## The hard part

Each dream rebuilds the 2-D PCA embedding from scratch, so a core's `(x,y)` is **not** comparable across dreams (sign/rotation ambiguity). Fix = a **frame-invariant content fingerprint**: a deterministic random projection (JL, cosine-preserving) of the core's k-neighbourhood **centroid in the stable wavefront space**. Cores match across dreams by fingerprint cosine + charge — by *what they organize*, not *where they landed*.

## Changes
- **`src/l6.rs`** — `CoreObs`, `fingerprint()` (16-d JL projection), `cosine()`, `build_tracks()` (greedy highest-cosine-first matching → per-core lifetime). Unit tests: determinism, similarity preservation, persistent-core tracking, opposite-charge separation.
- **`ChiralMedium::belief_core_snapshot`** / HrmStore passthrough — per-dream cores + centroid fingerprints (one PCA; folded into `append_l6_telemetry`, which now also writes `<data_dir>/l6-cores.jsonl`).
- **`kannaka belief cores [--last N] [--min-cos X] [--json]`** — track cores across snapshots; report appearances/span/stability. Stateless; matching is read-time (algorithm can evolve, no migration).

## Verification
3 dreams on a static field → cores chain to `appears=3/3` (stable), consolidation-killed cores show fewer appearances:
```
tracked 79 cores across 3 dreams (min_cos=0.85):
  id=0  charge=+1 appears=3/3 span=3 stability=100% ####################
  ...
```
`cargo test --lib spiral::` 9/0, `l6::` 4/0, build green. The medium change is additive (no Singularity change — anchor index recovered by matching the core's (x,y) back to the PCA points).

## Next
recall@k probe — the dependent variable for "core stability ⇒ recall reliability".

🤖 Generated with [Claude Code](https://claude.com/claude-code)