### PR TITLE
feat(agent): qBraid Lab / infrastructure tools (v0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/bin/handlers/agent.rs
+++ b/src/bin/handlers/agent.rs
@@ -28,6 +28,7 @@
 use kannaka_memory::agent::{self, AgentError, ContentBlock, Message, Tool};
 use kannaka_memory::coding_tools::{self, ToolCtx};
 use kannaka_memory::quantum_tools;
+use kannaka_memory::lab_tools;
 use kannaka_memory::openclaw::KannakaMemorySystem;
 use serde_json::{json, Value};
 use std::io::{BufRead, Write};
@@ -92,9 +93,39 @@ fn is_memory_tool(name: &str) -> bool {
 /// Decide whether a tool call may run. Read-only coding tools and all memory
 /// tools run freely; filesystem/shell mutations follow the permission mode.
 fn decide(mode: Mode, name: &str, allowlist: &std::collections::HashSet<String>, key: &str) -> Decision {
-    if coding_tools::is_read_only(name) || is_memory_tool(name) || quantum_tools::is_quantum_tool(name) {
+    if coding_tools::is_read_only(name) || is_memory_tool(name) || quantum_tools::is_quantum_tool(name)
+        || lab_tools::is_lab_readonly_tool(name)
+    {
         // Quantum tools run on qBraid, not the local machine — never gated.
+        // Lab read-only tools (credits/list/status) cost nothing and mutate
+        // nothing, so they're auto-allowed too.
         return Decision::Allow;
+    }
+    if lab_tools::is_lab_tool(name) {
+        if lab_tools::is_lab_paid_tool(name) {
+            // Real money, open-ended per-minute billing: NEVER auto-approve —
+            // not in yolo, and not via a persisted allowlist entry. Every paid
+            // launch needs a fresh human OK (plan refuses outright). This is the
+            // one class of action where yolo does not blanket-approve.
+            return match mode {
+                Mode::Plan => Decision::Deny("plan mode — propose the action instead of running it"),
+                _ => Decision::Ask,
+            };
+        }
+        // Free lab mutations (env/kernel lifecycle, stop/down). These must NOT
+        // ride the coding-edit auto-approve path; gate them like edits: ask
+        // (unless allowlisted), deny in plan, allow in yolo.
+        return match mode {
+            Mode::Yolo => Decision::Allow,
+            Mode::Plan => Decision::Deny("plan mode — propose the action instead of running it"),
+            _ => {
+                if allowlist.contains(key) {
+                    Decision::Allow
+                } else {
+                    Decision::Ask
+                }
+            }
+        };
     }
     // name is now a mutating coding tool: write_file | edit_file | bash
     match mode {
@@ -118,6 +149,15 @@ fn decide(mode: Mode, name: &str, allowlist: &std::collections::HashSet<String>,
 fn allow_key(name: &str, input: &Value) -> String {
     if name == "bash" {
         format!("bash:{}", input.get("command").and_then(|v| v.as_str()).unwrap_or(""))
+    } else if lab_tools::is_lab_paid_tool(name) {
+        // Scope "allow always" for paid compute to the specific profile/instance
+        // so blessing one launch doesn't bless every future paid launch.
+        let target = input
+            .get("profile")
+            .or_else(|| input.get("instance_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        format!("{name}:{target}")
     } else {
         name.to_string()
     }
@@ -127,6 +167,24 @@ fn tool_summary(name: &str, input: &Value) -> String {
     match name {
         "bash" => input.get("command").and_then(|v| v.as_str()).unwrap_or("").to_string(),
         "write_file" | "edit_file" => input.get("file_path").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        _ if lab_tools::is_lab_tool(name) => {
+            // Show the salient target (profile / slug / instance / env) for a
+            // readable approval line, plus the spend ceiling for paid tools so
+            // the human approves the real authorized amount.
+            let target = ["profile", "slug", "instance_id", "name", "env_id", "environment"]
+                .iter()
+                .find_map(|k| input.get(k).and_then(|v| v.as_str()))
+                .unwrap_or("");
+            let mut s = if target.is_empty() { name.to_string() } else { format!("{name} {target}") };
+            if lab_tools::is_lab_paid_tool(name) {
+                let allow = input.get("allow_spend").and_then(|v| v.as_bool()).unwrap_or(false);
+                match input.get("max_credits").and_then(|v| v.as_f64()) {
+                    Some(m) => s.push_str(&format!(" [PAID allow_spend={allow} max_credits={m}]")),
+                    None => s.push_str(&format!(" [PAID allow_spend={allow} max_credits=unset]")),
+                }
+            }
+            s
+        }
         _ => serde_json::to_string(input).unwrap_or_default(),
     }
 }
@@ -153,7 +211,16 @@ fn coding_system_prompt(cwd: &std::path::Path, mode: Mode) -> String {
            computing via qBraid. `quantum_run` executes OpenQASM 3 circuits (free simulator \
            by default; name a QPU device to run on hardware). `quantum_recall` performs \
            resonance recall as amplitude amplification; `quantum_random` gives true quantum \
-           entropy.\n\n\
+           entropy.\n\
+         - lab_* : manage qBraid Lab infrastructure. Read-only/free: `lab_credits` (balance), \
+           `lab_list_profiles` (compute instance types + per-minute cost — check before spending), \
+           `lab_list_envs`/`lab_env_info`, `lab_compute_status`, `lab_compute_usage`, \
+           `lab_list_instances`. Free mutations: `lab_create_env` (build an environment, packages \
+           install during the build), `lab_delete_env`. PAID (bills credits per wall-clock minute): \
+           `lab_compute_up`/`lab_compute_down` (the Lab server) and `lab_provision_instance`/\
+           `lab_start_instance`/`lab_stop_instance` (on-demand instances). For any PAID tool you \
+           MUST call `lab_credits` + `lab_list_profiles` first, then pass allow_spend=true and a \
+           max_credits ceiling, and tell the user the burn rate; always stop compute when done.\n\n\
          Working style:\n\
          - Investigate before acting: read the relevant files, search for usages.\n\
          - Make the smallest change that solves the task; match the surrounding style.\n\
@@ -165,6 +232,66 @@ fn coding_system_prompt(cwd: &std::path::Path, mode: Mode) -> String {
         os = os,
         mode = mode.label(),
     )
+}
+
+/// Track started paid compute so a forgotten, still-billing server/instance
+/// can't go unnoticed. Updated after each paid/stop tool result.
+fn update_active_compute(
+    set: &mut std::collections::HashSet<String>,
+    name: &str,
+    input: &Value,
+    content: &str,
+    is_error: bool,
+) {
+    if is_error {
+        return;
+    }
+    match name {
+        "lab_compute_up" => {
+            set.insert("Lab server".to_string());
+        }
+        "lab_compute_down" => {
+            set.remove("Lab server");
+        }
+        "lab_provision_instance" => {
+            // The instance id is assigned by the platform → read it from the result.
+            if let Some(id) = serde_json::from_str::<Value>(content)
+                .ok()
+                .as_ref()
+                .and_then(|v| v.get("instance_id"))
+                .and_then(|v| v.as_str())
+            {
+                set.insert(format!("instance {id}"));
+            }
+        }
+        "lab_start_instance" => {
+            if let Some(id) = input.get("instance_id").and_then(|v| v.as_str()) {
+                set.insert(format!("instance {id}"));
+            }
+        }
+        "lab_stop_instance" => {
+            if let Some(id) = input.get("instance_id").and_then(|v| v.as_str()) {
+                set.remove(&format!("instance {id}"));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Emit a prominent reminder if any paid compute is still billing.
+fn warn_active_compute(set: &std::collections::HashSet<String>, emit: &impl Fn(Value)) {
+    if set.is_empty() {
+        return;
+    }
+    let mut targets: Vec<&str> = set.iter().map(|s| s.as_str()).collect();
+    targets.sort_unstable();
+    emit(json!({
+        "kind": "warning",
+        "text": format!(
+            "⚠️ ACTIVE PAID COMPUTE still billing per minute: {}. Stop it with lab_compute_down / lab_stop_instance when done.",
+            targets.join(", ")
+        ),
+    }));
 }
 
 fn session_path(id: &str) -> Option<PathBuf> {
@@ -184,6 +311,7 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
     let mut model_override: Option<String> = None;
     let mut no_memory = false;
     let mut no_quantum = false;
+    let mut no_lab = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -216,6 +344,7 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
             }
             "--no-memory-tools" => no_memory = true,
             "--no-quantum" => no_quantum = true,
+            "--no-lab" => no_lab = true,
             _ => {}
         }
         i += 1;
@@ -253,6 +382,12 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
     if !no_quantum {
         tools.extend(quantum_tools::quantum_tools());
     }
+    // qBraid Lab / infrastructure tools (manage credits/envs/compute via the
+    // same bridge). Paid compute is gated behind allow_spend + approval; the
+    // bridge surfaces a clear hint if qbraid_core isn't installed.
+    if !no_lab {
+        tools.extend(lab_tools::lab_tools());
+    }
     let tool_names: Vec<&str> = tools.iter().map(|t| t.name).collect();
     let system = coding_system_prompt(&cwd, mode);
 
@@ -267,6 +402,10 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
 
     let mut tool_ctx = ToolCtx::new(cwd.clone());
     let mut allowlist: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Paid compute (Lab server / on-demand instances) the agent has started and
+    // not yet stopped — surfaced as a reminder each turn and on exit so a
+    // still-billing resource isn't silently forgotten.
+    let mut active_compute: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     emit(json!({
         "kind": "ready",
@@ -304,7 +443,7 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
                 messages.push(Message::user_text(text));
                 run_turn(
                     &mut client, &cfg_owned, &mut did_fallback, &system, &tools, &mut messages,
-                    sys, &mut tool_ctx, &mut allowlist, mode, &mut lines, &emit,
+                    sys, &mut tool_ctx, &mut allowlist, &mut active_compute, mode, &mut lines, &emit,
                 );
                 if let Some(p) = &sess_path {
                     let _ = agent::save_session(p, &messages);
@@ -313,6 +452,8 @@ pub fn handle_agent(sys: &mut KannakaMemorySystem, cfg: &KannakaConfig, args: &[
             _ => continue, // stray approval with no pending request, etc.
         }
     }
+    // On shutdown (exit / EOF), make sure any still-billing compute is flagged.
+    warn_active_compute(&active_compute, &emit);
 }
 
 /// Run the agentic loop for one user turn: repeatedly call the model, execute
@@ -369,10 +510,13 @@ fn run_turn(
     sys: &mut KannakaMemorySystem,
     tool_ctx: &mut ToolCtx,
     allowlist: &mut std::collections::HashSet<String>,
+    active_compute: &mut std::collections::HashSet<String>,
     mode: Mode,
     lines: &mut std::io::Lines<std::io::StdinLock<'_>>,
     emit: &impl Fn(Value),
 ) {
+    // Remind the user up front if paid compute from a prior turn is still billing.
+    warn_active_compute(active_compute, emit);
     let mut iteration = 0usize;
     loop {
         iteration += 1;
@@ -436,9 +580,11 @@ fn run_turn(
         for (id, name, input) in tool_uses {
             let read_only = coding_tools::is_read_only(&name)
                 || is_memory_tool(&name)
-                || quantum_tools::is_quantum_tool(&name);
-            let danger = name == "bash"
-                && input.get("command").and_then(|v| v.as_str()).map(coding_tools::bash_is_destructive).unwrap_or(false);
+                || quantum_tools::is_quantum_tool(&name)
+                || lab_tools::is_lab_readonly_tool(&name);
+            let danger = (name == "bash"
+                && input.get("command").and_then(|v| v.as_str()).map(coding_tools::bash_is_destructive).unwrap_or(false))
+                || lab_tools::is_lab_paid_tool(&name);
             emit(json!({
                 "kind": "tool_use", "id": id, "name": name, "input": input,
                 "read_only": read_only, "danger": danger,
@@ -460,6 +606,8 @@ fn run_turn(
                 _ => {
                     if quantum_tools::is_quantum_tool(&name) {
                         quantum_tools::dispatch_quantum_tool(&name, &input)
+                    } else if lab_tools::is_lab_tool(&name) {
+                        lab_tools::dispatch_lab_tool(&name, &input)
                     } else if coding_tools::is_coding_tool(&name) {
                         coding_tools::dispatch_coding_tool(tool_ctx, &name, &input)
                     } else {
@@ -472,6 +620,8 @@ fn run_turn(
                 "kind": "tool_result", "id": id, "name": name,
                 "content": content, "is_error": is_error,
             }));
+            // Track started/stopped paid compute so it can't be forgotten.
+            update_active_compute(active_compute, &name, &input, &content, is_error);
             result_blocks.push(ContentBlock::ToolResult {
                 tool_use_id: id,
                 content,

--- a/src/lab_tools.rs
+++ b/src/lab_tools.rs
@@ -1,0 +1,599 @@
+//! qBraid Lab / infrastructure tools for the `kannaka agent` harness.
+//!
+//! Where [`crate::quantum_tools`] runs *circuits* on qBraid, these tools manage
+//! the *platform* around them — credits, environments, compute profiles, the
+//! Lab server, and on-demand instances — by shelling out to the same
+//! `kannaka-quantum` bridge (its `lab-*` subcommands, which wrap `qbraid_core`).
+//!
+//! Three safety tiers, classified here and gated by the agent handler:
+//! - **read-only** ([`is_lab_readonly_tool`]) — visibility ops; never spend,
+//!   never mutate → auto-allowed like the quantum tools.
+//! - **free mutations** — env/package/kernel lifecycle + stop/down; cost no
+//!   credits but change state → routed through human approval.
+//! - **paid** ([`is_lab_paid_tool`]) — start/provision/resume compute; bill
+//!   credits *per wall-clock minute* → require `allow_spend` + `max_credits`
+//!   in the call AND human approval (the bridge refuses a paid run otherwise).
+
+use crate::agent::Tool;
+use serde_json::{json, Value};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Compute provisioning + `--wait` polling can take minutes; give it headroom.
+const BRIDGE_TIMEOUT_SECS: u64 = 660;
+
+fn python_bin() -> String {
+    std::env::var("KANNAKA_QUANTUM_PYTHON").unwrap_or_else(|_| "python".to_string())
+}
+
+/// True for any tool handled here.
+pub fn is_lab_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "lab_credits"
+            | "lab_list_envs"
+            | "lab_env_info"
+            | "lab_list_profiles"
+            | "lab_compute_status"
+            | "lab_compute_usage"
+            | "lab_list_instances"
+            | "lab_list_kernels"
+            | "lab_create_env"
+            | "lab_delete_env"
+            | "lab_pip_install"
+            | "lab_pip_freeze"
+            | "lab_add_kernel"
+            | "lab_remove_kernel"
+            | "lab_compute_up"
+            | "lab_compute_down"
+            | "lab_provision_instance"
+            | "lab_start_instance"
+            | "lab_stop_instance"
+    )
+}
+
+/// Read-only / $0 visibility tools — safe to auto-allow.
+pub fn is_lab_readonly_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "lab_credits"
+            | "lab_list_envs"
+            | "lab_env_info"
+            | "lab_list_profiles"
+            | "lab_compute_status"
+            | "lab_compute_usage"
+            | "lab_list_instances"
+            | "lab_list_kernels"
+            | "lab_pip_freeze"
+    )
+}
+
+/// Tools that spend qBraid credits (per-minute compute) — must never be
+/// auto-approved, and the bridge requires `allow_spend` + a `max_credits` cap.
+pub fn is_lab_paid_tool(name: &str) -> bool {
+    matches!(name, "lab_compute_up" | "lab_provision_instance" | "lab_start_instance")
+}
+
+/// The lab toolset exposed to the model. Names/descriptions are `'static` so the
+/// prompt cache stays stable across turns.
+pub fn lab_tools() -> Vec<Tool> {
+    vec![
+        // --- Phase 1: read-only / $0 ------------------------------------- //
+        Tool {
+            name: "lab_credits",
+            description: "Show the qBraid credit balance (1 credit = $0.01) and its USD value. Free, read-only.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        },
+        Tool {
+            name: "lab_list_envs",
+            description: "List qBraid environments available to the account (name, slug, description, tags). Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "page": { "type": "integer", "minimum": 1, "default": 1 },
+                    "limit": { "type": "integer", "minimum": 1, "default": 20 }
+                }
+            }),
+        },
+        Tool {
+            name: "lab_env_info",
+            description: "Get full metadata for one qBraid environment by its slug. Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "slug": { "type": "string" } },
+                "required": ["slug"]
+            }),
+        },
+        Tool {
+            name: "lab_list_profiles",
+            description: "List qBraid compute profiles (instance types) with live per-minute credit cost, USD/min, GPU \
+                          flag, plan, and capacity. Call this BEFORE starting paid compute to choose a profile and see \
+                          its burn rate. Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "gpu_only": { "type": "boolean", "default": false, "description": "Only GPU profiles." },
+                    "available_only": { "type": "boolean", "default": false, "description": "Only profiles ready (with capacity)." },
+                    "plan": { "type": "string", "description": "Filter by plan (e.g. Free, Standard, Pro)." },
+                    "limit": { "type": "integer", "minimum": 1 }
+                }
+            }),
+        },
+        Tool {
+            name: "lab_compute_status",
+            description: "Report the qBraid Lab server status: whether it's running, on which profile, and its URL. Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "cluster": { "type": "string", "description": "Cluster id (default 'lab')." } }
+            }),
+        },
+        Tool {
+            name: "lab_compute_usage",
+            description: "Show qBraid compute usage and per-session credit rates / totals charged (optionally for the last N days). Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "days": { "type": "integer", "minimum": 1 } }
+            }),
+        },
+        Tool {
+            name: "lab_list_instances",
+            description: "List on-demand (BMA) qBraid compute instances with status, URL, and running/stopped credits-per-minute. Free, read-only.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        },
+        Tool {
+            name: "lab_list_kernels",
+            description: "List Jupyter kernels installed locally (only meaningful when running inside qBraid Lab / on a provisioned instance). Free, read-only.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        },
+        // --- Phase 2: free mutations (env / package / kernel) ------------ //
+        Tool {
+            name: "lab_create_env",
+            description: "Create a qBraid environment. Any 'packages' listed install during the (async, cloud-side) build — \
+                          this is the way to install packages into a qBraid environment when not running inside Lab. \
+                          Free (no credits).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "python_version": { "type": "string", "description": "e.g. 3.11" },
+                    "packages": {
+                        "description": "Object {name: version} or array of package names to install during the build.",
+                        "oneOf": [ { "type": "object" }, { "type": "array", "items": { "type": "string" } } ]
+                    },
+                    "kernel_name": { "type": "string" },
+                    "visibility": { "type": "string", "default": "private" },
+                    "tags": { "type": "array", "items": { "type": "string" } }
+                },
+                "required": ["name"]
+            }),
+        },
+        Tool {
+            name: "lab_delete_env",
+            description: "Delete a qBraid environment by slug. Free (no credits).",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "slug": { "type": "string" } },
+                "required": ["slug"]
+            }),
+        },
+        Tool {
+            name: "lab_pip_install",
+            description: "pip-install packages into a LOCALLY-installed environment (keyed by its local env_id, NOT the cloud \
+                          slug). Only works inside qBraid Lab / on a provisioned instance. Free.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "env_id": { "type": "string", "description": "Local registry env id (not the cloud slug)." },
+                    "packages": { "type": "array", "items": { "type": "string" } },
+                    "upgrade_pip": { "type": "boolean", "default": false }
+                },
+                "required": ["env_id", "packages"]
+            }),
+        },
+        Tool {
+            name: "lab_pip_freeze",
+            description: "List packages installed in a locally-installed environment (in-Lab only). Free, read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "env_id": { "type": "string" } },
+                "required": ["env_id"]
+            }),
+        },
+        Tool {
+            name: "lab_add_kernel",
+            description: "Register a Jupyter kernel for a (locally-installed) environment (in-Lab only). Free.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "environment": { "type": "string" } },
+                "required": ["environment"]
+            }),
+        },
+        Tool {
+            name: "lab_remove_kernel",
+            description: "Remove a Jupyter kernel for an environment (in-Lab only). Free.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "environment": { "type": "string" } },
+                "required": ["environment"]
+            }),
+        },
+        // --- Phase 3: paid compute provisioning -------------------------- //
+        Tool {
+            name: "lab_compute_up",
+            description: "Start the qBraid Lab server on a compute profile. PAID — bills qBraid credits per wall-clock minute \
+                          until stopped. Requires allow_spend=true and a max_credits ceiling (the balance you accept to \
+                          risk). Call lab_list_profiles first for the burn rate; stop with lab_compute_down.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "profile": { "type": "string", "description": "Profile slug from lab_list_profiles." },
+                    "allow_spend": { "type": "boolean", "default": false, "description": "Required true — paid compute." },
+                    "max_credits": { "type": "number", "description": "Committed credit ceiling (default 60 ≈ $0.60)." },
+                    "cluster": { "type": "string" },
+                    "wait": { "type": "boolean", "default": false, "description": "Block until the server is ready." },
+                    "timeout": { "type": "number", "description": "Seconds to wait when wait=true." }
+                },
+                "required": ["profile", "allow_spend", "max_credits"]
+            }),
+        },
+        Tool {
+            name: "lab_compute_down",
+            description: "Stop the running qBraid Lab server (preserves disk, stops per-minute billing). Free.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "cluster": { "type": "string" } }
+            }),
+        },
+        Tool {
+            name: "lab_provision_instance",
+            description: "Provision (launch) a new on-demand qBraid compute instance on a profile. PAID — per-minute credits. \
+                          Requires allow_spend=true + max_credits. Pause it later with lab_stop_instance.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "profile": { "type": "string", "description": "Profile slug from lab_list_profiles." },
+                    "allow_spend": { "type": "boolean", "default": false },
+                    "max_credits": { "type": "number" },
+                    "wait": { "type": "boolean", "default": false },
+                    "timeout": { "type": "number" }
+                },
+                "required": ["profile", "allow_spend", "max_credits"]
+            }),
+        },
+        Tool {
+            name: "lab_start_instance",
+            description: "Resume a stopped on-demand instance by instance_id. PAID — per-minute credits. Requires allow_spend=true + max_credits.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "instance_id": { "type": "string" },
+                    "allow_spend": { "type": "boolean", "default": false },
+                    "max_credits": { "type": "number" }
+                },
+                "required": ["instance_id", "allow_spend", "max_credits"]
+            }),
+        },
+        Tool {
+            name: "lab_stop_instance",
+            description: "Stop (pause) an on-demand instance by instance_id — preserves disk, stops running billing (a stopped \
+                          instance still bills a small disk rate; terminate-to-delete is via the web UI by design). Free to call.",
+            input_schema: json!({
+                "type": "object",
+                "properties": { "instance_id": { "type": "string" } },
+                "required": ["instance_id"]
+            }),
+        },
+    ]
+}
+
+/// Execute a lab tool by shelling out to the bridge's matching `lab-*`
+/// subcommand. Returns `(result_text, is_error)`.
+pub fn dispatch_lab_tool(name: &str, input: &Value) -> (String, bool) {
+    // Enforce the paid-compute contract at the harness, not only in the bridge:
+    // the bridge has an env-var opt-in path, so the Rust side must independently
+    // require an explicit allow_spend=true + a positive max_credits ceiling.
+    if is_lab_paid_tool(name) {
+        if input.get("allow_spend").and_then(|v| v.as_bool()) != Some(true) {
+            return (
+                format!(
+                    "{name} is a PAID per-minute compute action and requires allow_spend=true. \
+                     Call lab_credits + lab_list_profiles first, then retry with allow_spend=true \
+                     and a max_credits ceiling."
+                ),
+                true,
+            );
+        }
+        if let Err(e) = req_num(input, "max_credits") {
+            return (e, true);
+        }
+    }
+    let mut args: Vec<String> = Vec::new();
+    match name {
+        "lab_credits" => args.push("lab-credits".into()),
+        "lab_list_envs" => {
+            args.push("lab-list-envs".into());
+            push_int(&mut args, "--page", input, "page");
+            push_int(&mut args, "--limit", input, "limit");
+        }
+        "lab_env_info" => {
+            let slug = match req_str(input, "slug") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-env-info".into());
+            args.push("--slug".into());
+            args.push(slug);
+        }
+        "lab_list_profiles" => {
+            args.push("lab-list-profiles".into());
+            push_flag(&mut args, "--gpu-only", input, "gpu_only");
+            push_flag(&mut args, "--available-only", input, "available_only");
+            push_str_opt(&mut args, "--plan", input, "plan");
+            push_int(&mut args, "--limit", input, "limit");
+        }
+        "lab_compute_status" => {
+            args.push("lab-compute-status".into());
+            push_str_opt(&mut args, "--cluster", input, "cluster");
+        }
+        "lab_compute_usage" => {
+            args.push("lab-compute-usage".into());
+            push_int(&mut args, "--days", input, "days");
+        }
+        "lab_list_instances" => args.push("lab-list-instances".into()),
+        "lab_list_kernels" => args.push("lab-list-kernels".into()),
+        "lab_create_env" => {
+            let n = match req_str(input, "name") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-create-env".into());
+            args.push("--name".into());
+            args.push(n);
+            push_str_opt(&mut args, "--description", input, "description");
+            push_str_opt(&mut args, "--python-version", input, "python_version");
+            push_json_opt(&mut args, "--packages", input, "packages");
+            push_str_opt(&mut args, "--kernel-name", input, "kernel_name");
+            push_str_opt(&mut args, "--visibility", input, "visibility");
+            push_json_opt(&mut args, "--tags", input, "tags");
+        }
+        "lab_delete_env" => {
+            let slug = match req_str(input, "slug") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-delete-env".into());
+            args.push("--slug".into());
+            args.push(slug);
+        }
+        "lab_pip_install" => {
+            let env_id = match req_str(input, "env_id") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            match input.get("packages") {
+                Some(p) if p.is_array() => {
+                    args.push("lab-pip-install".into());
+                    args.push("--env-id".into());
+                    args.push(env_id);
+                    args.push("--packages".into());
+                    args.push(p.to_string());
+                    push_flag(&mut args, "--upgrade-pip", input, "upgrade_pip");
+                }
+                _ => return ("lab_pip_install requires a packages array".into(), true),
+            }
+        }
+        "lab_pip_freeze" => {
+            let env_id = match req_str(input, "env_id") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-pip-freeze".into());
+            args.push("--env-id".into());
+            args.push(env_id);
+        }
+        "lab_add_kernel" | "lab_remove_kernel" => {
+            let env = match req_str(input, "environment") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push(if name == "lab_add_kernel" { "lab-add-kernel".into() } else { "lab-remove-kernel".into() });
+            args.push("--environment".into());
+            args.push(env);
+        }
+        "lab_compute_up" => {
+            let profile = match req_str(input, "profile") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-compute-up".into());
+            args.push("--profile".into());
+            args.push(profile);
+            push_str_opt(&mut args, "--cluster", input, "cluster");
+            push_flag(&mut args, "--wait", input, "wait");
+            push_num(&mut args, "--timeout", input, "timeout");
+            push_spend_args(&mut args, input);
+        }
+        "lab_compute_down" => {
+            args.push("lab-compute-down".into());
+            push_str_opt(&mut args, "--cluster", input, "cluster");
+        }
+        "lab_provision_instance" => {
+            let profile = match req_str(input, "profile") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-provision-instance".into());
+            args.push("--profile".into());
+            args.push(profile);
+            push_flag(&mut args, "--wait", input, "wait");
+            push_num(&mut args, "--timeout", input, "timeout");
+            push_spend_args(&mut args, input);
+        }
+        "lab_start_instance" => {
+            let id = match req_str(input, "instance_id") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-start-instance".into());
+            args.push("--instance-id".into());
+            args.push(id);
+            push_spend_args(&mut args, input);
+        }
+        "lab_stop_instance" => {
+            let id = match req_str(input, "instance_id") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-stop-instance".into());
+            args.push("--instance-id".into());
+            args.push(id);
+        }
+        other => return (format!("unknown lab tool: {other}"), true),
+    }
+    run_bridge(&args)
+}
+
+fn req_str(input: &Value, key: &str) -> Result<String, String> {
+    match input.get(key).and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => Ok(s.to_string()),
+        _ => Err(format!("lab tool requires a non-empty '{key}'")),
+    }
+}
+
+/// Require a strictly-positive numeric input (the committed credit ceiling).
+fn req_num(input: &Value, key: &str) -> Result<f64, String> {
+    match input.get(key).and_then(|v| v.as_f64()) {
+        Some(n) if n > 0.0 => Ok(n),
+        _ => Err(format!("paid lab tool requires a positive numeric '{key}' (committed credit ceiling)")),
+    }
+}
+
+/// Append `--flag` if the named boolean input is true.
+fn push_flag(args: &mut Vec<String>, flag: &str, input: &Value, key: &str) {
+    if input.get(key).and_then(|v| v.as_bool()) == Some(true) {
+        args.push(flag.to_string());
+    }
+}
+
+/// Append `--opt <value>` for a non-empty string input.
+fn push_str_opt(args: &mut Vec<String>, opt: &str, input: &Value, key: &str) {
+    if let Some(s) = input.get(key).and_then(|v| v.as_str()) {
+        if !s.is_empty() {
+            args.push(opt.to_string());
+            args.push(s.to_string());
+        }
+    }
+}
+
+/// Append `--opt <int>` for an integer input.
+fn push_int(args: &mut Vec<String>, opt: &str, input: &Value, key: &str) {
+    if let Some(n) = input.get(key).and_then(|v| v.as_i64()) {
+        args.push(opt.to_string());
+        args.push(n.to_string());
+    }
+}
+
+/// Append `--opt <number>` for a numeric input.
+fn push_num(args: &mut Vec<String>, opt: &str, input: &Value, key: &str) {
+    if let Some(n) = input.get(key).and_then(|v| v.as_f64()) {
+        args.push(opt.to_string());
+        args.push(n.to_string());
+    }
+}
+
+/// Append `--opt <json>` for an array/object input (the bridge parses it).
+fn push_json_opt(args: &mut Vec<String>, opt: &str, input: &Value, key: &str) {
+    if let Some(v) = input.get(key) {
+        if v.is_array() || v.is_object() {
+            args.push(opt.to_string());
+            args.push(v.to_string());
+        } else if let Some(s) = v.as_str() {
+            // The bridge's _parse_json_arg also accepts a CSV/JSON string, so
+            // forward a string form rather than silently dropping it.
+            if !s.is_empty() {
+                args.push(opt.to_string());
+                args.push(s.to_string());
+            }
+        }
+    }
+}
+
+/// Append `--allow-spend` / `--max-credits` from the tool input (paid tools).
+fn push_spend_args(args: &mut Vec<String>, input: &Value) {
+    if input.get("allow_spend").and_then(|v| v.as_bool()) == Some(true) {
+        args.push("--allow-spend".to_string());
+    }
+    if let Some(mc) = input.get("max_credits").and_then(|v| v.as_f64()) {
+        args.push("--max-credits".to_string());
+        args.push(mc.to_string());
+    }
+}
+
+fn run_bridge(args: &[String]) -> (String, bool) {
+    // NOTE: the pipes are drained only after the child exits (via
+    // wait_with_output below). This is safe ONLY because every `lab-*`
+    // subcommand prints a single small JSON object (cli.py does one
+    // `print(json.dumps(...))`, no streaming) — well under the OS pipe buffer.
+    // If a subcommand is ever made to stream large output, switch to draining
+    // stdout/stderr on reader threads to avoid a pipe-buffer deadlock.
+    let py = python_bin();
+    let mut full: Vec<String> = vec!["-m".to_string(), "kannaka_quantum".to_string()];
+    full.extend_from_slice(args);
+
+    let mut child = match Command::new(&py)
+        .args(&full)
+        .env("KANNAKA_QUIET", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                format!(
+                    "quantum bridge unavailable: could not run '{py} -m kannaka_quantum' ({e}). \
+                     Install it: pip install git+https://github.com/NickFlach/kannaka-quantum \
+                     (set KANNAKA_QUANTUM_PYTHON if python isn't on PATH)."
+                ),
+                true,
+            );
+        }
+    };
+    let _ = child.stdin.take(); // explicitly close stdin
+
+    let start = Instant::now();
+    let timed_out = loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break false,
+            Ok(None) => {
+                if start.elapsed() > Duration::from_secs(BRIDGE_TIMEOUT_SECS) {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break true;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return (format!("quantum bridge wait failed: {e}"), true),
+        }
+    };
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => return (format!("quantum bridge output failed: {e}"), true),
+    };
+    if timed_out {
+        return ("lab operation timed out (a compute action may still be in progress — check lab_compute_status)".into(), true);
+    }
+    let body = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if body.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let last = stderr.trim().lines().last().unwrap_or("no output");
+        return (format!("quantum bridge produced no result: {last}"), true);
+    }
+    let is_error = serde_json::from_str::<Value>(&body)
+        .map(|v| v.get("error").is_some())
+        .unwrap_or(false);
+    (body, is_error)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,10 @@ pub mod coding_tools;
 // the kannaka-quantum bridge.
 pub mod quantum_tools;
 
