### PR TITLE
fix(lab): PYTHONUTF8 for remote-agent reads (v0.9.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/lab_tools.rs
+++ b/src/lab_tools.rs
@@ -689,6 +689,10 @@ fn run_bridge(args: &[String]) -> (String, bool) {
 
     let mut child = match Command::new(&py)
         .args(&full)
+        // Force Python UTF-8 mode: the remote-agent tools read a remote TUI
+        // whose box-drawing chars crash qBraid's default-cp1252 subprocess
+        // decoding on Windows. UTF-8 mode makes that decode correctly.
+        .env("PYTHONUTF8", "1")
         .env("KANNAKA_QUIET", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())


### PR DESCRIPTION
The remote-agent tools read a remote TUI whose box-drawing chars crash qBraid's default-cp1252 subprocess decoding on Windows. Spawn the bridge under `PYTHONUTF8=1` so the decode is UTF-8.

Pairs with kannaka-quantum v0.2.2 (Windows ssh-bridge shim + SSH ACL self-heal). Verified the full remote round-trip on a real provisioned instance ($0.03 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)