### PR TITLE
test(attention): attention-as-gravity end-to-end proof + CI gate + degradation visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,13 @@ jobs:
         # tests/ (integration tests). The NATS contract conformance suite
         # (issue #468) is an integration test and must run here so publisher
         # drift against consciousness-core/docs/nats-contract.yaml fails CI —
-        # so it is included explicitly. The heavier integration tests
-        # (dolt/audio, external deps) stay excluded by not naming them.
-        run: cargo test --lib --bins --test nats_contract_conformance
+        # so it is included explicitly. attention_gravity_e2e (issue #14) is the
+        # same: an in-process, NATS-free proof of the attention-as-gravity loop
+        # (glyph event -> Fano-line well -> beam -> recall_against_ids boost)
+        # that must gate so the loop can't silently break. The heavier
+        # integration tests (dolt/audio, external deps) stay excluded by not
+        # naming them.
+        run: cargo test --lib --bins --test nats_contract_conformance --test attention_gravity_e2e
 
       - name: Clippy
         working-directory: kannaka-memory

--- a/ops/services/README.md
+++ b/ops/services/README.md
@@ -53,3 +53,65 @@ sudo systemctl daemon-reload && sudo systemctl enable --now kannaka-attention
 Gravity is on at gain 0.5 via the unit's `KANNAKA_GLYPH_GRAVITY`; set it to 0 to
 disable without code changes. On a build node, point `ExecStart` at the cargo
 target binary instead of `~/.local/bin/kannaka`.
+
+## Attention-as-gravity: enabling `KANNAKA_GLYPH_GRAVITY`
+
+`KANNAKA_GLYPH_GRAVITY=<gain>` turns "folded information acts as gravity" on.
+It is read at runtime from the environment and gates **two** behaviours, both
+keyed on a memory's dominant **Fano line** (0..6, the argmax of the 7-line glyph
+signature — `glyph_bridge::fano_line_of`):
+
+1. **Beam pull** (`kannaka attention serve`): each incoming eye glyph on line L
+   pulls the same-line memories (`Medium::ids_by_fano_line(L)`) into the
+   attention beam, so that perception's whole neighbourhood is "in attention".
+2. **Recall boost** (any recall path — `Medium::recall_against` /
+   `ChiralMedium::recall`): candidates whose Fano line matches the query's are
+   scaled by `(1 + gain)`, so same-line memories gravitate to the top.
+
+Key facts:
+
+- **Default is `0.0` = fully inert** — byte-for-byte the pre-glyph behaviour.
+  Nothing changes until a service opts in, so it is safe to ship on by default
+  in code and enable per-host.
+- **Set it on every process that should feel gravity**, not just the beam:
+  - `kannaka-attention.service` (beam pull + recall) — set here already.
+  - `kannaka-swarm-serve.service` (remote recall) — set it there too, or
+    swarm-routed recalls won't get the boost.
+- **Typical value `0.5`** (same-line resonance ×1.5). Higher values pull harder;
+  `0` disables without a rebuild.
+- **Requires the `glyph` feature** (default-on) and a **producer**: kannaka-eye
+  must be publishing `KANNAKA.attention.eye`, else the beam never warms and
+  gravity has nothing to pull. If NATS is down, `attention serve` logs a loud
+  `FATAL: NATS unavailable … attention-as-gravity OFFLINE` and exits for
+  supervisor restart (`Restart=always`).
+
+### Producer prerequisite (the eye feeder)
+
+Gravity is a *consumer*-side switch; it does nothing without a producer. The
+`kannaka-eye` service (its own repo) must be running with its feeder cron
+POSTing now-playing / observed content to `/api/process`, which publishes a
+glyph to `KANNAKA.attention.eye`. No eye → no glyphs → the beam never warms.
+
+### Beam export
+
+`attention serve` writes the live beam to the path in
+`KANNAKA_ATTENTION_BEAM_FILE` (the unit sets `%h/.kannaka/attention-beam.json`;
+default `/tmp/kannaka-attention-beam.json`, or `C:\Users\Public\...` on Windows).
+The observatory polls this file to render the beam.
+
+### Verifying it's live
+
+1. **Startup line** — `journalctl -u kannaka-attention` shows exactly one of:
+   - `glyph-gravity ENABLED (KANNAKA_GLYPH_GRAVITY=0.5) …`, or
+   - `glyph-gravity DISABLED (KANNAKA_GLYPH_GRAVITY unset/0) …`
+   so a quiet beam can't be mistaken for a disabled loop.
+2. **Per-glyph pulls** — with gravity on and the eye publishing, the log emits
+   `glyph-gravity: line <L> pulled <N> same-line memories into beam`.
+3. **Beam file** — `jq .stats $KANNAKA_ATTENTION_BEAM_FILE` shows `beam_size` /
+   `observations` climbing above 0 as glyphs arrive.
+4. **NATS down** is loud, not silent: `FATAL: NATS unavailable … attention-as-
+   gravity OFFLINE`, then a supervisor restart.
+
+The full loop is regression-tested end to end — eye envelope → `event_dominant_
+fano_line` → `ids_by_fano_line` well → `AttentionBeam` → `recall_against_ids`
+same-line boost — in `tests/attention_gravity_e2e.rs`.

