### PR TITLE
fix(clippy): clear pre-existing deny-by-default correctness errors (--all-targets)

### DIFF
--- a/src/bin/research.rs
+++ b/src/bin/research.rs
@@ -1389,6 +1389,10 @@ fn run_l4_pass(
     // outer orchestrator overwrites fitness with the resistance-adjusted
     // total. This keeps run_l4_pass reusable for both clean and adversarial
     // inner evaluations without double-counting.
+    // Neutral inside run_l4_pass; the outer orchestrator overwrites fitness with the
+    // resistance-adjusted total (see the note above). Named (not a literal 1.0 - 1.0)
+    // so it isn't a clippy::eq_op.
+    let adversarial_resistance = 1.0;
     let fitness = 0.05 * (1.0 - noise_removal)
         + 0.05 * (1.0 - signal_preservation)
         + 0.05 * (1.0 - phase_coherence)
@@ -1400,7 +1404,7 @@ fn run_l4_pass(
         + 0.15 * (1.0 - retention_score)
         + 0.05 * (1.0 - retention_plasticity)
         + 0.10 * (1.0 - chain_fidelity)
-        + 0.10 * (1.0 - 1.0) // adversarial_resistance slot, filled by caller
+        + 0.10 * (1.0 - adversarial_resistance) // slot filled by the outer orchestrator
         + 0.05 * (1.0 - encoding_entropy);
 
     let metrics = L4PassMetrics {

--- a/src/medium/tests.rs
+++ b/src/medium/tests.rs
@@ -468,7 +468,6 @@ fn dream_can_prune_weak_memories() {
     // Some weak memories should have been dissolved
     let final_count = medium.wavefront_count();
     assert!(final_count <= initial_count);
-    assert!(report.wavefronts_dissolved >= 0);
 
     println!("Pruned {} wavefronts during dream", report.wavefronts_dissolved);
 }
@@ -1423,7 +1422,7 @@ fn phi_trend_extraction_from_introspections() {
     println!("Phi trend: {:?}", emergence.phi_trend);
 
     // Should have extracted some phi values
-    assert!(emergence.phi_trend.len() >= 0); // May be empty if extraction fails, but that's ok
+    // phi_trend may be empty if extraction fails — that's ok; values (if any) checked below.
 
     // If we did extract values, they should be reasonable
     for phi in &emergence.phi_trend {

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -1842,8 +1842,9 @@ mod tests {
         sys.remember("the capital of france is paris").unwrap(); // knowledge
         
         let stats = sys.stats();
-        // HRM-native path doesn't populate legacy geometry, so geometric_classes may be 0
-        assert!(stats.geometric_classes >= 0);
+        // HRM-native path doesn't populate legacy geometry, so geometric_classes may be 0.
+        // (It's unsigned, so `>= 0` is vacuous — just confirm the field is accessible.)
+        let _ = stats.geometric_classes;
         // Triality coverage may also be 0 in HRM mode
         assert!(stats.triality_coverage.len() == 3);
         

--- a/src/sensemaking.rs
+++ b/src/sensemaking.rs
@@ -381,7 +381,7 @@ mod tests {
         let peers = vec![
             PeerCluster { agent_id: "a".into(), summary: "rates rise".into(), phase: 0.05 },
             PeerCluster { agent_id: "b".into(), summary: "rates rise".into(), phase: 0.1 },
-            PeerCluster { agent_id: "c".into(), summary: "rates rise".into(), phase: 3.14 }, // anti-phase, excluded
+            PeerCluster { agent_id: "c".into(), summary: "rates rise".into(), phase: std::f32::consts::PI }, // anti-phase, excluded
         ];
         let sim = |a: &str, b: &str| if a == b { 1.0 } else { 0.0 };
         let v = reinforce_hypotheses(&hyps, &peers, sim, 0.8, std::f32::consts::FRAC_PI_2, 2);


### PR DESCRIPTION
`cargo clippy --all-targets` errored on 5 sites with **deny-by-default `clippy::correctness`** lints. CI's clippy step is scoped (`cargo clippy --lib --bin kannaka`, ci.yml:62) and never compiles these — they're all in `#[cfg(test)]` code or the `research` bin — so they sat as silent debt invisible to the gate. This makes `--all-targets` clean.

| Site | Lint | Fix |
|------|------|-----|
| `research.rs` (fitness sum) | `eq_op` (`1.0 - 1.0`) | name it `adversarial_resistance = 1.0` (neutral here; outer orchestrator fills the slot) — numerically identical (still 0) |
| `openclaw.rs` geometry test | `absurd_extreme_comparisons` | `assert!(geometric_classes >= 0)` is vacuous (unsigned) → `let _ = stats.geometric_classes;` |
| `sensemaking.rs` peer test | `approx_constant` | `3.14` → `std::f32::consts::PI` (matches the `FRAC_PI_2` two lines down; still anti-phase) |
| `medium/tests.rs` ×2 | `absurd_extreme_comparisons` | dropped vacuous `wavefronts_dissolved >= 0` (real `final_count <= initial_count` stays) and `phi_trend.len() >= 0` |

## Verification
- `cargo clippy --all-targets`: **0 errors** (was 5).
- `sensemaking` 8/0; no behavior change anywhere (the research.rs term stays 0; the rest are test-only assert removals / a more-precise constant).
- Did **not** touch ci.yml — leaving CI's scoped clippy as-is; this just makes the broader `--all-targets` pass for local/dev runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)