### PR TITLE
release: v0.8.3 — FIFO size cap + slim export (fix unbounded-growth OOM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ the belief substrate). `kannaka export-json` then loaded every memory's full
 10k-dim vector into a serde tree — multiple GB on a 3000+ memory field — which
 repeatedly OOM-killed the radio on the 1-core/6 GB box.
 
-- **`triage --max-total N`** — a hard FIFO size cap: evict the oldest-created,
-  non-Pinned memories until the field is ≤ N. Lightweight (O(n log n), no O(n²)
-  cosine scan), safe to run hourly from prune-cron as a growth backstop
-  regardless of value-based triage. `--apply` to persist; Pinned never evicted.
+- **`triage --max-total N`** — a hard size cap: evict the LOWEST-VALUE
+  (effective-strength) non-Pinned memories until the field is ≤ N. Mirrors what
+  dream annealing is meant to do (let the weakest memories fade) — a backstop
+  for when consolidation can't reclaim (it is dry-run under the belief
+  substrate). Lightweight (O(n log n), no O(n²) cosine scan), safe to run hourly
+  from prune-cron. `--apply` to persist; Pinned never evicted; strong/recalled
+  memories kept regardless of age.
 - **`export-json --slim`** — omit the per-memory `vector`/`xi_signature`/
   `geometry` (the 10k-dim vector is ~99% of the size). Metadata-only consumers
   (the observatory's `/api/hrm/memories`) MUST use `--slim` so the export can't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-06-28
+
+### Fixed — unbounded HRM growth OOMing the hub
+
+The hub field grew without bound (~150 memories/day from the always-on
+research/curiosity/engagement crons while consolidation sits in dry-run under
+the belief substrate). `kannaka export-json` then loaded every memory's full
+10k-dim vector into a serde tree — multiple GB on a 3000+ memory field — which
+repeatedly OOM-killed the radio on the 1-core/6 GB box.
+
+- **`triage --max-total N`** — a hard FIFO size cap: evict the oldest-created,
+  non-Pinned memories until the field is ≤ N. Lightweight (O(n log n), no O(n²)
+  cosine scan), safe to run hourly from prune-cron as a growth backstop
+  regardless of value-based triage. `--apply` to persist; Pinned never evicted.
+- **`export-json --slim`** — omit the per-memory `vector`/`xi_signature`/
+  `geometry` (the 10k-dim vector is ~99% of the size). Metadata-only consumers
+  (the observatory's `/api/hrm/memories`) MUST use `--slim` so the export can't
+  balloon to GBs and OOM the box.
+
 ## [0.7.10] — 2026-06-22
 
 ### Fixed — hardening pass: 15 verified bug fixes (#439, #440)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1734,6 +1734,7 @@ fn main() {
             // Phase-1 reach (Pinned is never evicted either way).
             let mut apply = false;
             let mut include_long_term = false;
+            let mut max_total: Option<usize> = None;
             let mut params = kannaka_memory::openclaw::TriageParams {
                 redundancy: cfg.triage.redundancy,
                 min_amplitude: cfg.triage.min_amplitude,
@@ -1776,6 +1777,10 @@ fn main() {
                             params.max_evict = args[i + 1].parse().unwrap_or(params.max_evict);
                             i += 2;
                         }
+                        "--max-total" if i + 1 < args.len() => {
+                            max_total = args[i + 1].parse().ok();
+                            i += 2;
+                        }
                         other => {
                             eprintln!("[triage] ignoring unknown arg: {other}");
                             i += 1;
@@ -1784,6 +1789,32 @@ fn main() {
                 }
             }
             params.include_long_term = include_long_term;
+
+            // Hard FIFO size cap (`--max-total N`). A lightweight, predictable
+            // backstop against unbounded growth: evict the oldest-created
+            // non-Pinned memories until the field is <= N. Runs WITHOUT the
+            // O(n²) redundancy cosine scan below, so it is cheap enough for the
+            // hourly prune-cron on the 1-core hub. Takes precedence — when set,
+            // this is the whole operation.
+            if let Some(cap) = max_total {
+                let ids = sys.fifo_overflow_ids(cap);
+                println!(
+                    "[triage] FIFO cap: {} memories over max-total={cap} (oldest-created, non-pinned){}",
+                    ids.len(),
+                    if apply { "" } else { " (dry-run — pass --apply to forget)" }
+                );
+                if apply && !ids.is_empty() {
+                    warn_if_readonly("triage --max-total --apply");
+                    match sys.triage_forget(&ids) {
+                        Ok(n) => println!("[triage] FIFO-evicted={n} (oldest first; pinned protected)"),
+                        Err(e) => {
+                            eprintln!("Failed to persist HRM after FIFO cap: {e}");
+                            process::exit(1);
+                        }
+                    }
+                }
+                return;
+            }
 
             let sel = sys.triage_select(&params);
             println!(
@@ -3074,6 +3105,13 @@ fn main() {
             println!("Status announced to Flux.");
         }
         "export-json" => {
+            // `--slim` omits the per-memory hypervector, xi_signature, and
+            // geometry — the 10k-dim `vector` is ~99% of the output size, so on
+            // a multi-thousand-memory field the full export balloons a
+            // serde_json::Value tree + string to multiple GB and OOMs the 6 GB
+            // hub (it took the radio down repeatedly). Callers that only need
+            // metadata (the observatory's /api/hrm/memories) MUST use --slim.
+            let slim = args[command_start..].iter().any(|a| a == "--slim");
             let all_mems = sys
                 .engine
                 .store
@@ -3086,7 +3124,7 @@ fn main() {
             let output: Vec<serde_json::Value> = all_mems
                 .iter()
                 .map(|m| {
-                    serde_json::json!({
+                    let mut obj = serde_json::json!({
                         "id": m.id.to_string(),
                         "content": m.content,
                         "amplitude": m.amplitude,
@@ -3097,9 +3135,6 @@ fn main() {
                         "layer_depth": m.layer_depth,
                         "hallucinated": m.hallucinated,
                         "parents": m.parents,
-                        "vector": m.vector,
-                        "xi_signature": m.xi_signature,
-                        "geometry": m.geometry,
                         "connections": m.connections.iter().map(|c| {
                             serde_json::json!({
                                 "target_id": c.target_id.to_string(),
@@ -3107,7 +3142,15 @@ fn main() {
                                 "span": c.span
                             })
                         }).collect::<Vec<_>>()
-                    })
+                    });
+                    if !slim {
+                        if let Some(map) = obj.as_object_mut() {
+                            map.insert("vector".into(), serde_json::json!(m.vector));
+                            map.insert("xi_signature".into(), serde_json::json!(m.xi_signature));
+                            map.insert("geometry".into(), serde_json::json!(m.geometry));
+                        }
+                    }
+                    obj
                 })
                 .collect();
             println!("{}", serde_json::to_string(&output).unwrap());

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1790,25 +1790,27 @@ fn main() {
             }
             params.include_long_term = include_long_term;
 
-            // Hard FIFO size cap (`--max-total N`). A lightweight, predictable
-            // backstop against unbounded growth: evict the oldest-created
-            // non-Pinned memories until the field is <= N. Runs WITHOUT the
-            // O(n²) redundancy cosine scan below, so it is cheap enough for the
-            // hourly prune-cron on the 1-core hub. Takes precedence — when set,
-            // this is the whole operation.
+            // Hard size cap (`--max-total N`). A lightweight, predictable
+            // backstop against unbounded growth: evict the LOWEST-VALUE
+            // (effective-strength) non-Pinned memories until the field is <= N
+            // — the weak chaff annealing would dissolve, keeping strong/recalled
+            // memories regardless of age. Runs WITHOUT the O(n²) redundancy
+            // cosine scan below, so it is cheap enough for the hourly prune-cron
+            // on the 1-core hub. Takes precedence — when set, this is the whole
+            // operation.
             if let Some(cap) = max_total {
-                let ids = sys.fifo_overflow_ids(cap);
+                let ids = sys.lowest_value_overflow_ids(cap);
                 println!(
-                    "[triage] FIFO cap: {} memories over max-total={cap} (oldest-created, non-pinned){}",
+                    "[triage] size cap: {} lowest-value memories over max-total={cap} (non-pinned){}",
                     ids.len(),
                     if apply { "" } else { " (dry-run — pass --apply to forget)" }
                 );
                 if apply && !ids.is_empty() {
                     warn_if_readonly("triage --max-total --apply");
                     match sys.triage_forget(&ids) {
-                        Ok(n) => println!("[triage] FIFO-evicted={n} (oldest first; pinned protected)"),
+                        Ok(n) => println!("[triage] evicted={n} (lowest effective-strength first; pinned protected)"),
                         Err(e) => {
-                            eprintln!("Failed to persist HRM after FIFO cap: {e}");
+                            eprintln!("Failed to persist HRM after size cap: {e}");
                             process::exit(1);
                         }
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,7 +233,7 @@ EXAMPLE:
         ))
         .subcommand(passthrough("relate", "Find semantically related memories"))
         // Memory-tier ops + ADR-0031 triage (previously absent from --help).
-        .subcommand(passthrough("triage", "Evict redundant short-term memories (ADR-0031 Ξ-preserving prune; config [triage]). --max-total N: hard FIFO size cap (evict oldest non-pinned over N; --apply to persist)"))
+        .subcommand(passthrough("triage", "Evict redundant short-term memories (ADR-0031 Ξ-preserving prune; config [triage]). --max-total N: hard size cap (evict lowest effective-strength non-pinned memories over N; --apply to persist)"))
         .subcommand(passthrough("promote", "Promote a memory to the long-term tier (by id)"))
         .subcommand(passthrough("pin", "Pin a memory to the Pinned tier — never evicted by consolidation (by id)"))
         .subcommand(passthrough("demote", "Demote a memory to the short-term tier (by id)"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,7 +233,7 @@ EXAMPLE:
         ))
         .subcommand(passthrough("relate", "Find semantically related memories"))
         // Memory-tier ops + ADR-0031 triage (previously absent from --help).
-        .subcommand(passthrough("triage", "Evict redundant short-term memories (ADR-0031 Ξ-preserving prune; config [triage])"))
+        .subcommand(passthrough("triage", "Evict redundant short-term memories (ADR-0031 Ξ-preserving prune; config [triage]). --max-total N: hard FIFO size cap (evict oldest non-pinned over N; --apply to persist)"))
         .subcommand(passthrough("promote", "Promote a memory to the long-term tier (by id)"))
         .subcommand(passthrough("pin", "Pin a memory to the Pinned tier — never evicted by consolidation (by id)"))
         .subcommand(passthrough("demote", "Demote a memory to the short-term tier (by id)"))
@@ -387,7 +387,7 @@ EXAMPLE:
         .subcommand(passthrough("orchestrate", "Multi-step orchestration (legacy alias for ask --plan)"))
         .subcommand(passthrough("config", "Inspect / modify ~/.kannaka/config.toml"))
         .subcommand(passthrough("export", "Export all memories as JSON"))
-        .subcommand(passthrough("export-json", "Stream every wavefront as NDJSON to stdout (heavy)"))
+        .subcommand(passthrough("export-json", "Dump all memories as JSON to stdout. HEAVY: the full vectors are ~99% of the size and balloon to multiple GB on a large field. Use --slim (omit vector/xi_signature/geometry) for metadata-only consumers."))
         .subcommand(passthrough("import", "Import memories from a JSON file"))
         .subcommand(passthrough("import-json", "Import NDJSON wavefronts"))
         // `migrate` was the Dolt→HRM path; removed in v0.6.5 along

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -644,17 +644,23 @@ impl KannakaMemorySystem {
         Ok(n)
     }
 
-    /// Hard FIFO size cap. Returns the oldest-created, NON-Pinned memory ids
-    /// that exceed `max_total`, so the field can be bounded "regardless" of the
-    /// value-based ADR-0031 triage — a backstop against unbounded growth from
-    /// the always-on research/curiosity/engagement crons outpacing
-    /// consolidation (which is gated to dry-run under the belief substrate).
+    /// Hard size cap that evicts the LOWEST-VALUE memories. Returns the
+    /// NON-Pinned memory ids with the smallest effective strength (the system's
+    /// own recall salience: decayed amplitude + retrieval boost) needed to bring
+    /// the field down to `max_total`.
     ///
-    /// Lightweight: O(n log n) sort by created_at, no O(n²) cosine scan, so it
-    /// is safe to run hourly on the 1-core hub. Pinned memories are never
-    /// evicted; if the non-pinned pool is smaller than the overflow, it evicts
-    /// as many as it can (the floor is the pinned count).
-    pub fn fifo_overflow_ids(&self, max_total: usize) -> Vec<Uuid> {
+    /// This mirrors what dream annealing is *meant* to do — let the
+    /// lowest-energy memories fade — as a backstop for when consolidation can't
+    /// reclaim (notably while it is gated to dry-run under the belief
+    /// substrate), so the always-on research/curiosity/engagement crons can't
+    /// grow the field without bound. Evicting by value, not age, keeps strong
+    /// and frequently-recalled memories (including old foundational ones) and
+    /// drops the weak chaff first.
+    ///
+    /// Lightweight: O(n log n) sort, no O(n²) cosine scan — safe to run hourly
+    /// on the 1-core hub. Pinned memories are never evicted; if the non-pinned
+    /// pool is smaller than the overflow, it evicts as many as it can.
+    pub fn lowest_value_overflow_ids(&self, max_total: usize) -> Vec<Uuid> {
         use crate::medium::types::Tier;
         let all = match self.engine.store.all_memories() {
             Ok(a) => a,
@@ -664,10 +670,16 @@ impl KannakaMemorySystem {
             return Vec::new();
         }
         let overflow = all.len() - max_total;
+        let now = Utc::now();
         let mut evictable: Vec<&crate::memory::HyperMemory> =
             all.iter().filter(|m| m.tier != Tier::Pinned).copied().collect();
-        // Oldest first (FIFO).
-        evictable.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        // Lowest effective strength first — the weakest / least-salient
+        // memories, exactly what annealing would dissolve. NaN-safe ordering.
+        evictable.sort_by(|a, b| {
+            a.effective_strength(now)
+                .partial_cmp(&b.effective_strength(now))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         evictable.into_iter().take(overflow).map(|m| m.id).collect()
     }
 
@@ -1617,20 +1629,20 @@ mod tests {
     }
 
     #[test]
-    fn fifo_overflow_caps_to_max_total() {
-        let dir = temp_dir("fifo");
+    fn lowest_value_cap_bounds_to_max_total() {
+        let dir = temp_dir("cap");
         let mut sys = KannakaMemorySystem::init(dir.clone()).unwrap();
         for i in 0..5 {
             sys.remember(&format!("memory number {i}")).unwrap();
         }
         assert_eq!(sys.stats().total_memories, 5);
-        // Overflow = total - cap (oldest-created, non-pinned).
-        assert_eq!(sys.fifo_overflow_ids(3).len(), 2, "5 memories, cap 3 → 2 over");
-        assert_eq!(sys.fifo_overflow_ids(5).len(), 0, "at cap → nothing over");
-        assert_eq!(sys.fifo_overflow_ids(10).len(), 0, "under cap → nothing over");
-        assert_eq!(sys.fifo_overflow_ids(0).len(), 5, "cap 0 (none pinned) → all evictable");
+        // Overflow = total - cap (lowest effective-strength, non-pinned).
+        assert_eq!(sys.lowest_value_overflow_ids(3).len(), 2, "5 memories, cap 3 → 2 over");
+        assert_eq!(sys.lowest_value_overflow_ids(5).len(), 0, "at cap → nothing over");
+        assert_eq!(sys.lowest_value_overflow_ids(10).len(), 0, "under cap → nothing over");
+        assert_eq!(sys.lowest_value_overflow_ids(0).len(), 5, "cap 0 (none pinned) → all evictable");
         // Applying the cap actually bounds the field.
-        let ids = sys.fifo_overflow_ids(2);
+        let ids = sys.lowest_value_overflow_ids(2);
         let n = sys.triage_forget(&ids).unwrap();
         assert_eq!(n, 3);
         assert_eq!(sys.stats().total_memories, 2, "field hard-bounded to max_total");

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -644,6 +644,33 @@ impl KannakaMemorySystem {
         Ok(n)
     }
 
+    /// Hard FIFO size cap. Returns the oldest-created, NON-Pinned memory ids
+    /// that exceed `max_total`, so the field can be bounded "regardless" of the
+    /// value-based ADR-0031 triage — a backstop against unbounded growth from
+    /// the always-on research/curiosity/engagement crons outpacing
+    /// consolidation (which is gated to dry-run under the belief substrate).
+    ///
+    /// Lightweight: O(n log n) sort by created_at, no O(n²) cosine scan, so it
+    /// is safe to run hourly on the 1-core hub. Pinned memories are never
+    /// evicted; if the non-pinned pool is smaller than the overflow, it evicts
+    /// as many as it can (the floor is the pinned count).
+    pub fn fifo_overflow_ids(&self, max_total: usize) -> Vec<Uuid> {
+        use crate::medium::types::Tier;
+        let all = match self.engine.store.all_memories() {
+            Ok(a) => a,
+            Err(_) => return Vec::new(),
+        };
+        if all.len() <= max_total {
+            return Vec::new();
+        }
+        let overflow = all.len() - max_total;
+        let mut evictable: Vec<&crate::memory::HyperMemory> =
+            all.iter().filter(|m| m.tier != Tier::Pinned).copied().collect();
+        // Oldest first (FIFO).
+        evictable.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        evictable.into_iter().take(overflow).map(|m| m.id).collect()
+    }
+
     /// ADR-0031 Phase 2b: capture the current amplitude of every short-term
     /// memory, keyed by id. Used to detect dream-strengthening for promotion.
     fn snapshot_short_term_amplitudes(&self) -> std::collections::HashMap<Uuid, f32> {
@@ -1586,6 +1613,27 @@ mod tests {
         sys.remember("memory two").unwrap();
         let report = sys.dream().unwrap();
         assert!(report.cycles > 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fifo_overflow_caps_to_max_total() {
+        let dir = temp_dir("fifo");
+        let mut sys = KannakaMemorySystem::init(dir.clone()).unwrap();
+        for i in 0..5 {
+            sys.remember(&format!("memory number {i}")).unwrap();
+        }
+        assert_eq!(sys.stats().total_memories, 5);
+        // Overflow = total - cap (oldest-created, non-pinned).
+        assert_eq!(sys.fifo_overflow_ids(3).len(), 2, "5 memories, cap 3 → 2 over");
+        assert_eq!(sys.fifo_overflow_ids(5).len(), 0, "at cap → nothing over");
+        assert_eq!(sys.fifo_overflow_ids(10).len(), 0, "under cap → nothing over");
+        assert_eq!(sys.fifo_overflow_ids(0).len(), 5, "cap 0 (none pinned) → all evictable");
+        // Applying the cap actually bounds the field.
+        let ids = sys.fifo_overflow_ids(2);
+        let n = sys.triage_forget(&ids).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(sys.stats().total_memories, 2, "field hard-bounded to max_total");
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Fixes the hub OOM/death-spiral: the HRM grew unbounded (~150 mem/day from the always-on crons; consolidation dry-run under belief reclaims nothing), and `export-json` loaded every memory's full 10k-dim vector → multi-GB → OOM-killed the radio repeatedly on the 1-core/6GB box.

- **`triage --max-total N`** — hard FIFO size cap (evict oldest-created non-Pinned over N). Lightweight O(n log n), no O(n²) cosine scan; safe to run hourly from prune-cron as a growth backstop. `--apply` to persist; Pinned never evicted. (+regression test)
- **`export-json --slim`** — omit per-memory vector/xi_signature/geometry (~99% of the size) so metadata-only consumers (observatory `/api/hrm/memories`) can't OOM the box.

Diagnosis confirmed not an attack and not a bad commit — the dream/consolidation core is unchanged since v0.7.10; it's pure field-growth crossing the box's memory ceiling.