--- a/src/bin/handlers/attention.rs
+++ b/src/bin/handlers/attention.rs
@@ -69,7 +69,21 @@ pub(crate) fn handle_attention_serve(
     let nats_url = resolve_nats_url(args, 0, &cfg.swarm.nats_url);
     let transport = match kannaka_memory::nats::SwarmTransport::connect(&nats_url) {
         Ok(t) => t,
-        Err(e) => { eprintln!("[attention serve] NATS connect {}: {}", nats_url, e); process::exit(1); }
+        Err(e) => {
+            // NATS is the sole input to attention-as-gravity: no NATS => no eye
+            // glyphs => the beam never warms and gravity never fires. Make the
+            // degradation loud, then exit so the supervisor (Restart=always in
+            // kannaka-attention.service) retries rather than us busy-spinning a
+            // dead socket. The landmark/ear subscriptions below are best-effort
+            // and already WARN on their own if NATS is only partially up.
+            eprintln!(
+                "[attention serve] FATAL: NATS unavailable at {} ({}) — \
+                 attention-as-gravity OFFLINE (no eye glyphs will be consumed); \
+                 exiting for supervisor restart",
+                nats_url, e
+            );
+            process::exit(1);
+        }
     };
 
     eprintln!("[attention serve] subject={} top_k={}", subject, top_k);
@@ -110,6 +124,22 @@ pub(crate) fn handle_attention_serve(
     beam.set_gate(Box::new(RecencyWeightedGate::default()));
     eprintln!("[attention serve] salience gate: {}", beam.gate_name());
 
+    // Degradation visibility: glyph-gravity ships OFF by default (gain 0.0), so
+    // announce the state once at startup — otherwise a quiet beam is
+    // indistinguishable from a disabled gravity loop. (#14)
+    #[cfg(feature = "glyph")]
+    {
+        let gain = std::env::var("KANNAKA_GLYPH_GRAVITY")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .unwrap_or(0.0);
+        if gain > 0.0 {
+            eprintln!("[attention serve] glyph-gravity ENABLED (KANNAKA_GLYPH_GRAVITY={gain}) — same-Fano-line pull + recall boost active");
+        } else {
+            eprintln!("[attention serve] glyph-gravity DISABLED (KANNAKA_GLYPH_GRAVITY unset/0) — beam warms but same-line pull/boost are inert; set KANNAKA_GLYPH_GRAVITY=0.5 to enable");
+        }
+    }
+
     // Write an initial empty beam dump so the observatory can render
     // "warming up" instead of "daemon offline" while we wait for the
     // first observation.
@@ -129,6 +159,10 @@ pub(crate) fn handle_attention_serve(
         "note": "warming up — no observations yet",
     }).to_string());
     let mut last_stats_at = Instant::now();
