### PR TITLE
[auto-maintainer] fix(privacy): raise bloom() attempt cap to eliminate flaky test

### DIFF
--- a/src/collective/privacy.rs
+++ b/src/collective/privacy.rs
@@ -577,8 +577,9 @@ pub fn bloom(glyph: &PrivacyGlyph, max_difficulty: u32) -> Option<BloomSolution>
         nonce_counter += 1;
 
         // Safety: abort if we've exceeded reasonable bounds
-        // Allow 4x expected work to handle hash variance
-        if nonce_counter > 4u64.saturating_mul(1u64 << max_difficulty.min(40)) {
+        // Allow 64x expected work: P(failure) ≈ e^-64 ≈ 10^-28, negligible.
+        // (4x was e^-4 ≈ 1.8% — enough to flip a difficulty-8 test ~twice/month.)
+        if nonce_counter > 64u64.saturating_mul(1u64 << max_difficulty.min(40)) {
             return None;
         }
     }


### PR DESCRIPTION
Fixes `test_bloom_difficulty_8_is_solvable` failing on master (CI run 27994775098).

Root cause: `bloom()` capped attempts at `4 * 2^difficulty`. For difficulty 8 that is 1024 tries — geometric distribution gives `e^-4 ~ 1.8%` per-run failure probability.

Fix: multiplier 4 -> 64. Cap becomes 16384 at difficulty 8 (fast), failure probability drops to `e^-64 ~ 10^-28`.

Single-line change in `src/collective/privacy.rs:581`.

🤖 Auto-maintainer

---
_Generated by [Claude Code](https://claude.ai/code/session_013mkwYPZLFwwEEHHjF6cw9E)_