### PR TITLE
[auto-maintainer] fix(sync): guard import_phase_state against malformed PhaseState

### DIFF
--- a/src/medium/sync.rs
+++ b/src/medium/sync.rs
@@ -134,9 +134,12 @@ impl Medium {
         // Apply coupling for matched content
         for (remote_idx, &remote_hash) in remote.content_hashes.iter().enumerate() {
             if let Some(&our_idx) = our_hash_to_index.get(&remote_hash) {
-                // Found matching content - apply Kuramoto coupling
-                let remote_phase = remote.phases[remote_idx];
-                let remote_energy = remote.energies[remote_idx];
+                // Found matching content - apply Kuramoto coupling.
+                // Use .get() instead of direct indexing: PhaseState is Deserialize and
+                // travels over the network, so malformed payloads (version skew, truncation)
+                // could have content_hashes longer than phases/energies.
+                let Some(&remote_phase) = remote.phases.get(remote_idx) else { continue };
+                let Some(&remote_energy) = remote.energies.get(remote_idx) else { continue };
                 let phase_diff = remote_phase - self.store.phase[our_idx];
 
                 // Apply phase coupling


### PR DESCRIPTION
## Summary

`import_phase_state` in `src/medium/sync.rs` performed direct index access into `remote.phases[remote_idx]` and `remote.energies[remote_idx]` using an index derived from iterating `remote.content_hashes`. Since `PhaseState` is `#[derive(Serialize, Deserialize)]` and arrives over the gossip network from remote agents, a malformed payload (version skew, wire truncation, or agent ID collision) where `content_hashes.len() > phases.len()` would panic the receiving agent at runtime.

## Change (2 lines)

```rust
// Before
let remote_phase = remote.phases[remote_idx];
let remote_energy = remote.energies[remote_idx];

// After
let Some(&remote_phase) = remote.phases.get(remote_idx) else { continue };
let Some(&remote_energy) = remote.energies.get(remote_idx) else { continue };
```

Malformed remote entries are now silently skipped rather than crashing the process. This matches the defensive-skip pattern used elsewhere in the sync loop.

## Why this is safe

- `PhaseState` is a deserialized network struct — its internal invariants cannot be guaranteed
- Skipping a mismatched entry is correct: the local agent simply won't import that phase pairing this round; on the next gossip cycle, if the remote recovers, the entry will arrive with consistent lengths and be processed normally
- No local state is mutated before the bounds check, so skipping is clean and idempotent
- Existing tests pass unchanged; no new test surface is introduced (the fix is a guard, not logic)

## Files changed

- `src/medium/sync.rs` — 2 lines, `import_phase_state` function only

## Verification

- Diff is ≤ 3 files, ≤ 150 lines (2 lines changed)
- No secrets, no lockfile changes, no workflow changes, no dependency bumps

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ms1kaNWcJ5pa6dTVuiromV)_