### PR TITLE
release: v0.8.4 — the dream self-bounds the field (KANNAKA_MAX_MEMORIES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.8.4] — 2026-06-28
+
+### Added — the dream self-bounds the field (KANNAKA_MAX_MEMORIES)
+
+Makes growth-bounding part of annealing itself, instead of a separate cron step.
+When `KANNAKA_MAX_MEMORIES` is set (>0), `dream()` evicts the lowest
+effective-strength (weakest / least-salient) non-Pinned memories down to the cap
+as its FINAL step — after it has strengthened the memories worth keeping, so it
+only sheds the post-anneal weakest. This is the energy-minimization the system
+was designed to do via consolidation, made to actually reclaim even while the
+resonance-merge is gated to dry-run under the belief substrate. Default
+(unset/0) is a no-op; Pinned never evicted. The Oracle dream-cron sets
+`KANNAKA_MAX_MEMORIES=2000`, replacing the standalone `triage --max-total` step.
+
 ## [0.8.3] — 2026-06-28
 
 ### Fixed — unbounded HRM growth OOMing the hub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -880,6 +880,33 @@ impl KannakaMemorySystem {
             eprintln!("[dream] promoted {} strengthened short-term memory(ies) → long-term", promoted);
         }
 
+        // Self-bounding size cap — the dream's own growth backstop. When
+        // KANNAKA_MAX_MEMORIES is set (>0), evict the lowest effective-strength
+        // (weakest / least-salient) non-Pinned memories down to the cap. This is
+        // the energy-minimization annealing is *meant* to do, made to actually
+        // reclaim even while the resonance-merge consolidation is gated to
+        // dry-run under the belief substrate (so the always-on research/
+        // curiosity/engagement crons can't grow the field without bound). It
+        // runs LAST — after the dream has strengthened the memories worth
+        // keeping — so it only sheds the post-anneal weakest. Default (unset/0)
+        // is a no-op; Pinned is never evicted.
+        if let Some(max_total) = std::env::var("KANNAKA_MAX_MEMORIES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+        {
+            let ids = self.lowest_value_overflow_ids(max_total);
+            if !ids.is_empty() {
+                match self.triage_forget(&ids) {
+                    Ok(n) if n > 0 => eprintln!(
+                        "[dream] size cap (max={}): evicted {} lowest effective-strength memory(ies)",
+                        max_total, n),
+                    Ok(_) => {}
+                    Err(e) => eprintln!("[dream] size cap failed: {e}"),
+                }
+            }
+        }
+
         let emerged = after.consciousness_level.ordinal() > before.consciousness_level.ordinal();
 
         if self.auto_save {


### PR DESCRIPTION
Follow-up to v0.8.3: integrates the value-based size cap **into the dream itself**, so annealing bounds the field on its own (Nick's ask) instead of a separate cron step.

When `KANNAKA_MAX_MEMORIES` is set (>0), `dream()` evicts the **lowest effective-strength** (weakest/least-salient) non-Pinned memories down to the cap as its FINAL step — after the dream has strengthened the memories worth keeping, so it only sheds the post-anneal weakest. This is the energy-minimization the system was designed to do via consolidation, made to actually reclaim even while the resonance-merge stays gated to dry-run under belief (the safe path — re-enabling the merge is what lost 295→82).

Default (unset/0) = no-op; Pinned never evicted. The Oracle dream-cron will set `KANNAKA_MAX_MEMORIES=2000`, replacing the standalone `triage --max-total` step from v0.8.3.