### PR TITLE
feat(clustering): fix num_clusters=1 via "decone" (mean-center + top-PC removal)

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1126,6 +1126,9 @@ fn main() {
     // (and before the update-check thread spawns, so set_var is single-threaded).
     // Env still wins: only sets a var when unset.
     config::apply_belief_env_from_config(&cfg);
+    // num_clusters fix: bridge persisted [cluster].decone → KANNAKA_CLUSTER_DECONE
+    // (same single-threaded, env-wins contract as the belief bridge above).
+    config::apply_cluster_env_from_config(&cfg);
 
     // Non-blocking update check (background thread)
     config::check_for_updates_background(&cfg);

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct KannakaConfig {
     pub triage: TriageConfig,
     #[serde(default = "BeliefConfig::default")]
     pub belief: BeliefConfig,
+    #[serde(default = "ClusterConfig::default")]
+    pub cluster: ClusterConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,6 +145,16 @@ pub struct BeliefConfig {
     pub enabled: bool,
     #[serde(default = "default_belief_max_n")]
     pub max_n: usize,
+}
+
+/// num_clusters fix: "decone" (mean-center + top-PC removal) for the cluster
+/// detector (`cluster_decone_enabled` in `kuramoto`). env `KANNAKA_CLUSTER_DECONE`
+/// OVERRIDES this; `apply_cluster_env_from_config` bridges config→env at startup
+/// only when the env var is unset. Default off.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClusterConfig {
+    #[serde(default)]
+    pub decone: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -279,6 +291,7 @@ impl Default for KannakaConfig {
             updates: UpdatesConfig::default(),
             triage: TriageConfig::default(),
             belief: BeliefConfig::default(),
+            cluster: ClusterConfig::default(),
         }
     }
 }
@@ -422,6 +435,16 @@ pub fn apply_belief_env_from_config(cfg: &KannakaConfig) {
     }
     if std::env::var_os("KANNAKA_BELIEF_MAX_N").is_none() {
         std::env::set_var("KANNAKA_BELIEF_MAX_N", cfg.belief.max_n.to_string());
+    }
+}
+
+/// num_clusters fix: bridge the persisted `[cluster]` config to the env var the
+/// cluster detector reads (`cluster_decone_enabled` in `kuramoto`). **Env wins** —
+/// only set the var when it's unset, so a one-off `KANNAKA_CLUSTER_DECONE=…` still
+/// overrides the file. Call once at startup (single-threaded, before workers spawn).
+pub fn apply_cluster_env_from_config(cfg: &KannakaConfig) {
+    if std::env::var_os("KANNAKA_CLUSTER_DECONE").is_none() && cfg.cluster.decone {
+        std::env::set_var("KANNAKA_CLUSTER_DECONE", "on");
     }
 }
 

--- a/src/kuramoto.rs
+++ b/src/kuramoto.rs
@@ -99,6 +99,118 @@ fn save_sidecar(engine: &ResonanceEngine, entry: &ClusterCacheEntry) {
     }
 }
 
