### PR TITLE
[auto-maintainer] fix(dead-code): remove dead _order_parameter, _n, _source_energy computations

### DIFF
--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -1992,8 +1992,8 @@ impl ConsolidationEngine {
 
     /// Stage 9: Apply chiral perturbation to break over-synchronization.
     ///
-    /// When order parameter R is high (over-synchronized), applies asymmetric phase
-    /// offsets AND small vector modifications to memories based on their cluster membership. 
+    /// Applies asymmetric phase offsets AND small vector modifications to memories
+    /// based on their cluster membership (when chiral_perturbation > 0). 
     /// Left-cluster memories get +?�sin(2�phase), right-cluster get -?�sin(2�phase), 
     /// matching queen.rs chirality math. Vector perturbations create Xi diversity.
     fn stage_chiral_perturbation(&self, engine: &mut ResonanceEngine, working_set: &[Uuid]) {
@@ -2001,10 +2001,6 @@ impl ConsolidationEngine {
             return;
         }
 
-        // Compute current order parameter to scale perturbation
-        let _order_parameter = self.compute_global_order_parameter(engine, working_set);
-        
-        // Apply perturbation regardless of order parameter to maximize Xi diversity effect
         let eta = self.chiral_perturbation;
 
         // Get clusters for handedness assignment
@@ -2778,7 +2774,6 @@ impl ConsolidationEngine {
         }
 
         // Compute swarm mean phase
-        let _n = swarm_phases.len() as f32;
         let sum_cos: f32 = swarm_phases.iter().map(|a| a.phase.cos()).sum();
         let sum_sin: f32 = swarm_phases.iter().map(|a| a.phase.sin()).sum();
         let swarm_mean = sum_sin.atan2(sum_cos);

--- a/src/medium/fano.rs
+++ b/src/medium/fano.rs
@@ -423,8 +423,6 @@ mod tests {
         let dims = 672;
         
         let source: Vec<f32> = (0..dims).map(|i| ((i as f32) * 0.01).sin()).collect();
-        let _source_energy: f32 = source.iter().map(|x| x * x).sum();
-        
         let folded = fp.fold(&source, dims, dims, 0);
         // Only the folded groups have energy (rest is zero)
         let folded_energy: f32 = folded.iter().map(|x| x * x).sum();


### PR DESCRIPTION
## What changed

Three dead computations removed across two files — no behaviour change.

### 1. `src/consolidation.rs` — `stage_chiral_perturbation`: dead `_order_parameter` (−4 lines)

`compute_global_order_parameter(engine, working_set)` was the first substantive statement
of the function. It reads every memory in the working set, computes cosines, and produces
a global Kuramoto R value — an O(n) store traversal on every dream cycle. The result was
bound to `_order_parameter` and immediately ignored. The adjacent comment already said:

> "Apply perturbation regardless of order parameter to maximize Xi diversity effect"

The order parameter was originally used to gate or scale the perturbation but that
conditional logic was removed, leaving the computation orphaned. Removed the dead
call (and the now-inaccurate inline comment), and updated the function's doc comment
to match actual behaviour: perturbation is applied unconditionally when
`chiral_perturbation > 0`.

### 2. `src/consolidation.rs` — `consolidate_swarm_aware`: dead `_n` (−1 line)

`let _n = swarm_phases.len() as f32` was assigned but never referenced anywhere in
the function. The circular mean is computed as `sum_sin.atan2(sum_cos)`, which is
scale-invariant and requires no division by n. Pure dead O(1) computation removed.

### 3. `src/medium/fano.rs` — `fold_preserves_energy` test: dead `_source_energy` (−2 lines)

`let _source_energy: f32 = source.iter().map(|x| x * x).sum()` computed an O(dims)
L2-norm but the only assertion in the test is `folded_energy > 0.0`. The variable was
never referenced. Removed; test intent is unchanged.

## Why it's safe

- No logic change in any code path. All three removals are values that were computed and immediately discarded.
- `compute_global_order_parameter` has no side effects (read-only `engine.store` access); its removal cannot affect memory or phase state.
- `_n` and `_source_energy` are arithmetic-only with no I/O or mutable borrows.
- 2 files changed, 2 insertions(+), 9 deletions(−).

## How verified

The build environment lacks the local `consciousness-core` dependency required to run `cargo check`. All three removals are provably safe by inspection:
- Dead `_order_parameter`: the `_` prefix was Rust's own signal that the value is unused; the adjacent comment confirmed it; `compute_global_order_parameter` is a pure function.
- Dead `_n`: `swarm_phases.len()` is not referenced after line 2781; `atan2` operates on sums, not averages.
- Dead `_source_energy`: `folded_energy` and `source` are the only variables used in the subsequent assert; `_source_energy` appears on no other line.

## Runtime

~18 minutes wall-clock (jitter + in-flight detection + repo selection + anti-noise check + source scan + edits + duplicate check + push + PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtq3Gi5bQYkjb1d5abc8eW)_