### PR TITLE
harden: fix 10 verified bugs (correctness, graph integrity, durability, DoS)

### DIFF
--- a/src/bin/handlers/swarm.rs
+++ b/src/bin/handlers/swarm.rs
@@ -178,7 +178,13 @@ pub(crate) fn handle_swarm_serve(
                     let reply_to = msg.reply_to.clone();
                     let req: serde_json::Value = serde_json::from_slice(&msg.payload).unwrap_or(serde_json::Value::Null);
                     let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                    let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8) as usize;
+                    // Clamp peer-supplied top_k: it comes straight off the NATS
+                    // wire and drives recall + result-Vec allocation + per-result
+                    // store.get + JSON serialization. An unbounded value (e.g.
+                    // {"top_k": 4_000_000_000}) is an OOM/DoS vector on the
+                    // 1-core/6GB hub. The sibling `cores` handler caps peer input
+                    // the same way (truncate(1024)).
+                    let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8).min(100) as usize;
                     if let (false, Some(reply)) = (query.is_empty(), reply_to) {
                         let beam = kannaka_memory::agent::attention_beam_for_prompt(
                             sys, &query, kannaka_memory::agent::DEFAULT_ATTENTION_BEAM);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -363,10 +363,18 @@ impl ConsciousnessBridge {
             for j in (i + 1)..n {
                 let sim = cosine_similarity(&memories[i].vector, &memories[j].vector);
                 if sim > self.coupling_threshold {
-                    total_edges += 1;
-
                     if let (Some(&cluster_i), Some(&cluster_j)) =
                         (id_to_cluster.get(&memories[i].id), id_to_cluster.get(&memories[j].id)) {
+                        // Count the edge into total_edges only when BOTH
+                        // endpoints are clustered, so the edge total and the
+                        // degree sums use the same edge set. Counting edges
+                        // with unclustered endpoints into total_edges while
+                        // never adding them to any cluster_degree makes
+                        // Σ cluster_degree / (2·total_edges) < 1, under-
+                        // subtracting the modularity null-model term and biasing
+                        // Q high. (The skip-link loop below already counts edges
+                        // only inside this same membership check.)
+                        total_edges += 1;
                         cluster_degree[cluster_i] += 1;
                         cluster_degree[cluster_j] += 1;
 

--- a/src/collective/flux.rs
+++ b/src/collective/flux.rs
@@ -334,11 +334,19 @@ pub fn evaluate_pull(signal: &RemoteMemorySignal, trust_score: f32, current_focu
     if let Some(focus) = current_focus {
         let focus_lower = focus.to_lowercase();
         let summary_lower = signal.summary.to_lowercase();
-        let relevant = signal.tags.iter().any(|t| {
-            let tag_lower = t.to_lowercase();
-            // Match if tag contains focus term OR focus contains tag
-            tag_lower.contains(&focus_lower) || focus_lower.contains(&tag_lower)
-        }) || summary_lower.contains(&focus_lower);
+        // An empty focus would make every `contains()` below vacuously true —
+        // treat it as "no focus" rather than "matches everything".
+        let relevant = !focus_lower.is_empty()
+            && (signal.tags.iter().any(|t| {
+                let tag_lower = t.to_lowercase();
+                // Require a meaningful (>= 3 char) tag before bidirectional
+                // substring matching. An empty or 1-char peer-supplied tag
+                // makes `focus.contains(tag)` vacuously true, which would force
+                // topical relevance for any signal above the amplitude gate —
+                // a pull-flood vector a peer could trigger with a `""` tag.
+                tag_lower.len() >= 3
+                    && (tag_lower.contains(&focus_lower) || focus_lower.contains(&tag_lower))
+            }) || summary_lower.contains(&focus_lower));
         if relevant && signal.amplitude > 0.4 {
             return PullDecision::Pull;
         }
@@ -660,5 +668,28 @@ mod tests {
             branch: "arc/working".to_string(),
         };
         assert_eq!(evaluate_pull(&signal, 0.7, Some("collective memory")), PullDecision::Pull);
+    }
+
+    #[test]
+    fn pull_decision_ignores_empty_and_tiny_tags() {
+        // A peer must not be able to force a Pull with an empty or 1-char tag
+        // (the vacuous-substring pull-flood vector). Amplitude is above the
+        // topical gate (0.4) but below the trusted-always gate, and the focus
+        // does not appear in the summary, so the only path to Pull is a tag
+        // match — which an empty/tiny tag must NOT provide.
+        let signal = RemoteMemorySignal {
+            agent_id: "spammer".to_string(),
+            memory_id: Uuid::new_v4().to_string(),
+            amplitude: 0.5,
+            category: "knowledge".to_string(),
+            tags: vec!["".to_string(), "x".to_string()],
+            summary: "unrelated content".to_string(),
+            branch: "spammer/working".to_string(),
+        };
+        assert_ne!(
+            evaluate_pull(&signal, 0.6, Some("quantum entanglement")),
+            PullDecision::Pull,
+            "empty/1-char tags must not force topical relevance"
+        );
     }
 }

--- a/src/collective/glyph_store.rs
+++ b/src/collective/glyph_store.rs
@@ -165,6 +165,14 @@ impl GlyphStore {
     /// Insert a remote glyph (no openings — received from another agent).
     pub fn insert_remote(&mut self, glyph: PrivacyGlyph) {
         let hash = glyph.glyph_hash.clone();
+        // Never downgrade a glyph we OWN. If we already hold this hash with
+        // openings, a remote copy (openings: None) must not overwrite it —
+        // otherwise we lose the ability to open/prove our own memory, and a
+        // peer could poison local state simply by broadcasting a glyph whose
+        // hash collides with one of ours. A locally-owned entry wins.
+        if matches!(self.glyphs.get(&hash), Some(g) if g.openings.is_some()) {
+            return;
+        }
         self.glyphs.insert(hash, StoredGlyph {
             glyph,
             openings: None,
@@ -404,6 +412,26 @@ mod tests {
 
         let stored = store.get(&hash).unwrap();
         assert!(stored.openings.is_none()); // Remote — no openings
+    }
+
+    #[test]
+    fn test_insert_remote_does_not_clobber_owned() {
+        // A remote copy of a glyph we OWN must not wipe our openings — that
+        // would destroy our ability to open/prove our own memory and is a
+        // peer-poisoning vector.
+        let mut store = GlyphStore::new();
+        let owned = make_seal_result("my memory", 8, "me");
+        let hash = owned.glyph.glyph_hash.clone();
+        let remote_copy = owned.glyph.clone();
+        store.insert(owned); // we own it (openings: Some)
+
+        store.insert_remote(remote_copy); // peer echoes the same hash back
+
+        let stored = store.get(&hash).unwrap();
+        assert!(
+            stored.openings.is_some(),
+            "owned glyph openings must survive a remote insert of the same hash"
+        );
     }
 
     #[test]

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -104,7 +104,18 @@ impl CliffordElement {
                 }
             }
         }
-        
+
+        // Metric contraction. In Cl₀,₇ every basis vector squares to eᵢ² = −1
+        // (signature 0,7). Each basis vector shared by both blades becomes an
+        // adjacent eᵢeᵢ pair after the reordering above and contracts to that
+        // −1 scalar (the XOR has already removed the bit from `result`). Folding
+        // in one −1 per shared vector is what makes this Cl₀,₇ rather than the
+        // Euclidean Cl₇,₀ — without it e1·e1 returned +1 instead of −1, so the
+        // inner product silently used the wrong metric.
+        if (blade_a & blade_b).count_ones() % 2 == 1 {
+            sign = -sign;
+        }
+
         (result, sign)
     }
 
@@ -1005,6 +1016,33 @@ mod tests {
         let e1e2 = e1.geometric_product(&e2);
         let e2e1 = e2.geometric_product(&e1);
         assert!(e1e2.equals(&e2e1.scale(-1.0), EPSILON));
+    }
+
+    #[test]
+    fn test_clifford_negative_signature() {
+        // Cl₀,₇: every basis vector squares to −1 (signature 0,7), NOT +1.
+        // Regression guard for the metric-contraction sign in
+        // simplify_blade_merge.
+        for i in 1..=7u8 {
+            let ei = CliffordElement::basis_vector(i);
+            let sq = ei.geometric_product(&ei);
+            assert!(
+                (sq.scalar_part() - (-1.0)).abs() < EPSILON,
+                "e{}·e{} must equal −1 in Cl₀,₇, got {}",
+                i, i, sq.scalar_part()
+            );
+        }
+
+        // A bivector also squares to −1: (e1 e2)² = e1 e2 e1 e2 = −1.
+        let e1 = CliffordElement::basis_vector(1);
+        let e2 = CliffordElement::basis_vector(2);
+        let e12 = e1.geometric_product(&e2);
+        let e12_sq = e12.geometric_product(&e12);
+        assert!(
+            (e12_sq.scalar_part() - (-1.0)).abs() < EPSILON,
+            "(e1 e2)² must equal −1, got {}",
+            e12_sq.scalar_part()
+        );
     }
 
     #[test]

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -242,9 +242,22 @@ impl HrmStore {
             }
         }
 
-        // Restore saved connections from previous cache state
-        for (id, conns) in saved_connections {
+        // Restore saved connections from previous cache state, dropping any
+        // link whose target was removed since the snapshot. rebuild_cache runs
+        // after every removal path (resonance-merge absorb + ShortTerm evict in
+        // apply_consolidation, ghost compaction, delete), and none of those
+        // paths strip inbound links from survivors — so without this filter a
+        // LegacyLink{ target_id } pointing at a merged/evicted/compacted memory
+        // would survive here, re-serialize to the *.links.json sidecar, and
+        // accumulate every dream. Dangling targets corrupt bridge-node
+        // detection and cross-cluster link counts (id_to_cluster.get on a dead
+        // id). The authoritative store is fully reflected in memory_cache at
+        // this point, so any target_id not present is genuinely gone.
+        let live: std::collections::HashSet<uuid::Uuid> =
+            self.memory_cache.keys().copied().collect();
+        for (id, mut conns) in saved_connections {
             if let Some(mem) = self.memory_cache.get_mut(&id) {
+                conns.retain(|l| live.contains(&l.target_id));
                 mem.connections = conns;
             }
         }
@@ -313,6 +326,19 @@ impl HrmStore {
         Ok(())
     }
 
+    /// Atomically write `bytes` to `path`: write a unique per-process temp file
+    /// then rename it over the target. A plain `fs::write` is not atomic — a
+    /// crash or a concurrent writer can leave a truncated file, and the sidecar
+    /// loaders (`load_link_graph`, `load_reactivation`) silently discard ALL
+    /// state when the JSON fails to parse. `rename` within the same directory
+    /// is atomic, so a reader always sees either the old or the new file whole.
+    fn atomic_write(path: &std::path::Path, bytes: &[u8]) {
+        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        if std::fs::write(&tmp, bytes).is_ok() && std::fs::rename(&tmp, path).is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+
     /// Save the link graph as a sidecar JSON file alongside the HRM file.
     fn save_link_graph(&self) {
         let links_path = self.hrm_path.with_extension("links.json");
@@ -322,7 +348,7 @@ impl HrmStore {
             .collect();
         if graph.is_empty() { return; }
         if let Ok(json) = serde_json::to_vec(&graph) {
-            let _ = std::fs::write(&links_path, json);
+            Self::atomic_write(&links_path, &json);
         }
     }
 
@@ -404,7 +430,7 @@ impl HrmStore {
             return;
         }
         if let Ok(json) = serde_json::to_vec(&merged) {
-            let _ = std::fs::write(&path, json);
+            Self::atomic_write(&path, &json);
         }
     }
 

--- a/src/kuramoto.rs
+++ b/src/kuramoto.rs
@@ -775,6 +775,28 @@ impl KuramotoSync {
             }
             normalize(&mut theme);
 
+            // If the members' vectors largely cancel, the bundle sums to ~0 and
+            // normalize leaves it all-zeros. This is reachable when a cluster is
+            // grouped by PHASE coupling rather than vector similarity — notably
+            // in decone mode (default), where edges are built on residual
+            // vectors so a connected component can contain members whose
+            // ORIGINAL vectors are anti-correlated. An all-zero theme_vector
+            // scores cosine 0 against every query (cosine_similarity returns 0
+            // for a zero norm), silently making the whole cluster unreachable by
+            // theme-routed recall. Fall back to the strongest member's vector —
+            // a guaranteed non-zero, representative anchor.
+            let theme_norm: f32 = theme.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if theme_norm < 1e-6 {
+                if let Some(strongest) = cluster_mems.iter().max_by(|a, b| {
+                    a.amplitude
+                        .partial_cmp(&b.amplitude)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                }) {
+                    theme = strongest.vector.clone();
+                    normalize(&mut theme);
+                }
+            }
+
             clusters.push(MemoryCluster {
                 memory_ids: cluster_mems.iter().map(|m| m.id).collect(),
                 order_parameter: r,

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -1116,7 +1116,13 @@ impl ChiralMedium {
         // Count paired wavefronts
         let paired = self.left_to_right.len();
 
-        // Count phase-locked pairs (|sin(Δφ)| < 0.1)
+        // Count phase-locked pairs: Δφ aligned to within ~0.1 rad.
+        //
+        // Must test cos(Δφ) > cos(0.1) ≈ 0.995, NOT |sin(Δφ)| < 0.1 — the
+        // latter is also satisfied near Δφ ≈ π (sin(π) = 0), so a perfectly
+        // ANTI-phased pair (the opposite of locked) was being counted as
+        // locked, over-reporting hemispheric coherence. cos disambiguates:
+        // it is near +1 only when the phases are genuinely aligned.
         let locked = self.left_to_right.iter()
             .filter(|(lid, rid)| {
                 let lp = self.left.id_to_index.get(lid)
@@ -1124,7 +1130,7 @@ impl ChiralMedium {
                 let rp = self.right.id_to_index.get(rid)
                     .map(|&i| self.right.phase[i]);
                 match (lp, rp) {
-                    (Some(l), Some(r)) => (r - l).sin().abs() < 0.1,
+                    (Some(l), Some(r)) => (r - l).cos() > 0.995,
                     _ => false,
                 }
             })

--- a/src/medium/core.rs
+++ b/src/medium/core.rs
@@ -635,9 +635,18 @@ impl Medium {
                 *x /= norm;
             }
         } else {
-            // Degenerate case - use average instead
-            for (a, b) in vec_a.iter().zip(vec_b.iter()) {
-                associative_vector.push((a + b) * 0.5);
+            // Degenerate case: vec_a ≈ -vec_b, so their sum — and its 0.5
+            // average, which is collinear with the sum — is ~0 and has no
+            // meaningful direction to normalize. Fall back to vec_a's
+            // direction as the association anchor.
+            //
+            // NOTE: the previous code *pushed* a second DIM-length run onto
+            // the already-full `associative_vector`, producing a 2×DIM vector
+            // that `add_wavefront` then rejected with DimensionMismatch — so
+            // relating two phase-opposed wavefronts always errored instead of
+            // forming an association. Overwrite in place to keep length == DIM.
+            for (slot, a) in associative_vector.iter_mut().zip(vec_a.iter()) {
+                *slot = *a;
             }
         }
 

--- a/src/medium/tests.rs
+++ b/src/medium/tests.rs
@@ -21,6 +21,37 @@ fn new_medium_is_empty() {
 }
 
 #[test]
+fn relate_phase_opposed_wavefronts_does_not_error() {
+    // Regression: when two wavefronts are near-exact negatives, their sum is
+    // ~0 and cannot be normalized into a direction. The degenerate branch must
+    // still produce a valid DIM-length associative wavefront and succeed.
+    // Previously it *pushed* a second DIM-length run onto the already-full
+    // buffer, yielding a 2×DIM vector that add_wavefront rejected with
+    // DimensionMismatch — so relating any phase-opposed pair always errored.
+    let mut medium = Medium::new();
+    let mut v = vec![0.0f32; WAVEFRONT_DIM];
+    v[0] = 1.0;
+    v[1] = -0.5;
+    v[2] = 0.3;
+    let neg: Vec<f32> = v.iter().map(|x| -x).collect();
+    medium.add_wavefront(&v, "pos".to_string(), 1.0).unwrap();
+    medium.add_wavefront(&neg, "neg".to_string(), 1.0).unwrap();
+    let before = medium.wavefront_count();
+
+    let res = medium.relate_wavefronts(0, 1);
+    assert!(
+        res.is_ok(),
+        "relating phase-opposed wavefronts must not error: {:?}",
+        res.err()
+    );
+    assert_eq!(
+        medium.wavefront_count(),
+        before + 1,
+        "the association wavefront must be added"
+    );
+}
+
+#[test]
 fn spiral_field_2d_separates_clusters_and_reports() {
     // ADR-0037 Phase 4b: the PCA embedding must place two orthogonal wavefront
     // clusters apart in the 2-D field, and the cloud report must run clean.


### PR DESCRIPTION
Autonomous bug-hunt/hardening pass off `master` (v0.7.9). Findings surfaced by four parallel review agents over the medium/consolidation, numerics, and swarm/IO surfaces; **every finding was verified by reading the code** before fixing (≈18 candidates triaged down to the 10 below — speculative and already-guarded ones discarded).

**Full suite green: 656 passed / 0 failed**, plus 4 new regression tests. `cargo build --all-features --all-targets` clean; clippy deny-level clean.

## Correctness / math
- **`medium/core.rs` — `relate_wavefronts`**: the degenerate (phase-opposed) branch *pushed* a second `DIM`-length run onto the already-full buffer → a `2×DIM` vector that `add_wavefront` rejected, so relating any near-opposite pair **always errored**. Overwrite in place. *(+test)*
- **`medium/chiral.rs` — `phase_locked_pairs`**: `|sin(Δφ)|<0.1` is also satisfied near `Δφ≈π`, so perfectly **anti-phased pairs counted as locked**, over-reporting hemispheric coherence. Now `cos(Δφ)>0.995`.
- **`geometry.rs` — `simplify_blade_merge`**: omitted the `eᵢ²=−1` metric sign for shared basis vectors, so `Cl₀,₇` silently behaved as Euclidean `Cl₇,₀` (`e1·e1` returned `+1`). Fold in `(−1)^popcount(a&b)`. *(+test)*
- **`bridge.rs` — `compute_modularity`**: counted edges with unclustered endpoints into `total_edges` but never into `cluster_degree` (the skip-link loop already guarded this) → Newman **Q biased high**. Count edges only when both endpoints are clustered.
- **`kuramoto.rs` — `find_synchronized_clusters`**: anti-correlated members sum to ~0, so `normalize` left an **all-zero `theme_vector`**, which scores cosine 0 against every query → the cluster becomes **unreachable by theme-routed recall** (reachable in decone mode, now default; relevant to the hub recall@1 anomaly). Fall back to the strongest member's vector.

## Graph integrity / durability
- **`hrm_store.rs` — `rebuild_cache`**: re-attached saved `connections` without checking the target still exists, so links to merged/evicted/compacted memories survived and **re-serialized to `*.links.json` every dream**, corrupting bridge-node detection. Retain only links whose target is live (covers every removal path).
- **`hrm_store.rs` — sidecar writes**: link + reactivation sidecars used a non-atomic `fs::write`; a torn file makes the loaders **silently discard all history**. Added `atomic_write` (temp + rename).

## Hardening (peer-facing)
- **`bin/handlers/swarm.rs`**: peer-supplied recall `top_k` was unbounded — an **OOM/DoS vector on the 1-core/6 GB hub**. Clamp to 100 (matches the `cores` handler's `truncate(1024)` posture).
- **`collective/glyph_store.rs` — `insert_remote`**: unconditionally overwrote a locally-**owned** glyph, wiping its `openings`/`proofs` on a hash collision (loss of the ability to open our own memory; peer-poison). Owned entry wins. *(+test)*
- **`collective/flux.rs` — `evaluate_pull`**: an empty/1-char peer tag made `focus.contains(tag)` vacuously true, forcing topical-relevance **pulls (pull-flood)**. Require a non-empty focus and tag length ≥ 3. *(+test)*

## Deferred (verified real, not in this PR)
Larger/riskier or lower-severity, tracked for follow-up: merge carriers discard absorbed members' `connections` (association loss — needs a union-onto-carrier design); `KANNAKA_GHOST_RETAIN_DAYS=0` same-cycle ghost deletion; recall `touch()` resetting the ghost recovery window; `merge.rs` idempotency double-count on bumped `sync_version`; hallucinated wavefronts lacking a `scales` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)