+/// num_clusters fix: when on, `find_synchronized_clusters` mean-centers AND projects
+/// out the top principal components ("decones") the vectors before building the
+/// similarity graph. The field's hypervectors share a dominant common-mode direction
+/// (~38% of variance on the local field) that otherwise links nearly the whole field
+/// into ONE component at the raw 0.75 threshold; deconing removes it and exposes the
+/// real sub-structure. Default OFF — only the graph EDGES change (cluster themes,
+/// phases, and order-parameter still use the original vectors, so recall/storage are
+/// untouched).
+fn cluster_decone_enabled() -> bool {
+    std::env::var("KANNAKA_CLUSTER_DECONE")
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+/// Mean-center `vecs` and project out their top-`k` principal components, returning
+/// the residual vectors (same order). The PCs are estimated from a bounded, evenly
+/// spaced sample (≤ `SAMPLE` rows) via power iteration on the sample Gram, so the
+/// extra cost is O(sample²·d + n·d·k) rather than O(n²·d) — safe on the 1-core hub.
+/// With k==0 or a degenerate field it returns the mean-centered-only vectors.
+fn decone_vectors(vecs: &[&[f32]], k: usize) -> Vec<Vec<f32>> {
+    let n = vecs.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let d = vecs[0].len();
+    let mut mean = vec![0.0f32; d];
+    for v in vecs {
+        for (m, &x) in mean.iter_mut().zip(v.iter()) {
+            *m += x;
+        }
+    }
+    for m in mean.iter_mut() {
+        *m /= n as f32;
+    }
+    const SAMPLE: usize = 512;
+    let step = (n / SAMPLE).max(1);
+    let sample: Vec<usize> = (0..n).step_by(step).take(SAMPLE).collect();
+    let s = sample.len();
+    let cs: Vec<Vec<f32>> = sample
+        .iter()
+        .map(|&i| vecs[i].iter().zip(mean.iter()).map(|(&x, &m)| x - m).collect())
+        .collect();
+    let mut dirs: Vec<Vec<f32>> = Vec::new();
+    if k > 0 && s >= 2 {
+        let mut gram = vec![0.0f32; s * s];
+        for a in 0..s {
+            for b in a..s {
+                let dot: f32 = cs[a].iter().zip(cs[b].iter()).map(|(x, y)| x * y).sum();
+                gram[a * s + b] = dot;
+                gram[b * s + a] = dot;
+            }
+        }
+        for _ in 0..k {
+            let mut u = vec![1.0f32 / (s as f32).sqrt(); s];
+            let mut lam = 0.0f32;
+            for _ in 0..60 {
+                let mut w: Vec<f32> = (0..s)
+                    .map(|i| (0..s).map(|j| gram[i * s + j] * u[j]).sum())
+                    .collect();
+                let nrm = w.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if nrm <= 1e-12 {
+                    break;
+                }
+                for x in w.iter_mut() {
+                    *x /= nrm;
+                }
+                lam = nrm;
+                u = w;
+            }
+            if lam <= 1e-9 {
+                break;
+            }
+            // Feature-space direction v = Σ uᵢ·csᵢ, unit-normalized.
+            let mut v = vec![0.0f32; d];
+            for (i, &ui) in u.iter().enumerate() {
+                for (vd, &c) in v.iter_mut().zip(cs[i].iter()) {
+                    *vd += ui * c;
+                }
+            }
+            let vn = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if vn <= 1e-12 {
+                break;
+            }
+            for x in v.iter_mut() {
+                *x /= vn;
+            }
+            dirs.push(v);
+            // Deflate so the next power iteration finds the following PC.
+            for i in 0..s {
+                for j in 0..s {
+                    gram[i * s + j] -= lam * u[i] * u[j];
+                }
+            }
+        }
+    }
+    vecs.iter()
+        .map(|v| {
+            let mut r: Vec<f32> = v.iter().zip(mean.iter()).map(|(&x, &m)| x - m).collect();
+            for dir in &dirs {
+                let dot: f32 = r.iter().zip(dir.iter()).map(|(a, b)| a * b).sum();
+                for (rx, &dx) in r.iter_mut().zip(dir.iter()) {
+                    *rx -= dot * dx;
+                }
+            }
+            r
+        })
+        .collect()
+}
+
 /// Coupling tier for the Kuramoto model.
 ///
 /// Controls the effective coupling constant K depending on the relationship
@@ -507,7 +619,10 @@ impl KuramotoSync {
 
         // Two-tier cache check: in-process fingerprint first, then on-disk
         // sidecar keyed by HRM file mtime.
-        let fp = fingerprint_memories(&all);
+        let decone = cluster_decone_enabled();
+        // Fold the decone flag into the cache key so toggling it never returns
+        // clusters computed under the other mode.
+        let fp = fingerprint_memories(&all) ^ if decone { 0x5EC0_DE5E_5EC0_DE5E } else { 0 };
         if let Ok(guard) = CLUSTER_CACHE.lock() {
             if let Some(ref entry) = *guard {
                 if entry.fingerprint == fp && entry.min_cluster_size == min_cluster_size {
@@ -516,7 +631,7 @@ impl KuramotoSync {
             }
         }
         let mtime = hrm_mtime_secs(engine).unwrap_or(0);
-        if mtime != 0 {
+        if !decone && mtime != 0 {
             if let Some(clusters) = load_sidecar(engine, mtime, min_cluster_size) {
                 // Populate process cache for future calls in this same run.
                 if let Ok(mut guard) = CLUSTER_CACHE.lock() {
@@ -558,11 +673,24 @@ impl KuramotoSync {
         // that are stitched back into an adjacency list. Each pair is visited
         // once (j > i) so there's no redundant work.
         use rayon::prelude::*;
-        let threshold = self.coupling_threshold;
+        // num_clusters fix: optionally "decone" the vectors before the graph (see
+        // cluster_decone_enabled). Only the EDGES change — themes/phases/order below
+        // still use the original vectors. Lower threshold for the residual cosine scale.
+        let dvecs: Vec<Vec<f32>> = if decone {
+            let refs: Vec<&[f32]> = all.iter().map(|m| m.vector.as_slice()).collect();
+            decone_vectors(&refs, 3)
+        } else {
+            Vec::new()
+        };
+        let threshold = if decone { 0.30 } else { self.coupling_threshold };
         let neighbors_per_i: Vec<Vec<usize>> = (0..n).into_par_iter().map(|i| {
             let mut neigh = Vec::new();
             for j in (i + 1)..n {
-                let sim = cosine_similarity(&all[i].vector, &all[j].vector);
+                let sim = if decone {
+                    cosine_similarity(&dvecs[i], &dvecs[j])
+                } else {
+                    cosine_similarity(&all[i].vector, &all[j].vector)
+                };
                 if sim > threshold {
                     neigh.push(j);
                 }
@@ -607,7 +735,7 @@ impl KuramotoSync {
         let mut final_components = Vec::new();
         for component in raw_components {
             let component_size = component.len();
-            if component_size > n / 2 { // Large component (>50% of memories)
+            if !decone && component_size > n / 2 { // Large component (>50% of memories)
                 let subcomponents = self.spectral_split_component(&component, &all, self.coupling_threshold);
                 for subcomp in subcomponents {
                     if subcomp.len() >= min_cluster_size {
@@ -669,7 +797,11 @@ impl KuramotoSync {
         if let Ok(mut guard) = CLUSTER_CACHE.lock() {
             *guard = Some(entry.clone());
         }
-        save_sidecar(engine, &entry);
+        // Don't persist the on-disk sidecar in decone mode: it's keyed by mtime+size,
+        // not the decone flag, so a later non-decone run would wrongly load it.
+        if !decone {
+            save_sidecar(engine, &entry);
+        }
 
         clusters
     }

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -1862,6 +1862,177 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "probe: KANNAKA_PROBE_HRM=<path.hrm> cargo test --lib probe_cluster_centering_live_hrm -- --ignored --nocapture"]
+    fn probe_cluster_centering_live_hrm() {
+        // READ-ONLY. num_clusters=1 comes from the anisotropic cone: the cluster
+        // graph links any pair with cosine > 0.75, but the field's mean pairwise
+        // cosine is ~0.8, so ~every pair links into ONE component. Mean-centering
+        // removes the cone (centered cosine ~0.2) but needs a LOWER threshold. This
+        // counts connected components at several thresholds, RAW vs CENTERED, to pick
+        // the threshold from real data. Never saves.
+        let path = match std::env::var("KANNAKA_PROBE_HRM") {
+            Ok(p) => p,
+            Err(_) => { eprintln!("[probe] set KANNAKA_PROBE_HRM=<path to .hrm>"); return; }
+        };
+        let cm = match ChiralMedium::load(&path) {
+            Ok(c) => c,
+            Err(e) => { eprintln!("[probe] load failed: {e}"); return; }
+        };
+        let n = cm.right.count();
+        let dim = cm.right.wavefronts.ncols();
+        eprintln!("[probe] loaded n={n} dim={dim}");
+        if n < 2 { return; }
+        // Corpus mean over the right hemisphere (the clustering vectors live here).
+        let mut mean = vec![0.0f32; dim];
+        for i in 0..n {
+            for (m, &v) in mean.iter_mut().zip(cm.right.wavefronts.row(i).iter()) { *m += v; }
+        }
+        for m in mean.iter_mut() { *m /= n as f32; }
+        let zero = vec![0.0f32; dim];
+        let cosc = |i: usize, j: usize, ctr: &[f32]| -> f32 {
+            let (a, b) = (cm.right.wavefronts.row(i), cm.right.wavefronts.row(j));
+            let (mut d, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+            for ((x, y), m) in a.iter().zip(b.iter()).zip(ctr.iter()) {
+                let (xc, yc) = (x - m, y - m); d += xc * yc; na += xc * xc; nb += yc * yc;
+            }
+            if na <= 0.0 || nb <= 0.0 { 0.0 } else { d / (na.sqrt() * nb.sqrt()) }
+        };
+        // Precompute pairwise cosines once (raw + centered), then sweep thresholds.
+        let idx = |i: usize, j: usize| i * n + j;
+        let mut rmat = vec![0.0f32; n * n];
+        let mut cmat = vec![0.0f32; n * n];
+        let (mut rs, mut cs, mut np) = (0.0f32, 0.0f32, 0u32);
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let r = cosc(i, j, &zero);
+                let c = cosc(i, j, &mean);
+                rmat[idx(i, j)] = r;
+                cmat[idx(i, j)] = c;
+                rs += r; cs += c; np += 1;
+            }
+        }
+        eprintln!("[probe] mean pairwise cosine raw={:.3} centered={:.3} ({} pairs)",
+            rs / np.max(1) as f32, cs / np.max(1) as f32, np);
+        // (components, #components with >=3 members, largest component size)
+        let comps = |mat: &[f32], thr: f32| -> (usize, usize, usize) {
+            let mut adj: Vec<Vec<usize>> = vec![vec![]; n];
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    if mat[idx(i, j)] > thr { adj[i].push(j); adj[j].push(i); }
+                }
+            }
+            let mut seen = vec![false; n];
+            let mut sizes = vec![];
+            for s in 0..n {
+                if seen[s] { continue; }
+                let mut st = vec![s];
+                seen[s] = true;
+                let mut sz = 0usize;
+                while let Some(u) = st.pop() {
+                    sz += 1;
+                    for &v in &adj[u] { if !seen[v] { seen[v] = true; st.push(v); } }
+                }
+                sizes.push(sz);
+            }
+            let largest = *sizes.iter().max().unwrap_or(&0);
+            (sizes.len(), sizes.iter().filter(|&&s| s >= 3).count(), largest)
+        };
+        let (t, b, l) = comps(&rmat, 0.75);
+        eprintln!("[probe] RAW @0.75 (current behavior): components={t} (>=3 members:{b}) largest={l}/{n}");
+        eprintln!("[probe] CENTERED sweep (components / >=3-member / largest):");
+        for thr in [0.20f32, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50] {
+            let (t, b, l) = comps(&cmat, thr);
+            eprintln!("  thr={thr:.2}: comps={t} (>=3:{b}) largest={l}/{n}");
+        }
+
+        // ── Why does the blob survive centering? Either ONE dominant residual
+        // direction (→ whitening/PC-removal fixes it) or genuinely dense variance
+        // (→ the content is homogeneous, 1 cluster is content-correct). Decide via
+        // the top eigenvalues of the centered Gram + connectivity after projecting
+        // out the top principal component(s).
+        let cvec: Vec<Vec<f32>> = (0..n)
+            .map(|i| cm.right.wavefronts.row(i).iter().zip(mean.iter()).map(|(&x, &m)| x - m).collect())
+            .collect();
+        let mut g = vec![0.0f32; n * n];
+        let mut trace = 0.0f32;
+        for i in 0..n {
+            for j in i..n {
+                let d: f32 = cvec[i].iter().zip(cvec[j].iter()).map(|(a, b)| a * b).sum();
+                g[idx(i, j)] = d;
+                g[j * n + i] = d;
+                if i == j { trace += d; }
+            }
+        }
+        let matvec = |m: &[f32], u: &[f32]| -> Vec<f32> {
+            (0..n).map(|i| (0..n).map(|j| m[i * n + j] * u[j]).sum()).collect()
+        };
+        let mut gd = g.clone();
+        let mut feat_dirs: Vec<Vec<f32>> = vec![]; // top principal directions in feature space (unit)
+        for k in 0..3 {
+            let mut u = vec![1.0f32 / (n as f32).sqrt(); n];
+            let mut lam = 0.0f32;
+            for _ in 0..80 {
+                let mut w = matvec(&gd, &u);
+                let norm = w.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm <= 0.0 { break; }
+                for x in w.iter_mut() { *x /= norm; }
+                lam = norm;
+                u = w;
+            }
+            eprintln!("[probe] PC{}: explains {:.1}% of centered variance", k + 1, lam / trace.max(1e-9) * 100.0);
+            let mut v = vec![0.0f32; dim];
+            for i in 0..n {
+                for (vd, &c) in v.iter_mut().zip(cvec[i].iter()) { *vd += u[i] * c; }
+            }
+            let vn = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if vn > 0.0 { for x in v.iter_mut() { *x /= vn; } }
+            feat_dirs.push(v);
+            for i in 0..n {
+                for j in 0..n { gd[i * n + j] -= lam * u[i] * u[j]; }
+            }
+        }
+        let resid_largest = |kdirs: usize, thr: f32| -> usize {
+            let res: Vec<Vec<f32>> = (0..n)
+                .map(|i| {
+                    let mut r = cvec[i].clone();
+                    for v in feat_dirs.iter().take(kdirs) {
+                        let dot: f32 = r.iter().zip(v.iter()).map(|(a, b)| a * b).sum();
+                        for (rx, &vx) in r.iter_mut().zip(v.iter()) { *rx -= dot * vx; }
+                    }
+                    r
+                })
+                .collect();
+            let cosr = |i: usize, j: usize| -> f32 {
+                let (mut d, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+                for (a, b) in res[i].iter().zip(res[j].iter()) { d += a * b; na += a * a; nb += b * b; }
+                if na <= 0.0 || nb <= 0.0 { 0.0 } else { d / (na.sqrt() * nb.sqrt()) }
+            };
+            let mut adj: Vec<Vec<usize>> = vec![vec![]; n];
+            for i in 0..n {
+                for j in (i + 1)..n { if cosr(i, j) > thr { adj[i].push(j); adj[j].push(i); } }
+            }
+            let mut seen = vec![false; n];
+            let mut largest = 0usize;
+            for s in 0..n {
+                if seen[s] { continue; }
+                let mut st = vec![s];
+                seen[s] = true;
+                let mut sz = 0usize;
+                while let Some(u) = st.pop() {
+                    sz += 1;
+                    for &v in &adj[u] { if !seen[v] { seen[v] = true; st.push(v); } }
+                }
+                largest = largest.max(sz);
+            }
+            largest
+        };
+        eprintln!(
+            "[probe] largest component @residual-cos>0.30: top1-removed={}/{} top3-removed={}/{}",
+            resid_largest(1, 0.30), n, resid_largest(3, 0.30), n
+        );
+    }
+
+    #[test]
     #[ignore = "experiment: run with --ignored --nocapture"]
     fn experiment_exemplar_revives_collapsed_node() {
         // Two-systems / EXEMPLAR coupling: a COLLAPSED node (phase 0, order ~1.0)


### PR DESCRIPTION
## Problem
`find_synchronized_clusters` links any pair with raw cosine > 0.75, but the local field's hypervectors form a tight **anisotropic cone** (mean pairwise cosine ≈ 0.81) — so nearly every pair links into one giant component → `num_clusters: 1`.

## Why the obvious fix fails
The planned fix (mean-center the clustering cosine) **does not work** — a measurement probe shows the largest component stays **210/297 across all thresholds 0.20–0.50** even fully centered. The field has a dominant **"common-mode" direction: PC1 = 37.7% of the *centered* variance** (PC2 3.6%, PC3 2.6%) that mean-centering can't remove. Projecting out the top components ("decone") is what works:

```
largest component @residual>0.30:  centered 210/297 → top-1 removed 118 → top-3 removed 71
```

## Fix
Behind a **default-off** `KANNAKA_CLUSTER_DECONE` flag (repo-standard, like `KANNAKA_BELIEF_PHASE`):
- `decone_vectors()` = mean-center + project out the top-3 PCs, with PCs estimated from a **≤512-row sample** via power iteration on the sample Gram → `O(s²·d + n·d·k)`, safe on the 1-core hub.
- `find_synchronized_clusters` uses deconed vectors + a 0.30 threshold (residual cosine scale) **only for the graph edges** — cluster themes/phases/order-parameter still use the **original** vectors, so **recall and storage are untouched**.
- Decone flag folded into the in-process cache key; on-disk sidecar + spectral-split skipped in decone mode.
- `chiral.rs`: `probe_cluster_centering_live_hrm` (`#[ignore]`) — the read-only measurement that drove the diagnosis.

## Validation (live local field, 297 mems)
| Check | Result |
|---|---|
| `num_clusters` flag on | **1 → 11** |
| default-off path | byte-identical (still 1) |
| recall@1 | unchanged (0.406 == 0.406; probe noise ±0.03–0.05) |
| kuramoto tests | 15/0 |
| clippy (lib/bin) | 0 new warnings |

## Notes
- Threshold `0.30` + `k=3` are **tuned for the local field**. Default-off ⇒ **zero prod risk**; hub validation/tuning (and optional env-tunable thr/k) is a follow-up.
- The `#[ignore]` probe documents the analysis and lets anyone re-measure on another field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)