### PR TITLE
feat(agent): lab_agent_setup for autonomous remote agents (v0.9.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kannaka-memory"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 description = "Hypervector memory system for Kannaka — wave-modulated holographic memory with skip links"
 license = "MIT"

--- a/src/bin/handlers/agent.rs
+++ b/src/bin/handlers/agent.rs
@@ -221,9 +221,10 @@ fn coding_system_prompt(cwd: &std::path::Path, mode: Mode) -> String {
            `lab_start_instance`/`lab_stop_instance` (on-demand instances). For any PAID tool you \
            MUST call `lab_credits` + `lab_list_profiles` first, then pass allow_spend=true and a \
            max_credits ceiling, and tell the user the burn rate; always stop compute when done. \
-           Remote agents: after provisioning an instance, `lab_ssh_configure` returns an ssh_alias, \
-           then `lab_agent_launch`/`lab_agent_list`/`lab_agent_read`/`lab_agent_send` run and drive a \
-           coding agent (claude/codex/opencode) ON that instance.\n\n\
+           Remote agents (drive a coding agent on cloud compute): provision an instance → \
+           `lab_ssh_configure` (returns ssh_alias) → `lab_agent_setup` (injects your API key + a valid \
+           model so claude runs autonomously) → `lab_agent_launch` → then DRIVE it with `lab_agent_send` \
+           + `lab_agent_read` (launch does not auto-submit the task). `lab_agent_list` shows what's running.\n\n\
          Working style:\n\
          - Investigate before acting: read the relevant files, search for usages.\n\
          - Make the smallest change that solves the task; match the surrounding style.\n\

--- a/src/lab_tools.rs
+++ b/src/lab_tools.rs
@@ -54,6 +54,7 @@ pub fn is_lab_tool(name: &str) -> bool {
             | "lab_agent_list"
             | "lab_agent_read"
             | "lab_agent_send"
+            | "lab_agent_setup"
     )
 }
 
@@ -303,10 +304,27 @@ pub fn lab_tools() -> Vec<Tool> {
             }),
         },
         Tool {
+            name: "lab_agent_setup",
+            description: "Prepare a remote instance so a launched claude agent runs AUTONOMOUSLY: injects your Anthropic \
+                          API key (resolved locally from ~/.kannaka config or ANTHROPIC_API_KEY — NOT passed here), \
+                          pre-accepts onboarding, and pins a valid model. Run once after lab_ssh_configure, before \
+                          lab_agent_launch. Uploads the key to the instance (stored 0600).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ssh_alias": { "type": "string", "description": "From lab_ssh_configure." },
+                    "provider": { "type": "string", "default": "anthropic", "description": "Currently 'anthropic' (claude)." },
+                    "model": { "type": "string", "default": "claude-sonnet-4-6", "description": "Model to pin (the image default may be unavailable)." }
+                },
+                "required": ["ssh_alias"]
+            }),
+        },
+        Tool {
             name: "lab_agent_launch",
             description: "Launch a coding agent (claude / codex / opencode) ON a remote provisioned instance over SSH — \
-                          have Kannaka drive another agent on cloud compute. Needs lab_ssh_configure first and the \
-                          instance running. The remote agent may incur its own model-API costs.",
+                          have Kannaka drive another agent on cloud compute. Run lab_ssh_configure + lab_agent_setup \
+                          first (else claude stops at its login prompt). qBraid's launch does NOT auto-submit \
+                          instructions — after launching, drive the agent with lab_agent_send. Instance must be running.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -594,6 +612,17 @@ pub fn dispatch_lab_tool(name: &str, input: &Value) -> (String, bool) {
             args.push(sid);
             args.push("--text".into());
             args.push(text);
+        }
+        "lab_agent_setup" => {
+            let alias = match req_str(input, "ssh_alias") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-agent-setup".into());
+            args.push("--ssh-alias".into());
+            args.push(alias);
+            push_str_opt(&mut args, "--provider", input, "provider");
+            push_str_opt(&mut args, "--model", input, "model");
         }
         other => return (format!("unknown lab tool: {other}"), true),
     }


### PR DESCRIPTION
New `lab_agent_setup` agent tool (companion to kannaka-quantum v0.2.3): prepares a provisioned instance so a launched `claude` runs autonomously — injects your Anthropic key (resolved locally, **not** passed through the model's context), pre-accepts onboarding, pins a valid model. Approval-gated. System prompt updated to the full flow: provision → ssh_configure → agent_setup → launch → send.

Verified end-to-end on a real instance: the remote agent authenticated and replied to a task. Release tag v0.9.3 to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)