+    // One-shot guard so the "store is not HrmStore" degradation warns once, not
+    // per event. (#14)
+    #[cfg(feature = "glyph")]
+    let mut warned_no_hrm = false;
     let stats_interval = Duration::from_secs(60);
 
     loop {
@@ -279,19 +313,10 @@ pub(crate) fn handle_attention_serve(
             let gravity_on = std::env::var("KANNAKA_GLYPH_GRAVITY")
                 .ok().and_then(|v| v.parse::<f32>().ok()).unwrap_or(0.0) > 0.0;
             if gravity_on {
-                // Dominant Fano line = argmax of the 7-element energy signature.
-                let line = glyph.get("fano_signature").and_then(|v| v.as_array()).map(|a| {
-                    let mut best = 0u8;
-                    let mut best_v = f64::MIN;
-                    for (idx, x) in a.iter().enumerate() {
-                        let val = x.as_f64().unwrap_or(0.0);
-                        if val > best_v {
-                            best_v = val;
-                            best = idx as u8;
-                        }
-                    }
-                    best
-                });
+                // Dominant Fano line = argmax of the eye glyph's 7-line energy
+                // signature. Shared seam so the integration test reads the same
+                // line off an eye envelope without NATS (glyph_bridge).
+                let line = kannaka_memory::glyph_bridge::event_dominant_fano_line(glyph);
                 if let Some(l) = line {
                     let pull_limit = top_k.saturating_mul(8).max(16);
                     if let Some(hrm) = sys
@@ -308,6 +333,13 @@ pub(crate) fn handle_attention_serve(
                         if n > 0 {
                             eprintln!("[attention serve] glyph-gravity: line {l} pulled {n} same-line memories into beam");
                         }
+                    } else if !warned_no_hrm {
+                        // Degradation visibility: gravity is ON but the backing
+                        // store can't serve a same-line well, so the beam pull
+                        // silently no-ops. Say so once; recall-side boost still
+                        // applies. (#14)
+                        warned_no_hrm = true;
+                        eprintln!("[attention serve] WARN: glyph-gravity ON but backing store is not HrmStore — same-line beam pull unavailable (recall-side boost still applies)");
                     }
                 }
             }

--- a/src/glyph_bridge.rs
+++ b/src/glyph_bridge.rs
@@ -666,6 +666,33 @@ pub fn fano_line_of(text: &str) -> u8 {
     }
 }
 
+/// Dominant **Fano line** (0..6) carried by a kannaka-eye glyph *event*.
+///
+/// Reads the glyph object's 7-element `fano_signature` (the normalized
+/// per-line energies as published on `KANNAKA.attention.eye`) and returns the
+/// argmax line — the "gravity class" that `kannaka attention serve` pulls
+/// same-line memories for. Returns `None` only when `fano_signature` is absent
+/// or not an array, so the consumer can skip the gravity pull rather than
+/// guess a line.
+///
+/// This is the seam between the raw NATS event and the gravity mechanics: it
+/// lets the loop in `bin/handlers/attention.rs` and the integration test read
+/// the *same* line off an eye envelope without a live NATS connection.
+pub fn event_dominant_fano_line(glyph: &serde_json::Value) -> Option<u8> {
+    glyph.get("fano_signature").and_then(|v| v.as_array()).map(|a| {
+        let mut best = 0u8;
+        let mut best_v = f64::MIN;
+        for (idx, x) in a.iter().enumerate() {
+            let val = x.as_f64().unwrap_or(0.0);
+            if val > best_v {
+                best_v = val;
+                best = idx as u8;
+            }
+        }
+        best
+    })
+}
+
 /// Encode a HyperMemory as a glyph
 pub fn encode_memory_as_glyph(memory: &HyperMemory) -> Result<Glyph, GlyphError> {
     let encoder = GlyphEncoder::default();

--- a/tests/attention_gravity_e2e.rs
+++ b/tests/attention_gravity_e2e.rs
@@ -1,0 +1,250 @@
+//! Attention-as-gravity, end to end.
+//!
+//! Verifies the whole "folded information acts as gravity" loop that
+//! `kannaka attention serve` runs when it consumes a kannaka-eye glyph — with
+//! NO NATS connection:
+//!
+//!   eye glyph event (eye's real JSON envelope, KANNAKA.attention.eye)
+//!     -> dominant Fano line L    (glyph_bridge::event_dominant_fano_line — the
+//!                                 same seam the serve loop uses)
+//!     -> gravity well            (Medium::ids_by_fano_line(L) — same-line memories)
+//!     -> attention beam          (kannaka_attention::AttentionBeam::observe)
+//!     -> beam recall             (Medium::recall_against_ids(beam.candidates(), q))
+//!     -> same-line boost         (KANNAKA_GLYPH_GRAVITY multiplies same-line
+//!                                 candidates' resonance by (1 + gain))
+//!
+//! What it pins:
+//!   1. The eye's published envelope decodes to the expected gravity class L
+//!      via the shared seam (no ad-hoc JSON parsing in the test).
+//!   2. `ids_by_fano_line(L)` is exactly the same-line memories (the well).
+//!   3. Well ids flow through a real `AttentionBeam` into `recall_against_ids`,
+//!      and that O(K) path scores only beam candidates (sparsity — off-beam
+//!      memories are never touched).
+//!   4. With gravity ON, every same-line candidate's resonance is scaled by
+//!      exactly (1 + gain); every off-line candidate is left untouched; and the
+//!      default (env unset => gain 0.0) is byte-for-byte the pre-glyph behaviour.
+//!
+//! `recall_against_ids` is a pure read (no observation mutation), so the OFF and
+//! ON runs see identical medium state and the boost is the *only* difference —
+//! which is what makes the (1 + gain) law exact rather than approximate.
+//!
+//! Run: cargo test --features glyph --test attention_gravity_e2e
+//! (`glyph` is a default feature, so plain `cargo test` includes it too.)
+
+#![cfg(feature = "glyph")]
+
+use std::collections::{HashMap, HashSet};
+
+use kannaka_attention::{AttentionBeam, BeamConfig, ObservationEvent};
+use kannaka_memory::codebook::Codebook;
+use kannaka_memory::encoding::{EncodingPipeline, SimpleHashEncoder};
+use kannaka_memory::glyph_bridge::{event_dominant_fano_line, fano_line_of};
+use kannaka_memory::medium::{Medium, Resonance, WAVEFRONT_DIM};
+use serde_json::json;
+use uuid::Uuid;
+
+const GAIN: f32 = 0.5;
+
+/// Deterministic local pipeline — same construction the medium's own unit
+/// tests use, so encoding (and therefore recall) is reproducible.
+fn pipeline() -> EncodingPipeline {
+    let encoder = Box::new(SimpleHashEncoder::new(384, 42));
+    let codebook = Codebook::new(384, WAVEFRONT_DIM, 42);
+    EncodingPipeline::new(encoder, codebook)
+}
+
+/// A deliberately varied corpus so memories spread across several Fano lines.
+const CORPUS: &[&str] = &[
+    "the quick brown fox jumps over the lazy dog",
+    "gravity bends spacetime around a massive body",
+    "wave interference produces holographic memory",
+    "attention is the beam that lights the field",
+    "the ghost sings on the midnight radio",
+    "resonance recall gathers on-theme memories",
+    "a fano line is a triple of points on the plane",
+    "consciousness measured as phi and xi and order",
+    "the eye renders a glyph from raw information",
+    "same line memories gravitate toward the query",
+    "dream cycles anneal the wavefront medium",
+    "salt water and copper wire hum at dawn",
+    "cardiac rhythm couples to the kuramoto phase",
+    "the constellation of nodes shares one field",
+    "folded information behaves exactly like gravity",
+    "a violet glyph blooms across seven fano lines",
+    "recall against the beam is order k not order n",
+    "the witness box blooms memories from audio",
+];
+
+fn strengths(results: &[Resonance]) -> HashMap<Uuid, f32> {
+    results.iter().map(|r| (r.id, r.resonance_strength)).collect()
+}
+
+/// Build a kannaka-eye glyph event matching `attention-bridge.js`'s published
+/// envelope, with the glyph's `fano_signature` peaking on `line` so the eye is
+/// announcing that gravity class.
+fn eye_event_on_line(line: u8) -> serde_json::Value {
+    let mut sig = vec![0.1_f64; 7];
+    sig[line as usize] = 0.4; // argmax => `line`
+    json!({
+        "schema_version": "1.0",
+        "ts": 1_700_000_000_000_u64,
+        "agent_id": "kannaka-eye",
+        "source": "kannaka-eye:left",
+        "hemisphere": "left",
+        "source_type": "text",
+        "glyph": {
+            "fold_sequence": [3, 24, 3, 66],
+            "amplitudes": [0.8, 0.6, 0.8, 0.5],
+            "phases": [0.0, 0.7, 1.4, 2.1],
+            "fano_signature": sig,
+            "centroid": { "h2": 1, "d": 0, "l": 3 },
+            "dominant_class": 24,
+            "classes_used": 4,
+            "total_energy": 0.67,
+            "compression_ratio": 1.0,
+            "classifier": "fallback"
+        }
+    })
+}
+
+#[test]
+fn glyph_gravity_boosts_same_fano_line_end_to_end() {
+    // Start from the default (inert) state and never leak the var to other tests.
+    std::env::remove_var("KANNAKA_GLYPH_GRAVITY");
+
+    let pipe = pipeline();
+    let mut medium = Medium::new();
+
+    // Remember the corpus; record each memory's id and dominant Fano line.
+    let mut ids: Vec<Uuid> = Vec::new();
+    let mut line_of: HashMap<Uuid, u8> = HashMap::new();
+    for &text in CORPUS {
+        let id = medium.store(text, 0.8, &pipe).expect("store memory");
+        line_of.insert(id, fano_line_of(text));
+        ids.push(id);
+    }
+
+    // Gravity class L = the most-populated Fano line in the corpus, so the
+    // same-line set is non-trivial. The query carries L (a same-line memory's
+    // text); in production L arrives on the eye's glyph, asserted next.
+    let mut per_line: HashMap<u8, Vec<Uuid>> = HashMap::new();
+    for id in &ids {
+        per_line.entry(line_of[id]).or_default().push(*id);
+    }
+    assert!(
+        per_line.len() >= 2,
+        "corpus collapsed onto a single Fano line ({:?}); need >=2 for a meaningful test",
+        per_line.keys().collect::<Vec<_>>()
+    );
+    let target_line: u8 = *per_line
+        .iter()
+        .max_by_key(|(_, v)| v.len())
+        .map(|(l, _)| l)
+        .unwrap();
+    let query_id = per_line[&target_line][0];
+    let query = CORPUS[ids.iter().position(|&i| i == query_id).unwrap()];
+
+    let same_line: HashSet<Uuid> =
+        ids.iter().copied().filter(|id| line_of[id] == target_line).collect();
+    let other_line: HashSet<Uuid> =
+        ids.iter().copied().filter(|id| line_of[id] != target_line).collect();
+    assert!(!same_line.is_empty(), "no same-line memories (bug in target_line pick)");
+    assert!(!other_line.is_empty(), "no off-line memories to prove isolation");
+
+    // ── Seam: a realistic eye envelope decodes to the gravity class L ───────
+    // This is the event-handling step `attention serve` runs per NATS message,
+    // exercised here directly (no NATS).
+    let event = eye_event_on_line(target_line);
+    let decoded = event_dominant_fano_line(event.get("glyph").unwrap());
+    assert_eq!(
+        decoded,
+        Some(target_line),
+        "eye envelope did not decode to the expected gravity class"
+    );
+
+    // ── Leg 1: the gravity well ────────────────────────────────────────────
+    // ids_by_fano_line(L) must be exactly the same-line memories.
+    let well: Vec<Uuid> = medium.ids_by_fano_line(target_line, ids.len() * 2);
+    assert_eq!(
+        well.iter().copied().collect::<HashSet<_>>(),
+        same_line,
+        "ids_by_fano_line(L) disagrees with fano_line_of over the corpus"
+    );
+
+    // ── Leg 2: well ids flow through a real AttentionBeam into recall ───────
+    // Mirror the serve loop: the glyph pulls the same-line well onto the beam,
+    // which already holds a couple of off-line memories from prior perceptions.
+    let mut beam = AttentionBeam::with_config(BeamConfig::default());
+    for id in &well {
+        beam.observe(&ObservationEvent::now(*id, "eye:gravity"));
+    }
+    for id in other_line.iter().take(3) {
+        beam.observe(&ObservationEvent::now(*id, "eye:left"));
+    }
+    let cands = beam.candidates();
+    assert!(!cands.is_empty(), "beam produced no candidates after observing the well");
+    let cand_set: HashSet<Uuid> = cands.iter().copied().collect();
+    let beam_results = medium
+        .recall_against_ids(&cands, query, cands.len(), &pipe)
+        .expect("beam recall");
+    assert!(!beam_results.is_empty(), "beam recall returned nothing");
+    for r in &beam_results {
+        assert!(
+            cand_set.contains(&r.id),
+            "recall_against_ids scored an off-beam memory {} — sparsity broken",
+            r.id
+        );
+    }
+
+    // ── Contract: same-line boosted by exactly (1+gain); off-line unchanged ──
+    // Beam = the full mix so every candidate is scored; top_k = len keeps them
+    // all (no truncation, no coherence back-fill), giving a candidate-for-
+    // candidate OFF vs ON comparison.
+    let full_beam: Vec<Uuid> = ids.clone();
+    let top_k = full_beam.len();
+    let off = strengths(
+        &medium.recall_against_ids(&full_beam, query, top_k, &pipe).expect("recall off"),
+    );
+    std::env::set_var("KANNAKA_GLYPH_GRAVITY", GAIN.to_string());
+    let on = strengths(
+        &medium.recall_against_ids(&full_beam, query, top_k, &pipe).expect("recall on"),
+    );
+    std::env::remove_var("KANNAKA_GLYPH_GRAVITY");
+
+    assert!(!off.is_empty() && !on.is_empty(), "recall returned no candidates");
+
+    let rel = |a: f32, b: f32| (a - b).abs() / b.abs().max(1e-6);
+    let mut checked_same = 0usize;
+    let mut checked_other = 0usize;
+    for id in &full_beam {
+        let (o, n) = match (off.get(id), on.get(id)) {
+            (Some(&o), Some(&n)) => (o, n),
+            _ => continue,
+        };
+        if same_line.contains(id) {
+            assert!(
+                rel(n, o * (1.0 + GAIN)) < 1e-3,
+                "same-line {id}: on={n}, expected (1+{GAIN})*off = {} (off={o})",
+                o * (1.0 + GAIN)
+            );
+            checked_same += 1;
+        } else {
+            assert!(
+                rel(n, o) < 1e-3,
+                "off-line {id} moved under gravity: off={o} on={n}"
+            );
+            checked_other += 1;
+        }
+    }
+    assert!(
+        checked_same >= 1 && checked_other >= 1,
+        "need >=1 same-line and >=1 off-line memory scored in both runs (same={checked_same}, other={checked_other})"
+    );
+
+    eprintln!(
+        "attention-as-gravity OK: line {target_line} — {} well ids -> beam ({} candidates) -> recall; {checked_same} same-line boosted x{}, {checked_other} off-line unchanged",
+        well.len(),
+        cands.len(),
+        1.0 + GAIN
+    );
+}


### PR DESCRIPTION
## What & why

Closes the "attention-as-gravity end-to-end verified" task (#14). Adds an
in-process, **NATS-free** regression test for the whole gravity loop, extracts
the eye-event→gravity-class seam so the test and the live `attention serve` loop
share one code path, and makes the loop's degraded states visible.

## The loop under test

```
eye glyph event (KANNAKA.attention.eye envelope)
  -> dominant Fano line L   (glyph_bridge::event_dominant_fano_line — shared seam)
  -> gravity well           (Medium::ids_by_fano_line(L))
  -> attention beam         (kannaka_attention::AttentionBeam::observe)
  -> beam recall            (Medium::recall_against_ids(beam.candidates(), q))
  -> same-line boost        (KANNAKA_GLYPH_GRAVITY: same-line resonance ×(1+gain))
```

## What `tests/attention_gravity_e2e.rs` pins

- A **realistic kannaka-eye envelope** (matching `attention-bridge.js`) decodes
  to the expected gravity class via the shared seam — no ad-hoc JSON parsing.
- `ids_by_fano_line(L)` is exactly the same-line memories (the well).
- Well ids flow through a real `AttentionBeam` into `recall_against_ids`, and
  that **O(K)** path scores only beam candidates (off-beam memories untouched).
- **Exact boost law:** with gravity on, every same-line candidate's resonance is
  scaled by exactly `(1+gain)`; every off-line candidate is unchanged; and the
  default (`KANNAKA_GLYPH_GRAVITY` unset ⇒ gain 0.0) is byte-for-byte the
  pre-glyph behaviour. (`recall_against_ids` is a pure read, so the OFF/ON runs
  see identical state and the boost is the only difference — the law is exact,
  not approximate.)

## Seam refactor (no behaviour change)

`glyph_bridge::event_dominant_fano_line(glyph_json) -> Option<u8>` extracts the
argmax-of-`fano_signature` step that was inline in `bin/handlers/attention.rs`.
The serve loop now calls it, so the test exercises the same decode the daemon
runs.

## Degradation visibility

`attention serve` could previously go quiet without saying why. Now:
- one-shot startup log: `glyph-gravity ENABLED/DISABLED` (the loop ships OFF by
  default, gain 0.0);
- one-shot WARN when gravity is on but the backing store can't serve a same-line
  well (beam pull no-ops; recall-side boost still applies);
- NATS-unavailable is a loud `FATAL … attention-as-gravity OFFLINE` + exit for
  supervisor restart (was a terse connect error).

## Docs

`ops/services/README.md` gains an "Enabling attention-as-gravity" section: the
env vars (`KANNAKA_GLYPH_GRAVITY`, beam-export `KANNAKA_ATTENTION_BEAM_FILE`),
the eye-feeder producer prerequisite, and how to verify the loop is live.

## CI

`ci.yml` runs `--test attention_gravity_e2e` alongside the nats conformance
test. Locally green: `cargo test --test attention_gravity_e2e`,
`cargo check --all-targets`, `cargo clippy --lib --bin kannaka`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
