### PR TITLE
[auto-maintainer] fix(dead-code): remove dead _is_hrm, _order, _initial_r/_final_r computations

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -2260,9 +2260,6 @@ fn main() {
                 .collect::<serde_json::Map<String, serde_json::Value>>()
                 .into();
 
-            // Check if HRM mode is active
-            let _is_hrm = true; // HRM is the canonical substrate
-
             let mut output = serde_json::json!({
                 "total_memories": stats.total_memories,
                 "active_memories": stats.active_memories,
@@ -2964,8 +2961,6 @@ fn main() {
         }
         "stats" => {
             let stats = sys.stats();
-            let _is_hrm = true; // HRM is the canonical substrate
-
             println!("Kannaka Memory System:");
             println!("  Total memories: {}", stats.total_memories);
             println!("  Active memories: {}", stats.active_memories);

--- a/src/collective/proofs.rs
+++ b/src/collective/proofs.rs
@@ -208,8 +208,6 @@ pub fn prove_existence(
 ///
 /// Checks: g^z_v · h^z_r == t · C^c
 pub fn verify_existence(proof: &ExistenceProof) -> bool {
-    let _order = PRIME - 1;
-
     // Recompute challenge
     let c = challenge_hash(&[proof.commitment, proof.t]);
 

--- a/src/queen.rs
+++ b/src/queen.rs
@@ -1319,8 +1319,6 @@ mod tests {
             make_agent_phase("b", 2.0, 0.8, 1.0),
         ];
 
-        let _initial_r = QueenSync::compute_order_parameter(&swarm).0;
-
         // Run 50 sync steps
         for _ in 0..50 {
             let state = queen.queen_sync_step(&swarm);
@@ -1329,7 +1327,6 @@ mod tests {
             let _ = state;
         }
 
-        let _final_r = QueenSync::compute_order_parameter(&swarm).0;
         // Our phase should have moved toward the mean field
         // (full convergence requires all agents to move, but our phase should shift)
         assert!(


### PR DESCRIPTION
## What changed

Four dead computations removed across three files — no behaviour change.

### 1. `src/bin/kannaka.rs` (observe path) — dead `_is_hrm = true` (−3 lines)

```rust
// Check if HRM mode is active
let _is_hrm = true; // HRM is the canonical substrate
```

`_is_hrm` is assigned the constant `true` and never referenced anywhere in the enclosing block or the file. The comment intent ("HRM is the canonical substrate") is already expressed by the unconditional HRM code path that follows; nothing branches on this variable. Dead since the non-HRM backends were removed.

### 2. `src/bin/kannaka.rs` (stats path) — dead `_is_hrm = true` (−2 lines)

Identical pattern in the `"stats"` command arm. Same analysis: assigned `true`, never referenced.

### 3. `src/collective/proofs.rs` `verify_existence` — dead `_order = PRIME - 1` (−2 lines)

```rust
let _order = PRIME - 1;
```

`_order` is never referenced anywhere in `verify_existence`. All modular arithmetic in the verifier passes `PRIME` directly to `mod_pow`/`mod_mul` (exponentiation and multiplication happen in **Zp**, mod the prime). Contrast `prove_existence` on the line above, which correctly uses `order = PRIME - 1` for the Schnorr response arithmetic (mod the group order **Zp\***). In the verifier there is no group-order modular reduction, so `_order` is dead. Pure constant arithmetic with no side effects.

### 4. `src/queen.rs` test `queen_sync_converges` — dead `_initial_r` and `_final_r` (−3 lines)

```rust
let _initial_r = QueenSync::compute_order_parameter(&swarm).0;
// ... 50 sync steps ...
let _final_r = QueenSync::compute_order_parameter(&swarm).0;
```

Both call `compute_order_parameter(&swarm)` — a pure, immutable read (`&[AgentPhase]` input, no mutable state). Neither value appears in any assertion; the test only asserts `queen.phase != 0.0`. The values were likely stubs for a planned `assert!(final_r > initial_r)` convergence assertion that was never written. Dead pure computations removed; test intent is unchanged.

## Why it's safe

- All five removals are values computed and immediately discarded.
- No logic change in any live code path. `_is_hrm` was a literal `true`; nothing branched on it. `_order` was pure arithmetic with no I/O or mutation. `_initial_r`/`_final_r` used a pure `&`-receiver function.
- The `_` prefix on each variable was Rust's own signal that the value is unused; removing the computation is the logical completion of that intent.
- **3 files changed, 10 deletions(−), 0 insertions.**

## How verified

`cargo check` is unavailable in this environment (private `consciousness-core` dependency not present). Correctness verified by inspection:
- `_is_hrm`: assigned constant `true`; `grep -n _is_hrm src/bin/kannaka.rs` returns only the two assignment lines — no use sites.
- `_order`: `grep -n _order src/collective/proofs.rs` returns only line 211 (now removed) — no use sites.
- `_initial_r`/`_final_r`: `grep -n '_initial_r\|_final_r' src/queen.rs` returns only the two assignment lines — no use sites. `compute_order_parameter` takes `&[AgentPhase]`, confirmed pure by signature.

## Runtime

~22 minutes wall-clock (jitter + in-flight detection + repo selection + anti-noise check + source scan + edits + duplicate check + push + PR).

---
*Auto-maintainer run · 2026-07-01T22:17 UTC · kannaka-memory*

---
_Generated by [Claude Code](https://claude.ai/code/session_012rWbRHu35kuJLDL8sZkMm8)_