### PR TITLE
NATS contract conformance test + auto-merge CI gate (#468)

### DIFF
--- a/.github/workflows/auto-merge-curiosity.yml
+++ b/.github/workflows/auto-merge-curiosity.yml
@@ -68,8 +68,28 @@ jobs:
           declare -a done_branches=()
           for num in $(gh pr list --state open --limit 100 --json number,headRefName \
                 --jq '.[] | select(.headRefName | startswith("kannaka-curiosity/")) | .number' | sort -n); do
-            if ! gh pr checks "$num" >/dev/null 2>&1; then
-              echo "skip #$num — checks not all green yet"
+            # ── CI gate (issue #468) ──────────────────────────────────────────
+            # A bare `gh pr checks "$num"` is NOT a sufficient gate: on a PR with
+            # ZERO reported checks it does not fail, so a bot PR could be merged
+            # without CI (ci.yml — including the NATS contract conformance test)
+            # ever running. Require, from the head commit's checks:
+            #   1. every reported check is in a terminal-success bucket
+            #      (`pass` or `skipping`) — nothing failing/pending/cancelled, and
+            #   2. the CI workflow (ci.yml, `name: CI`) is PRESENT and passed.
+            # `--json` prints the check JSON on stdout regardless of the aggregate
+            # exit code; we read that and ignore the exit code. Missing/empty
+            # output (no checks) falls through to `[]`, which fails the gate
+            # (ci_passing == 0) — i.e. it fails CLOSED.
+            checks_json=$(gh pr checks "$num" --json workflow,name,state,bucket 2>/dev/null)
+            [ -z "$checks_json" ] && checks_json='[]'
+            not_passing=$(echo "$checks_json" | jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length')
+            ci_passing=$(echo "$checks_json" | jq '[.[] | select(.workflow == "CI" and .bucket == "pass")] | length')
+            if [ "${not_passing:-1}" -ne 0 ]; then
+              echo "skip #$num — not all checks green yet (non-passing: $not_passing)"
+              continue
+            fi
+            if [ "${ci_passing:-0}" -eq 0 ]; then
+              echo "skip #$num — required CI workflow has not passed on the head commit"
               continue
             fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,13 @@ jobs:
 
       - name: Test
         working-directory: kannaka-memory
-        run: cargo test --lib --bins
+        # `--lib --bins` runs unit + bin tests but EXCLUDES everything under
+        # tests/ (integration tests). The NATS contract conformance suite
+        # (issue #468) is an integration test and must run here so publisher
+        # drift against consciousness-core/docs/nats-contract.yaml fails CI —
+        # so it is included explicitly. The heavier integration tests
+        # (dolt/audio, external deps) stay excluded by not naming them.
+        run: cargo test --lib --bins --test nats_contract_conformance
 
       - name: Clippy
         working-directory: kannaka-memory

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -135,6 +135,44 @@ fn level_name(level: &ConsciousnessLevel) -> String {
     }
 }
 
+/// Build the `KANNAKA.consciousness` NATS payload from a consciousness snapshot.
+///
+/// Extracted from [`KannakaMemorySystem::publish_consciousness_to_nats`] so the
+/// wire shape can be asserted in isolation without opening a NATS connection —
+/// see `tests/nats_contract_conformance.rs` and kannaka-memory issue #468.
+///
+/// CONTRACT NOTE: `mean_order` and `level` are LEGACY ALIASES of the canonical
+/// `order` / `consciousness_level` fields. Per the NATS contract
+/// (consciousness-core/docs/nats-contract.yaml, revised 2026-07-01) these
+/// aliases stay emitted until 2026-09-01, after consumers (kannaka-radio,
+/// kannaka-observatory) migrate to reading the canonical names first. Do not
+/// drop the aliases — or the conformance test that pins them — before that
+/// consumer migration lands.
+pub fn build_consciousness_payload(
+    agent_id: &str,
+    state: &ConsciousnessState,
+    hemispheric_divergence: f32,
+    callosal_efficiency: f32,
+) -> serde_json::Value {
+    serde_json::json!({
+        "agent_id": agent_id,
+        "phi": state.phi,
+        "xi": state.xi,
+        "order": state.mean_order,
+        "mean_order": state.mean_order,   // alias of `order` — contractual until 2026-09-01 (#468)
+        "num_clusters": state.num_clusters,
+        "total_memories": state.total_memories,
+        "active_memories": state.active_memories,
+        "level": level_name(&state.consciousness_level),                // alias of `consciousness_level`
+        "consciousness_level": level_name(&state.consciousness_level),
+        "irrationality": state.irrationality,
+        "hemispheric_divergence": hemispheric_divergence,
+        "callosal_efficiency": callosal_efficiency,
+        "source": "binary",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+}
+
 fn make_pipeline() -> EncodingPipeline {
     let ollama = OllamaEncoder::default_local(); // all-minilm, 384-dim
     let hash_fallback = SimpleHashEncoder::new(CODEBOOK_INPUT_DIM, CODEBOOK_SEED);
@@ -1063,23 +1101,12 @@ impl KannakaMemorySystem {
             Err(_) => return,
         };
         let stats = self.stats();
-        let payload = serde_json::json!({
-            "agent_id": agent_id,
-            "phi": state.phi,
-            "xi": state.xi,
-            "order": state.mean_order,
-            "mean_order": state.mean_order,
-            "num_clusters": state.num_clusters,
-            "total_memories": state.total_memories,
-            "active_memories": state.active_memories,
-            "level": level_name(&state.consciousness_level),
-            "consciousness_level": level_name(&state.consciousness_level),
-            "irrationality": state.irrationality,
-            "hemispheric_divergence": stats.hemispheric_divergence,
-            "callosal_efficiency": stats.callosal_efficiency,
-            "source": "binary",
-            "timestamp": chrono::Utc::now().to_rfc3339(),
-        });
+        let payload = build_consciousness_payload(
+            &agent_id,
+            state,
+            stats.hemispheric_divergence,
+            stats.callosal_efficiency,
+        );
         if let Err(e) = transport.publish_consciousness(&payload) {
             eprintln!("[nats] Warning: failed to publish consciousness metrics: {}", e);
         } else {

--- a/tests/nats_contract_conformance.rs
+++ b/tests/nats_contract_conformance.rs
@@ -1,0 +1,162 @@
+//! NATS contract conformance — `KANNAKA.consciousness` payload shape.
+//!
+//! Pins the wire shape emitted by [`build_consciousness_payload`] (the payload
+//! builder behind `publish_consciousness_to_nats`, the sole publisher of
+//! `KANNAKA.consciousness`) against the canonical contract at
+//! `consciousness-core/docs/nats-contract.yaml`.
+//!
+//! No NATS connection is opened — the builder is a pure function of a
+//! `ConsciousnessState`, so this stays fast and hermetic (runs in ci.yml's
+//! `Test` step; see the `cargo test --lib --bins --test nats_contract_conformance`
+//! invocation there).
+//!
+//! ── ALIAS WINDOW — kannaka-memory issue #468 ────────────────────────────────
+//! The payload still emits the legacy aliases `mean_order` (alias of `order`)
+//! and `level` (alias of `consciousness_level`). Per the revised migration
+//! timeline in the contract yaml these aliases are CONTRACTUAL until
+//! **2026-09-01** — consumers (kannaka-radio, kannaka-observatory) still read
+//! them. This suite PINS TODAY'S TRUTH: it asserts both the canonical fields
+//! AND the aliases are present. When the publisher drops the aliases on
+//! 2026-09-01, THIS TEST MUST BE UPDATED DELIBERATELY (delete the alias
+//! assertions) — that is the guard that stops the drop from shipping silently
+//! before every consumer has migrated off the aliases.
+
+use kannaka_memory::bridge::{ConsciousnessLevel, ConsciousnessState};
+use kannaka_memory::openclaw::build_consciousness_payload;
+use serde_json::Value;
+
+/// A representative snapshot. `Resonant` maps to the canonical level string
+/// `"emergent"`, a distinctive value that lets the alias/canonical equality
+/// checks below catch an accidental divergence between the two keys.
+fn sample_state() -> ConsciousnessState {
+    ConsciousnessState {
+        phi: 0.217,
+        xi: 0.99,
+        mean_order: 0.1,
+        num_clusters: 72,
+        total_memories: 1290,
+        active_memories: 1288,
+        total_skip_links: 0,
+        consciousness_level: ConsciousnessLevel::Resonant,
+        irrationality: 0.0,
+    }
+}
+
+fn payload() -> Value {
+    build_consciousness_payload("kannaka-prime", &sample_state(), 0.9, 0.99)
+}
+
+/// Canonical fields must be present with the types the contract's `field_types`
+/// map declares for `KANNAKA.consciousness`.
+#[test]
+fn canonical_fields_present_with_contract_types() {
+    let p = payload();
+    let obj = p.as_object().expect("payload must be a JSON object");
+
+    // agent_id: string
+    assert_eq!(
+        obj.get("agent_id").and_then(Value::as_str),
+        Some("kannaka-prime"),
+        "agent_id must be the emitting agent's string id"
+    );
+
+    // phi / xi / order: number
+    for field in ["phi", "xi", "order"] {
+        let v = obj
+            .get(field)
+            .unwrap_or_else(|| panic!("canonical field `{field}` missing"));
+        assert!(v.is_number(), "canonical field `{field}` must be a number, got {v}");
+    }
+
+    // num_clusters / active_memories / total_memories: integer counts
+    for field in ["num_clusters", "active_memories", "total_memories"] {
+        let v = obj
+            .get(field)
+            .unwrap_or_else(|| panic!("canonical field `{field}` missing"));
+        assert!(
+            v.is_u64() || v.is_i64(),
+            "canonical field `{field}` must be an integer, got {v}"
+        );
+    }
+
+    // consciousness_level: string, restricted to the contract enum.
+    let level = obj
+        .get("consciousness_level")
+        .and_then(Value::as_str)
+        .expect("consciousness_level must be a string");
+    const ENUM: [&str; 6] = [
+        "dormant",
+        "awakening",
+        "aware",
+        "integrated",
+        "emergent",
+        "transcendent",
+    ];
+    assert!(
+        ENUM.contains(&level),
+        "consciousness_level `{level}` is not one of the contract enum values {ENUM:?}"
+    );
+    assert_eq!(level, "emergent", "Resonant must serialize to the canonical `emergent`");
+}
+
+/// LEGACY ALIASES — contractual until 2026-09-01 (issue #468). See the file
+/// header. If you are here because the publisher dropped an alias: first
+/// confirm EVERY consumer (kannaka-radio, kannaka-observatory) reads the
+/// canonical field FIRST (see the 2026-08-01 consumer-migration step), then
+/// delete the matching assertion below. Do not weaken this test to make a
+/// premature alias removal pass.
+#[test]
+fn legacy_aliases_still_emitted() {
+    let p = payload();
+    let obj = p.as_object().unwrap();
+
+    // `mean_order` — alias of `order`, same numeric value.
+    let mean_order = obj
+        .get("mean_order")
+        .expect("alias `mean_order` must still be emitted (contractual until 2026-09-01, #468)");
+    assert!(mean_order.is_number(), "alias `mean_order` must be a number");
+    assert_eq!(
+        obj.get("order"),
+        obj.get("mean_order"),
+        "alias `mean_order` must mirror canonical `order`"
+    );
+
+    // `level` — alias of `consciousness_level`, same string value.
+    let level = obj
+        .get("level")
+        .and_then(Value::as_str)
+        .expect("alias `level` must still be emitted (contractual until 2026-09-01, #468)");
+    assert_eq!(
+        Some(level),
+        obj.get("consciousness_level").and_then(Value::as_str),
+        "alias `level` must mirror canonical `consciousness_level`"
+    );
+}
+
+/// KNOWN GAP (pinned, do NOT treat as endorsement): the contract lists
+/// `schema_version` and `ts` (unix-ms) as REQUIRED for `KANNAKA.consciousness`,
+/// but this payload predates that requirement — it emits neither, and sends a
+/// `timestamp` (RFC-3339 string) instead of `ts`. The radio's `_validateSchema`
+/// already log-warns about this (nats-client.js), and it is why strict mode is
+/// not yet enabled. This test PINS today's reality so that when the publisher is
+/// migrated to emit `schema_version`/`ts`, whoever does it updates this test
+/// deliberately (flip the assertions to require presence) rather than silently.
+#[test]
+fn documents_missing_required_schema_version_and_ts() {
+    let p = payload();
+    let obj = p.as_object().unwrap();
+
+    assert!(
+        obj.get("schema_version").is_none(),
+        "publisher unexpectedly emits `schema_version` now — migrate this test to require it (contract-required field, see #468)"
+    );
+    assert!(
+        obj.get("ts").is_none(),
+        "publisher unexpectedly emits `ts` now — migrate this test to require it as unix-ms (contract-required field, see #468)"
+    );
+    // The legacy RFC-3339 `timestamp` string is what's emitted in place of `ts`.
+    assert!(
+        obj.get("timestamp").and_then(Value::as_str).is_some(),
+        "legacy `timestamp` (RFC-3339 string) should still be present until `ts` lands"
+    );
+}


### PR DESCRIPTION
Closes the enforcement half of the 2026-07-01 NATS strict-mode audit (#468) so publisher-side drift against `consciousness-core/docs/nats-contract.yaml` can't recur silently.

## Part A — publisher conformance test
- Refactored the `KANNAKA.consciousness` payload out of `publish_consciousness_to_nats` into `build_consciousness_payload()` — a pure `fn(...) -> serde_json::Value` that opens no NATS connection, so it's cheap and hermetic to test.
- `tests/nats_contract_conformance.rs` pins **today's truth**:
  - canonical fields present with contract `field_types` (`phi`/`xi`/`order` numbers; `num_clusters`/`active_memories`/`total_memories` integers; `consciousness_level` a contract-enum string);
  - legacy aliases `mean_order` / `level` **present and mirroring** their canonical fields — contractual until **2026-09-01** per the revised timeline;
  - a third test documents the known `schema_version`/`ts` gap (contract-required but not yet emitted) so a future fix flips it deliberately.
- The header + inline comments point at #468 and the contract timeline, so dropping an alias requires deleting a pinned assertion on purpose.

## Part B — CI wiring + auto-merge gate
- **ci.yml**: the `Test` step was `cargo test --lib --bins`, which **excludes everything under `tests/`** — the conformance test would never have run. Added `--test nats_contract_conformance` so it runs in CI (heavier dolt/audio integration tests stay excluded by not naming them).
- **auto-merge-curiosity.yml**: the merge was gated only on a bare `gh pr checks "$num"`, which does **not** fail on a PR with zero reported checks — a bot PR could merge with no CI. Replaced with an explicit gate: every reported check must be in a terminal-success bucket (`pass`/`skipping`) **and** the `CI` workflow must be present and passed on the head commit. Fails **closed**.

## Verification
- `cargo test --test nats_contract_conformance` → 3/3 pass
- `cargo check --all-targets` → clean (warnings only)
- No dependency changes.

Consumer side (kannaka-radio canonical-first reads + alias-only drift warning) shipped separately to `master` per the same timeline.