### PR TITLE
feat(ADR-0037): Track-D always-on heartbeat belief coupling (default-off)

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1146,6 +1146,8 @@ fn main() {
     // num_clusters fix: bridge persisted [cluster].decone → KANNAKA_CLUSTER_DECONE
     // (same single-threaded, env-wins contract as the belief bridge above).
     config::apply_cluster_env_from_config(&cfg);
+    // Track-D: bridge persisted [coupling].enabled → KANNAKA_EXEMPLAR_COUPLING.
+    config::apply_coupling_env_from_config(&cfg);
 
     // Non-blocking update check (background thread)
     config::check_for_updates_background(&cfg);

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -691,6 +691,23 @@ fn try_nats_connect(url: &str) -> Option<kannaka_memory::nats::SwarmTransport> {
     }
 }
 
+/// ADR-0037 Track-D: always-on belief-coupling toggle. When on, `swarm join`'s
+/// heartbeat periodically publishes this node's belief cores AND couples its phases
+/// toward peers' — so swarm agents drift toward shared beliefs without a manual
+/// `belief couple`. Default OFF — the riskiest Track-D step (continuous live-HRM
+/// mutation), enable per-node observer-first. Phase-only (recall preserved),
+/// min_cos-gated + displacement-capped (unique beliefs stay distinct; shared ones
+/// converge to consensus and then stop, since sin(target−phase)→0 at agreement).
+#[cfg(feature = "nats")]
+fn exemplar_coupling_enabled() -> bool {
+    std::env::var("KANNAKA_EXEMPLAR_COUPLING")
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
 /// Cheap pre-clap check: is `verb` one of the built-in subcommand
 /// names? Used to skip the clap layer on the hot path (built-in
 /// invocations don't pay for clap parsing). Mirrors the subcommand set
@@ -3801,6 +3818,27 @@ fn main() {
                     sys.publish_consciousness_to_nats(&initial_assess);
                     const CONSCIOUSNESS_REFRESH_TICKS: u64 = 10;
 
+                    // ADR-0037 Track-D heartbeat coupling (default OFF). Conservative,
+                    // env-tunable cadence + gate: slow (so it doesn't thrash the .hrm /
+                    // 1-core box) and a HIGH min_cos so it under-couples by default
+                    // (couple only strongly-shared beliefs). Gentle per-event nudge
+                    // (strength/cycles/max_disp below) so consensus builds gradually.
+                    let coupling_on = exemplar_coupling_enabled();
+                    let coupling_ticks = std::env::var("KANNAKA_EXEMPLAR_COUPLING_TICKS")
+                        .ok()
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .filter(|&n| n > 0)
+                        .unwrap_or(20);
+                    let coupling_min_cos = std::env::var("KANNAKA_EXEMPLAR_COUPLING_MIN_COS")
+                        .ok()
+                        .and_then(|v| v.parse::<f32>().ok())
+                        .unwrap_or(0.7);
+                    if coupling_on {
+                        println!(
+                            "[couple] always-on belief coupling ENABLED — every {coupling_ticks} ticks, min_cos {coupling_min_cos:.2} (phase-only, displacement-capped; needs belief on)"
+                        );
+                    }
+
                     let mut tick: u64 = 0;
                     while running.load(Ordering::SeqCst) {
                         // Granular sleep so Ctrl+C is responsive (<= 1s).
@@ -3835,6 +3873,95 @@ fn main() {
                         if tick % CONSCIOUSNESS_REFRESH_TICKS == 0 {
                             let state = sys.assess();
                             sys.publish_consciousness_to_nats(&state);
+                        }
+
+                        // ADR-0037 Track-D: always-on belief coupling (default OFF).
+                        // On a slow cadence: (1) publish our belief cores so peers can
+                        // converge toward us, (2) couple our phases toward peers' shared
+                        // beliefs. Phase-only ⇒ recall preserved; the heartbeat's own
+                        // flush (in swarm_publish_heartbeat above) persists the result.
+                        // Requires a re-phased belief field; skips on no peers / errors.
+                        if coupling_on
+                            && tick % coupling_ticks == 0
+                            && kannaka_memory::medium::chiral::belief_phase_enabled()
+                        {
+                            // (1) publish our (fresh) cores.
+                            if let Some(h) = sys
+                                .engine
+                                .store
+                                .as_any()
+                                .downcast_ref::<kannaka_memory::hrm_store::HrmStore>()
+                            {
+                                let own = h.belief_core_snapshot();
+                                if !own.is_empty() {
+                                    let _ = transport.ensure_cores_stream();
+                                    let payload = serde_json::json!({
+                                        "agent_id": my_agent_id,
+                                        "core_count": own.len(),
+                                        "cores": own,
+                                        "created_at": chrono::Utc::now().to_rfc3339(),
+                                    });
+                                    let _ = transport.publish_cores(&my_agent_id, &payload);
+                                }
+                            }
+                            // (2) fetch peers' cores + couple toward them.
+                            match transport.get_peer_cores(None) {
+                                Ok(payloads) => {
+                                    let mut peer_cores: Vec<kannaka_memory::l6::CoreObs> = Vec::new();
+                                    let mut sources = 0usize;
+                                    for p in &payloads {
+                                        if p.get("agent_id").and_then(|v| v.as_str())
+                                            == Some(my_agent_id.as_str())
+                                        {
+                                            continue; // never couple toward self
+                                        }
+                                        if let Some(cs) = p.get("cores").and_then(|c| {
+                                            serde_json::from_value::<Vec<kannaka_memory::l6::CoreObs>>(
+                                                c.clone(),
+                                            )
+                                            .ok()
+                                        }) {
+                                            let valid: Vec<_> =
+                                                cs.into_iter().filter(|c| c.fp.len() == 16).collect();
+                                            if !valid.is_empty() {
+                                                sources += 1;
+                                                peer_cores.extend(valid);
+                                            }
+                                        }
+                                    }
+                                    peer_cores.truncate(1024); // bound O(n×cores) on the 1-core box
+                                    if !peer_cores.is_empty() {
+                                        // Gentle per-event nudge: small strength/cycles + a
+                                        // tight displacement budget so consensus accrues
+                                        // gradually across heartbeats, never in one jump.
+                                        let moved = sys
+                                            .engine
+                                            .store
+                                            .as_any_mut()
+                                            .downcast_mut::<kannaka_memory::hrm_store::HrmStore>()
+                                            .map(|h| {
+                                                h.couple_belief(
+                                                    &peer_cores,
+                                                    5,
+                                                    0.05,
+                                                    0.2,
+                                                    coupling_min_cos,
+                                                )
+                                            })
+                                            .map(|(m, _)| m)
+                                            .unwrap_or(0);
+                                        if moved > 0 {
+                                            println!(
+                                                "[couple] tick #{tick}: nudged {moved} wavefronts toward {} cores from {sources} peer(s)",
+                                                peer_cores.len()
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!("[couple] tick #{tick}: peer cores fetch failed: {e}");
+                                }
+                            }
                         }
                     }
 

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -3819,23 +3819,38 @@ fn main() {
                     const CONSCIOUSNESS_REFRESH_TICKS: u64 = 10;
 
                     // ADR-0037 Track-D heartbeat coupling (default OFF). Conservative,
-                    // env-tunable cadence + gate: slow (so it doesn't thrash the .hrm /
-                    // 1-core box) and a HIGH min_cos so it under-couples by default
-                    // (couple only strongly-shared beliefs). Gentle per-event nudge
-                    // (strength/cycles/max_disp below) so consensus builds gradually.
-                    let coupling_on = exemplar_coupling_enabled();
+                    // env-tunable cadence + gate. NB: a coupling tick is SYNCHRONOUS in
+                    // this single-threaded loop — belief_core_snapshot (a dense-Gram PCA)
+                    // + couple + save can block the phase beacon for several seconds on a
+                    // large field / 1-core box, so the cadence is slow by default (40
+                    // ticks ≈ 20 min @ 30s). min_cos is HIGH (0.7, well above the ~0.54
+                    // median match scale) so it under-couples — only strongly-shared
+                    // beliefs. The per-event nudge is gentle; max_disp caps drift PER
+                    // EVENT, not cumulatively, so over many events a node's SHARED-content
+                    // phases converge toward swarm consensus (intended) while unmatched/
+                    // unique beliefs stay put (min_cos gate) and recall is untouched
+                    // (phase-only ⇒ recall = cosine×energy is phase-independent). Coupling
+                    // is SKIPPED on a read-only node (it could never persist and would
+                    // only pollute the reader's published beacon/metrics). ⚠ A coupling
+                    // node holds the writer lock continuously: any prune/triage cron on
+                    // the same node MUST stop the writer first (like dream-cron) or its
+                    // lockless save can lost-update the coupled state — see the PR notes.
+                    let coupling_on = exemplar_coupling_enabled() && !readonly_env_active();
+                    if exemplar_coupling_enabled() && readonly_env_active() {
+                        println!("[couple] KANNAKA_EXEMPLAR_COUPLING set but node is read-only — coupling SKIPPED (a reader can't persist).");
+                    }
                     let coupling_ticks = std::env::var("KANNAKA_EXEMPLAR_COUPLING_TICKS")
                         .ok()
                         .and_then(|v| v.parse::<u64>().ok())
                         .filter(|&n| n > 0)
-                        .unwrap_or(20);
+                        .unwrap_or(40);
                     let coupling_min_cos = std::env::var("KANNAKA_EXEMPLAR_COUPLING_MIN_COS")
                         .ok()
                         .and_then(|v| v.parse::<f32>().ok())
                         .unwrap_or(0.7);
                     if coupling_on {
                         println!(
-                            "[couple] always-on belief coupling ENABLED — every {coupling_ticks} ticks, min_cos {coupling_min_cos:.2} (phase-only, displacement-capped; needs belief on)"
+                            "[couple] always-on belief coupling ENABLED — every {coupling_ticks} ticks, min_cos {coupling_min_cos:.2} (phase-only; a coupling tick briefly blocks the beacon; needs belief on)"
                         );
                     }
 
@@ -3881,7 +3896,8 @@ fn main() {
                         // beliefs. Phase-only ⇒ recall preserved; the heartbeat's own
                         // flush (in swarm_publish_heartbeat above) persists the result.
                         // Requires a re-phased belief field; skips on no peers / errors.
-                        if coupling_on
+                        if running.load(Ordering::SeqCst)
+                            && coupling_on
                             && tick % coupling_ticks == 0
                             && kannaka_memory::medium::chiral::belief_phase_enabled()
                         {
@@ -3934,7 +3950,7 @@ fn main() {
                                         // Gentle per-event nudge: small strength/cycles + a
                                         // tight displacement budget so consensus accrues
                                         // gradually across heartbeats, never in one jump.
-                                        let moved = sys
+                                        let (moved, saved_ok) = sys
                                             .engine
                                             .store
                                             .as_any_mut()
@@ -3948,9 +3964,14 @@ fn main() {
                                                     coupling_min_cos,
                                                 )
                                             })
-                                            .map(|(m, _)| m)
-                                            .unwrap_or(0);
-                                        if moved > 0 {
+                                            .unwrap_or((0, true));
+                                        if moved > 0 && !saved_ok {
+                                            // Don't report success on a failed persist; the
+                                            // next heartbeat flush re-attempts the save.
+                                            eprintln!(
+                                                "[couple] tick #{tick}: nudged {moved} wavefronts but SAVE FAILED — on-disk .hrm unchanged (retries next flush)"
+                                            );
+                                        } else if moved > 0 {
                                             println!(
                                                 "[couple] tick #{tick}: nudged {moved} wavefronts toward {} cores from {sources} peer(s)",
                                                 peer_cores.len()

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,8 @@ pub struct KannakaConfig {
     pub belief: BeliefConfig,
     #[serde(default = "ClusterConfig::default")]
     pub cluster: ClusterConfig,
+    #[serde(default = "CouplingConfig::default")]
+    pub coupling: CouplingConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,6 +157,16 @@ pub struct BeliefConfig {
 pub struct ClusterConfig {
     #[serde(default)]
     pub decone: bool,
+}
+
+/// ADR-0037 Track-D: always-on heartbeat belief coupling. env KANNAKA_EXEMPLAR_
+/// COUPLING OVERRIDES this; `apply_coupling_env_from_config` bridges config→env at
+/// startup only when the env var is unset. Default off — the riskiest Track-D step;
+/// enable per-node, observer-first. Cadence/min_cos tune via the _TICKS/_MIN_COS env.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CouplingConfig {
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +304,7 @@ impl Default for KannakaConfig {
             triage: TriageConfig::default(),
             belief: BeliefConfig::default(),
             cluster: ClusterConfig::default(),
+            coupling: CouplingConfig::default(),
         }
     }
 }
@@ -445,6 +458,15 @@ pub fn apply_belief_env_from_config(cfg: &KannakaConfig) {
 pub fn apply_cluster_env_from_config(cfg: &KannakaConfig) {
     if std::env::var_os("KANNAKA_CLUSTER_DECONE").is_none() && cfg.cluster.decone {
         std::env::set_var("KANNAKA_CLUSTER_DECONE", "on");
+    }
+}
+
+/// ADR-0037 Track-D: bridge persisted `[coupling].enabled` → KANNAKA_EXEMPLAR_
+/// COUPLING (read by the swarm-join heartbeat). **Env wins** — only set when unset.
+/// Call once at startup (single-threaded, before workers spawn).
+pub fn apply_coupling_env_from_config(cfg: &KannakaConfig) {
+    if std::env::var_os("KANNAKA_EXEMPLAR_COUPLING").is_none() && cfg.coupling.enabled {
+        std::env::set_var("KANNAKA_EXEMPLAR_COUPLING", "on");
     }
 }
 


### PR DESCRIPTION
The **final Track-D piece**: continuous, automatic belief-syncing. When `KANNAKA_EXEMPLAR_COUPLING` is set, `swarm join`'s heartbeat — on a slow cadence — publishes this node's belief cores and gently nudges its phases toward peers' shared beliefs. The unattended version of `kannaka belief couple`. **Default OFF**; this is the riskiest Track-D step (continuous live-HRM mutation), meant to be staged **observer-node-first**.

## How it works
Per coupling tick (default every 40 ticks ≈ 20 min @ 30s heartbeat), if belief is on and the node is not read-only:
1. publish `belief_core_snapshot` so peers can converge toward us;
2. fetch peers' cores (skip self/malformed, cap 1024) and `couple_belief` toward them with a gentle nudge (strength 0.05, cycles 5, max_disp 0.2, `min_cos` default 0.7).

Phase-only ⇒ recall preserved. Same `&mut sys` + writer lock as the heartbeat (no new lock). The heartbeat's existing per-tick flush persists it. Env knobs: `KANNAKA_EXEMPLAR_COUPLING`, `_TICKS`, `_MIN_COS`.

## Adversarial review (10 confirmed / 3 rejected) — fixed in commit 2
**Rejections** (false alarms, verified): the "double 161 MB write/tick" is actually one write (dirty-flag gates the flush); "min_cos 0.7 too low" is backwards (0.7 is *high* vs the ~0.54 median match scale); "mutual feedback destroys belief diversity" — refuted, coupling is phase-only so **recall/content/identity are preserved**, only the *phase* of shared beliefs converges (the design goal).

**Fixed:**
- Skip coupling on a `KANNAKA_READONLY` node (was: mutated RAM + polluted the reader's beacon). ✔ smoke-tested: now prints "coupling SKIPPED".
- Log `SAVE FAILED` on a failed persist instead of a misleading "nudged" line.
- `running.load` guard so Ctrl+C during the sleep skips the multi-second coupling.
- Slower default cadence (40 ticks) + honest comments (per-event vs cumulative drift; writer-lock caveat).

## Known limitations / follow-ups (documented, not in this PR)
- **Cost on a 1-core node**: a coupling tick's `belief_core_snapshot` (dense-Gram PCA) blocks the single-threaded heartbeat for ~seconds on a large field. Mitigated by default-off + slow cadence + observer-first staging (local is fast); the proper fix is **off-threading** the snapshot+couple — follow-up.
- **Pre-existing lockless writers**: `prune-prefix` and `triage --apply` don't take the write lock. The coupling node holds it continuously, so those crons can lost-update the coupled state. **A coupling node's prune/triage crons must stop the writer first (like dream-cron).** Lock-gating those two commands is a separate follow-up.
- **Cumulative anti-homogenization**: `max_disp` bounds per-event drift; a lifetime cap (or pinning targets to a fixed reference) would bound cumulative convergence — follow-up. (Recall is preserved regardless.)

## Validation
- Smoke test (READONLY, throwaway id): joins → publishes → fetches the hub's 711 cores → nudges 112 wavefronts/tick (pre-readonly-fix); post-fix readonly node correctly **skips**.
- cargo check + clippy clean; default-off path byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)