### PR TITLE
[auto-maintainer] fix(substrate): clamp peer-supplied top_k to prevent OOM/DoS

### DIFF
--- a/src/bin/handlers/substrate.rs
+++ b/src/bin/handlers/substrate.rs
@@ -669,7 +669,7 @@ pub(crate) fn handle_substrate_run(
                 let req: serde_json::Value = serde_json::from_slice(&msg.payload)
                     .unwrap_or(serde_json::Value::Null);
                 let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("");
-                let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8) as usize;
+                let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8).min(100) as usize;
                 if !query.is_empty() && reply_to.is_some() {
                     // Use the attention-beam prefilter (token-overlap → top
                     // candidates → resonance against beam only) so the recall


### PR DESCRIPTION
## Summary

`handle_substrate_run` in `src/bin/handlers/substrate.rs` (line 672) parsed `top_k` from the incoming NATS payload on `KANNAKA.substrate.recall` without an upper-bound clamp:

```rust
// Before (line 672) — no ceiling
let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8) as usize;
```

A peer (or adversary on the mesh) could send `{"query": "x", "top_k": 4000000000}` to the substrate daemon and trigger an OOM-killing allocation on the 1-core/6 GB hub. The substrate's 750+ wavefront HRM would attempt to build a result vector of 4 billion entries.

PR #439 fixed the identical pattern in `swarm.rs` (line 187, `KANNAKA.swarm.recall`) by adding `.min(100)`. This PR applies the same fix to `substrate.rs`, which was missed in that pass.

## Change (1 line)

```rust
// After
let top_k = req.get("top_k").and_then(|v| v.as_u64()).unwrap_or(8).min(100) as usize;
```

## Why this is safe

- `.min(100)` is a pure arithmetic clamp with no state side-effects
- 100 matches is more than any legitimate caller would need from a collective recall
- The same cap is already enforced in `swarm.rs`; this restores parity
- No local state is read before the clamp, so ordering doesn't matter
- Default of 8 is unchanged; the cap only fires on an explicit oversized request

## Files changed

- `src/bin/handlers/substrate.rs` — 1 line, `handle_substrate_run` collective-recall handler only

## Verification

- Diff is 1 file, 1 line changed
- No secrets, no lockfile changes, no workflow changes, no dependency bumps
- Pattern is identical to the already-merged fix in `swarm.rs` (PR #439 line 187)
- `cargo check` blocked by missing path deps (`consciousness-core`, `kannaka-attention`) in this environment; change is syntactically trivial — a method call on `u64` that has been in stable Rust since 1.0

🤖 Auto-maintainer

---
_Generated by [Claude Code](https://claude.ai/code/session_018yVNdZ1VzUgN4B7pfauXb4)_