### PR TITLE
feat(bench): export-recall-scenarios — kannaka-recall-bench/1 (T2.1, #476)

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -748,6 +748,7 @@ fn is_builtin_subcommand(verb: &str) -> bool {
         | "radio" | "market" | "constellation"
         // ops / data movement
         | "orchestrate" | "config" | "export" | "export-json"
+        | "export-recall-scenarios"
         | "import" | "import-json" | "announce-status"
         // feature-gated
         | "classify" | "cross-modal-dream"
@@ -3151,6 +3152,105 @@ fn main() {
                 })
                 .collect();
             println!("{}", serde_json::to_string(&output).unwrap());
+        }
+        "export-recall-scenarios" => {
+            // T2.1 (#476): dump real recall events as `kannaka-recall-bench/1` —
+            // per query: candidate amplitudes, HASHED labels, classical argmax,
+            // hemisphere, timestamp. Labels are hashed so the corpus can leave the
+            // private repo without leaking memory content. Read-only: uses the
+            // non-observing recall path so exporting never perturbs the field, and
+            // caps candidates at 16 (4 qubits) for shallow circuits.
+            use kannaka_memory::recall_bench::{
+                build_scenario, hash_label, shuffled_indices, Candidate, RecallBench,
+                MAX_CANDIDATES, RECALL_BENCH_FORMAT,
+            };
+            const USAGE: &str = "Usage: kannaka export-recall-scenarios [--n N] [--seed S]";
+            let mut n = 50usize;
+            let mut seed = 42u64;
+            let mut i = command_start + 1;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--n" | "--count" => {
+                        n = parse_flag_value(&args, i, "--n", USAGE);
+                        i += 2;
+                    }
+                    "--seed" => {
+                        seed = parse_flag_value(&args, i, "--seed", USAGE);
+                        i += 2;
+                    }
+                    other if other.starts_with("--") => {
+                        eprintln!("export-recall-scenarios: unknown flag: {other}");
+                        eprintln!("{USAGE}");
+                        process::exit(2);
+                    }
+                    _ => i += 1,
+                }
+            }
+
+            let hemisphere = if sys.engine.store.is_chiral() { "right" } else { "flat" };
+            let all = sys.engine.store.all_memories().unwrap_or_default();
+            // Query seeds = real, live content memories — skip structural summaries,
+            // hallucinated bridges, and ghosted (zero-amplitude) traces.
+            let seeds: Vec<&kannaka_memory::memory::HyperMemory> = all
+                .iter()
+                .copied()
+                .filter(|m| {
+                    m.amplitude > 0.0
+                        && !m.hallucinated
+                        && !m.content.starts_with("__")
+                        && !m.content.trim().is_empty()
+                })
+                .collect();
+
+            let order = shuffled_indices(seeds.len(), seed);
+            let now = chrono::Utc::now().to_rfc3339();
+            let mut scenarios = Vec::with_capacity(n);
+            for &si in &order {
+                if scenarios.len() >= n {
+                    break;
+                }
+                let seed_mem = seeds[si];
+                let cands: Vec<Candidate> = match sys
+                    .engine
+                    .store
+                    .recall_resonance_readonly(&seed_mem.content, MAX_CANDIDATES)
+                {
+                    Ok(rs) => rs
+                        .into_iter()
+                        .map(|r| Candidate {
+                            label: hash_label(&r.content),
+                            amplitude: r.resonance_strength,
+                        })
+                        .collect(),
+                    Err(_) => Vec::new(),
+                };
+                if cands.is_empty() {
+                    continue;
+                }
+                scenarios.push(build_scenario(
+                    hash_label(&seed_mem.content),
+                    cands,
+                    hemisphere,
+                    now.clone(),
+                ));
+            }
+
+            if scenarios.len() < n {
+                eprintln!(
+                    "export-recall-scenarios: emitted {} of {} requested ({} eligible seed memories)",
+                    scenarios.len(),
+                    n,
+                    seeds.len()
+                );
+            }
+
+            let bench = RecallBench {
+                format: RECALL_BENCH_FORMAT.to_string(),
+                generated_at: now,
+                n: scenarios.len(),
+                scenarios,
+            };
+            println!("{}", serde_json::to_string_pretty(&bench).unwrap());
         }
         "import-json" => {
             if args.len() < command_start + 2 {

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -828,6 +828,18 @@ impl HrmStore {
         Ok(results)
     }
 
+    /// Read-only resonance recall — same scoring as [`recall_resonance`] but
+    /// WITHOUT the observation write-back, so it never mutates energies or marks
+    /// the store dirty. Used by the recall-scenario benchmark export (#476):
+    /// dumping a corpus must not perturb the live substrate, and back-to-back
+    /// export queries must not amplify each other's amplitudes. Runs against the
+    /// flat medium (which mirrors the right hemisphere in chiral mode),
+    /// consistent with [`consciousness_metrics`](Self::consciousness_metrics).
+    pub fn recall_resonance_readonly(&self, query: &str, top_k: usize) -> Result<Vec<Resonance>, StoreError> {
+        self.medium.recall(query, top_k, &self.pipeline)
+            .map_err(|e| StoreError::Other(format!("readonly resonance recall failed: {}", e)))
+    }
+
     /// Beam-aware recall — score only the memories in the attention beam.
     ///
     /// This is the system-level entry to `Medium::recall_against_ids`. The
@@ -1914,6 +1926,18 @@ impl MediumBackend for HrmStore {
 
     fn flush_reactivation(&self) {
         Self::flush_reactivation(self);
+    }
+
+    fn recall_resonance_readonly(
+        &self,
+        query: &str,
+        top_k: usize,
+    ) -> Result<Vec<Resonance>, StoreError> {
+        Self::recall_resonance_readonly(self, query, top_k)
+    }
+
+    fn is_chiral(&self) -> bool {
+        Self::is_chiral(self)
     }
 
     fn consolidate_resonance(&mut self, opts: &ConsolidateOpts) -> ConsolidateReport {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod l6;
 pub mod medium;
 
 pub mod hrm_store;
+pub mod recall_bench;
 
 pub mod config;
 

--- a/src/recall_bench.rs
+++ b/src/recall_bench.rs
@@ -1,0 +1,188 @@
+//! T2.1 — recall-scenario benchmark export (`kannaka-recall-bench/1`).
+//!
+//! Dumps real recall events as JSON for the Quantum-Wave correspondence
+//! benchmark (issue #476): each scenario is one recall event — a ranked set of
+//! candidate amplitudes plus the classical argmax — that a quantum backend can
+//! reproduce via amplitude amplification and compare against.
+//!
+//! **Privacy:** labels are HASHED (SHA-256, non-reversible), so a generated
+//! scenario corpus may leave the private repo without any memory content
+//! leaking. The hash is stable, so a candidate that IS the query seed keeps the
+//! same label as `query_label` — ground truth survives the scrub.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+/// Wire-format identifier embedded in every export.
+pub const RECALL_BENCH_FORMAT: &str = "kannaka-recall-bench/1";
+
+/// Max candidates per scenario. 16 = 4 qubits, keeping circuits shallow on
+/// noisy hardware (#476).
+pub const MAX_CANDIDATES: usize = 16;
+
+/// Stable, non-reversible label for a memory's content: the first 64 bits of
+/// SHA-256, hex-encoded. Collision-safe at corpus scale and content can't be
+/// recovered, so a scenario file is safe to publish. Identical content →
+/// identical label (preserves the query↔target linkage post-scrub).
+pub fn hash_label(content: &str) -> String {
+    let digest = Sha256::digest(content.as_bytes());
+    let mut s = String::with_capacity(16);
+    for b in digest.iter().take(8) {
+        use std::fmt::Write;
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+/// One recall candidate: a hashed label and its resonance amplitude.
+#[derive(Debug, Clone, Serialize)]
+pub struct Candidate {
+    /// Hashed content label — never raw content.
+    pub label: String,
+    /// Resonance amplitude for this candidate under the scenario's query.
+    pub amplitude: f32,
+}
+
+/// One recall event, ready for the correspondence benchmark.
+#[derive(Debug, Clone, Serialize)]
+pub struct RecallScenario {
+    /// Hashed label of the query seed memory (matches its own candidate label).
+    pub query_label: String,
+    /// Candidates in recall-rank order, capped at [`MAX_CANDIDATES`].
+    pub candidates: Vec<Candidate>,
+    /// Index into `candidates` of the highest-amplitude candidate — the answer
+    /// classical (argmax) recall returns. `None` iff there are no candidates.
+    pub classical_argmax: Option<usize>,
+    /// Which store the recall ran against: `"right"` (chiral deep hemisphere,
+    /// which recall resonates on) or `"flat"` (single medium).
+    pub hemisphere: String,
+    /// RFC3339 time this scenario was exported.
+    pub timestamp: String,
+}
+
+/// The full export envelope.
+#[derive(Debug, Clone, Serialize)]
+pub struct RecallBench {
+    /// Always [`RECALL_BENCH_FORMAT`].
+    pub format: String,
+    /// RFC3339 export time.
+    pub generated_at: String,
+    /// Number of scenarios actually emitted.
+    pub n: usize,
+    pub scenarios: Vec<RecallScenario>,
+}
+
+/// Assemble a scenario from a query label and ranked candidates.
+///
+/// Truncates to [`MAX_CANDIDATES`] and computes the classical argmax over the
+/// KEPT candidates (so the argmax always indexes into the emitted list). Pure —
+/// no I/O — so the argmax/cap/hash contract is unit-tested directly.
+pub fn build_scenario(
+    query_label: String,
+    mut candidates: Vec<Candidate>,
+    hemisphere: &str,
+    timestamp: String,
+) -> RecallScenario {
+    candidates.truncate(MAX_CANDIDATES);
+    let classical_argmax = candidates
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| {
+            a.amplitude
+                .partial_cmp(&b.amplitude)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(i, _)| i);
+    RecallScenario {
+        query_label,
+        candidates,
+        classical_argmax,
+        hemisphere: hemisphere.to_string(),
+        timestamp,
+    }
+}
+
+/// A deterministic shuffle of `0..len`, seeded so an export is reproducible on
+/// the same corpus. Callers walk this order and keep the first `n` seeds whose
+/// recall yields candidates (some may be empty on a tiny/degenerate field).
+pub fn shuffled_indices(len: usize, seed: u64) -> Vec<usize> {
+    use rand::seq::SliceRandom;
+    use rand::SeedableRng;
+    let mut idx: Vec<usize> = (0..len).collect();
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+    idx.shuffle(&mut rng);
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_label_is_stable_and_hides_content() {
+        let a = hash_label("the quiet wave settles");
+        let b = hash_label("the quiet wave settles");
+        let c = hash_label("a different memory");
+        assert_eq!(a, b, "same content → same label");
+        assert_ne!(a, c, "different content → different label");
+        assert_eq!(a.len(), 16, "64-bit hex label");
+        assert!(a.chars().all(|ch| ch.is_ascii_hexdigit()));
+        // The raw content must not be recoverable from / present in the label.
+        assert!(!a.contains("quiet"));
+    }
+
+    #[test]
+    fn build_scenario_caps_at_16_and_reindexes_argmax() {
+        // 20 candidates; the global max is beyond the 16-cap and must NOT be the
+        // argmax — the argmax is over the KEPT candidates only.
+        let mut cands: Vec<Candidate> = (0..20)
+            .map(|i| Candidate { label: format!("{i:016x}"), amplitude: i as f32 * 0.01 })
+            .collect();
+        // Make candidate #3 (kept) the strongest within the first 16.
+        cands[3].amplitude = 0.99;
+        let s = build_scenario("q".into(), cands, "flat", "t".into());
+        assert_eq!(s.candidates.len(), MAX_CANDIDATES, "capped to 16 (4 qubits)");
+        assert_eq!(s.classical_argmax, Some(3), "argmax indexes into the kept set");
+    }
+
+    #[test]
+    fn build_scenario_empty_has_no_argmax() {
+        let s = build_scenario("q".into(), Vec::new(), "right", "t".into());
+        assert_eq!(s.classical_argmax, None);
+        assert!(s.candidates.is_empty());
+    }
+
+    #[test]
+    fn shuffled_indices_is_a_seeded_permutation() {
+        let a = shuffled_indices(100, 42);
+        let b = shuffled_indices(100, 42);
+        let c = shuffled_indices(100, 7);
+        assert_eq!(a, b, "same seed → same order (reproducible export)");
+        assert_ne!(a, c, "different seed → different order");
+        let mut sorted = a.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, (0..100).collect::<Vec<_>>(), "a true permutation, no dupes/drops");
+    }
+
+    #[test]
+    fn envelope_serializes_with_format_tag() {
+        let s = build_scenario(
+            hash_label("seed"),
+            vec![Candidate { label: hash_label("seed"), amplitude: 1.0 }],
+            "flat",
+            "2026-07-01T00:00:00+00:00".into(),
+        );
+        let bench = RecallBench {
+            format: RECALL_BENCH_FORMAT.to_string(),
+            generated_at: "2026-07-01T00:00:00+00:00".into(),
+            n: 1,
+            scenarios: vec![s],
+        };
+        let v: serde_json::Value = serde_json::to_value(&bench).unwrap();
+        assert_eq!(v["format"], "kannaka-recall-bench/1");
+        assert_eq!(v["n"], 1);
+        assert_eq!(v["scenarios"][0]["classical_argmax"], 0);
+        // No raw content anywhere — only hashed labels.
+        assert_eq!(v["scenarios"][0]["query_label"], serde_json::json!(hash_label("seed")));
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -97,6 +97,24 @@ pub trait MediumBackend: Send + Sync {
         self.resonate_query(query, top_k)
     }
 
+    /// Read-only resonance recall — resonance scoring WITHOUT the observation
+    /// write-back, so it never mutates the field. Unlike [`resonate_query`], a
+    /// caller can run many of these without amplifying amplitudes or marking the
+    /// store dirty. Used by the recall-scenario benchmark export (#476). Default
+    /// errors; the HRM backend overrides it.
+    ///
+    /// [`resonate_query`]: MediumBackend::resonate_query
+    fn recall_resonance_readonly(
+        &self,
+        query: &str,
+        top_k: usize,
+    ) -> Result<Vec<crate::medium::Resonance>, StoreError> {
+        let _ = (query, top_k);
+        Err(StoreError::Other(
+            "recall_resonance_readonly not supported by this backend".into(),
+        ))
+    }
+
     /// Sparse-attention recall — score only the memories in `beam`.
     ///
     /// Default impl falls back to full `resonate_query` so backends that
@@ -208,6 +226,13 @@ pub trait MediumBackend: Send + Sync {
     /// Perform a chiral dream pass (right hemisphere only for deep=true).
     /// Only meaningful for HrmStore with a chiral medium. Default is a no-op.
     fn chiral_dream(&mut self, _deep: bool, _cycles: usize) {}
+
+    /// Whether this backend is running the chiral (two-hemisphere) medium.
+    /// Default false; HrmStore reports its actual mode. Lets read-only callers
+    /// (e.g. the recall-scenario export) label which store a recall ran against.
+    fn is_chiral(&self) -> bool {
+        false
+    }
 
     /// ADR-0036 Phase 1: flush per-memory reactivation counts to the sidecar.
     /// Default no-op; HrmStore writes `.reactivation.json` (sidecar only, safe


### PR DESCRIPTION
Closes #476.

## Summary

Adds `kannaka export-recall-scenarios [--n 50] [--seed 42]` — dumps real recall events as JSON for the Quantum-Wave correspondence benchmark. Each scenario is one recall event: a ranked set of **candidate amplitudes**, **hashed labels**, the **classical argmax**, **hemisphere**, and **timestamp**. Envelope format `kannaka-recall-bench/1`.

## Acceptance criteria (all met)

- [x] **exporter ships** — new CLI verb, wired into the builtin-subcommand set.
- [x] **50-scenario corpus generated from live memory** — verified end-to-end against the local 387-memory HRM: exactly 50 scenarios, `format=kannaka-recall-bench/1`, `hemisphere=right` (chiral field), `classical_argmax` equals the true amplitude-argmax in all 50.
- [x] **labels hashed; no memory content leaves** — every label is SHA-256 (first 64 bits, hex); validated 0 non-hex labels and no raw content anywhere in the output.

## Design

- **Privacy.** `hash_label` = SHA-256 → 16 hex chars. Non-reversible, so a corpus can leave the private repo. Stable, so a candidate that *is* the query seed keeps the same label as `query_label` — ground-truth linkage survives the scrub (in the local run, 20/50 scenarios surfaced the seed in their top-16, which is exactly the kind of signal the benchmark studies).
- **≤16 candidates/scenario** (4 qubits) so circuits stay shallow on noisy hardware.
- **Read-only by construction.** New `recall_resonance_readonly` runs the resonance scoring **without** the observation write-back that `recall_resonance` applies, so exporting never perturbs the live field and back-to-back export queries don't amplify each other's amplitudes. Exposed as a `MediumBackend` trait method (default errors; `HrmStore` overrides) so it's callable through the boxed backend, alongside a trait-level `is_chiral()` for the hemisphere label. `TestMedium` uses the defaults (untouched).
- **Deterministic sampling.** Query seeds are a seeded shuffle of live *content* memories, skipping consolidation summaries (`__`-prefixed), hallucinated bridges, and ghosted (zero-amplitude) traces. `--seed` makes an export reproducible on a fixed corpus.

## Testing

`src/recall_bench.rs` holds the pure, testable core with 5 unit tests (all green): stable content-hiding hash, 16-cap + argmax reindex, empty→no-argmax, seeded-permutation sampling, and envelope serialization with the format tag. `cargo check --lib --bin kannaka` clean; `cargo clippy --lib --bin kannaka` (the CI gate) exits 0 with zero warnings from the new code. The generated corpus is a runtime artifact (hashed-label-only, regenerable) and is intentionally not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)