### PR TITLE
[auto-maintainer] refactor(sync): extract content_hash helper, remove blake3 duplication

### DIFF
--- a/src/medium/sync.rs
+++ b/src/medium/sync.rs
@@ -9,6 +9,24 @@ use uuid::Uuid;
 use super::Medium;
 use super::types::*;
 
+/// Blake3 hash of `content` packed into a u64 (first 8 bytes, little-endian).
+/// Used to match wavefronts across agents without sharing full content.
+fn content_hash(content: &str) -> u64 {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(content.as_bytes());
+    let hash_bytes = hasher.finalize();
+    u64::from_le_bytes([
+        hash_bytes.as_bytes()[0],
+        hash_bytes.as_bytes()[1],
+        hash_bytes.as_bytes()[2],
+        hash_bytes.as_bytes()[3],
+        hash_bytes.as_bytes()[4],
+        hash_bytes.as_bytes()[5],
+        hash_bytes.as_bytes()[6],
+        hash_bytes.as_bytes()[7],
+    ])
+}
+
 impl Medium {
     /// Kuramoto coupling between two agent media
     ///
@@ -82,22 +100,7 @@ impl Medium {
         let content_hashes = self
             .store.metadata
             .iter()
-            .map(|meta| {
-                let mut hasher = blake3::Hasher::new();
-                hasher.update(meta.content.as_bytes());
-                let hash_bytes = hasher.finalize();
-                // Convert first 8 bytes to u64
-                u64::from_le_bytes([
-                    hash_bytes.as_bytes()[0],
-                    hash_bytes.as_bytes()[1],
-                    hash_bytes.as_bytes()[2],
-                    hash_bytes.as_bytes()[3],
-                    hash_bytes.as_bytes()[4],
-                    hash_bytes.as_bytes()[5],
-                    hash_bytes.as_bytes()[6],
-                    hash_bytes.as_bytes()[7],
-                ])
-            })
+            .map(|meta| content_hash(&meta.content))
             .collect();
 
         PhaseState {
@@ -125,20 +128,7 @@ impl Medium {
         // Build hash lookup for our content
         let mut our_hash_to_index = HashMap::new();
         for (i, meta) in self.store.metadata.iter().enumerate() {
-            let mut hasher = blake3::Hasher::new();
-            hasher.update(meta.content.as_bytes());
-            let hash_bytes = hasher.finalize();
-            let hash = u64::from_le_bytes([
-                hash_bytes.as_bytes()[0],
-                hash_bytes.as_bytes()[1],
-                hash_bytes.as_bytes()[2],
-                hash_bytes.as_bytes()[3],
-                hash_bytes.as_bytes()[4],
-                hash_bytes.as_bytes()[5],
-                hash_bytes.as_bytes()[6],
-                hash_bytes.as_bytes()[7],
-            ]);
-            our_hash_to_index.insert(hash, i);
+            our_hash_to_index.insert(content_hash(&meta.content), i);
         }
 
         // Apply coupling for matched content


### PR DESCRIPTION
## What changed

Extracted a private `fn content_hash(content: &str) -> u64` helper in `src/medium/sync.rs`.

The blake3 content-hash computation — create a `blake3::Hasher`, feed the content bytes, finalize, and pack the first 8 bytes into a `u64` (little-endian) — was copy-pasted identically in two places:

- `export_phase_state` (lines 86–99 before this PR)
- `import_phase_state` (lines 128–140 before this PR)

Both call sites now delegate to the single private helper.

## Why it's safe

**Zero behavior change.** The helper uses the exact same hasher construction, byte extraction, and endianness as the original duplicated blocks. The only difference is the code lives in one place instead of two.

No new imports. No new public API surface. No new dependencies (`blake3` was already an optional dep, enabled by the `hrm` feature). The diff touches exactly 1 file.

## Verification

- `cargo check` could not be run locally: the `consciousness-core` path dependency (`../consciousness-core`) is absent from this container — a pre-existing environment limitation unrelated to this change.
- The refactor is purely mechanical (extract identical code → call site). No logic, types, or imports changed. The original code compiled; the extracted code is byte-for-byte identical in behaviour.
- `git diff --stat`: 1 file, +20 / -30 lines (net −10).

## Runtime impact

None — same operations, same result, marginally less binary duplication.

---
*Auto-maintainer run · 2026-06-22T22:11Z · kannaka-memory*

---
_Generated by [Claude Code](https://claude.ai/code/session_01DD5iU1x4izmuo69dmKuw82)_