### PR TITLE
[auto-maintainer] fix dead _now variable and wrong interval_lerp comment

### DIFF
--- a/src/invariant.rs
+++ b/src/invariant.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 use uuid::Uuid;
-use chrono::Utc;
 
 use crate::memory::HyperMemory;
 use crate::store::ResonanceEngine;
@@ -189,7 +188,6 @@ pub fn compute_invariant_metrics(
 
 /// Cluster memories by their δ values - memories with similar δ are coboundary equivalent candidates
 pub fn cluster_by_delta(engine: &ResonanceEngine, tolerance: f32) -> Vec<DeltaCluster> {
-    let _now = Utc::now();
     let all_memories = match engine.store.all_memories() {
         Ok(mems) => mems,
         Err(_) => return Vec::new(),

--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -178,7 +178,7 @@ impl RhythmEngine {
         eta
     }
 
-    // hi_ms at t=0, lo_ms at t=1 (higher arousal → lower t-parameter → longer interval).
+    // hi_ms at t=0, lo_ms at t=1 (higher arousal → higher t → shorter interval).
     fn interval_lerp(hi_ms: f64, lo_ms: f64, t: f64) -> u64 {
         (hi_ms - t * (hi_ms - lo_ms)) as u64
     }


### PR DESCRIPTION
## What changed

**`src/invariant.rs`** — removed dead variable and unused import:
- `let _now = Utc::now()` was the first line of `cluster_by_delta()`. The value was never read anywhere in the function or the file. The `_` prefix suppressed the Rust dead-variable lint, but the `Utc::now()` syscall still executed on every call.
- `use chrono::Utc` was the only import site for `Utc` in this file; with `_now` gone it became an unused import, so it was removed too.

**`src/rhythm.rs`** — corrected misleading comment on `interval_lerp`:
- Old: `(higher arousal → lower t-parameter → longer interval)`
- New: `(higher arousal → higher t → shorter interval)`
- The old comment was backwards. All three `compute_interval` call sites pass `(arousal - band_floor) / band_width` as `t`, so higher arousal produces a higher `t`, which drives the result toward `lo_ms` (the *smaller* value), giving a *shorter* interval. The math was always correct; only the comment was wrong.

## Why safe

- No behavior change — only a dead statement removed and a comment corrected.
- No public API surface altered.
- All existing tests remain valid and should pass without modification.

## How verified

- Diff is 2 files, ~5 lines changed.
- Removed code path was provably unreachable by callers (value never referenced after assignment).
- Comment fix cross-checked against all three `compute_interval` call sites in the same file.
- No Rust build or test infrastructure available in this environment; changes are comment-only or dead-code removal, making behavioral regression impossible.

## Runtime

~25 minutes wall-clock (repo selection, source scan of 18 files, duplicate check, branch + push + PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNJeF1WQLTDxtDWb7qrsUy)_