+// qBraid Lab / infrastructure tools for the agent — credits, environments,
+// compute profiles, Lab server, and on-demand instances via the same bridge.
+pub mod lab_tools;
+
 // SpaceChild SSO identity for swarm agents (spacechild-auth client + token store).
 pub mod identity;
 


### PR DESCRIPTION
Adds a `lab` agent-tool category (new `src/lab_tools.rs`, wired into `bin/handlers/agent.rs`) giving the Kannaka coding agent control over qBraid Lab infrastructure — companion to kannaka-quantum bridge v0.2.0 (`lab.py`).

**19 `lab_*` tools**: spin up/manage the Lab server, provision GPU/CPU on-demand instances, install packages / manage environments, list profiles+pricing, and surface credits/usage. The TUI auto-surfaces them.

**Spend safety (3 tiers in `decide()`):** read-only auto-allow; free mutations approval-gated; **paid compute triple-gated** — `allow_spend` + positive `max_credits` (schema-required AND hard-failed in `dispatch_lab_tool`) + human approval that never auto-approves (not even yolo) and is never persisted to the allowlist. An active-compute **watchdog** reminds each turn + on exit so a still-billing server/instance isn't forgotten.

Built via a research→verify→synthesize workflow and a 4-dimension adversarial review (16 findings, all fixed). Verified live end-to-end on the account — **$0 spent**. Release tag `v0.9.0` to follow (triggers the cross-platform build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)