### PR TITLE
feat(entropy): provenance on dreams + Ξ (T1.4, #474)

### DIFF
--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -3134,6 +3134,10 @@ fn main() {
                         "created_at": m.created_at.to_rfc3339(),
                         "layer_depth": m.layer_depth,
                         "hallucinated": m.hallucinated,
+                        // T1.4 (#474): entropy provenance of the dream/Ξ that last
+                        // wrote this wavefront (null ⇒ prng://legacy). Read from
+                        // the canonical WavefrontMeta.
+                        "provenance": sys.engine.store.provenance_of(&m.id),
                         "parents": m.parents,
                         "connections": m.connections.iter().map(|c| {
                             serde_json::json!({

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,11 +180,16 @@ pub struct EntropyConfig {
     /// `"prng"` (default) or `"reservoir"`.
     #[serde(default = "default_entropy_source")]
     pub source: String,
+    /// T1.4: whether dreams/Ξ actually CONSUME entropy from `source` (and record
+    /// its provenance). **Default false** — decoupled from `source` so the dream
+    /// stays deterministic until explicitly opted in. env `KANNAKA_DREAM_ENTROPY`.
+    #[serde(default)]
+    pub dream_perturbation: bool,
 }
 
 impl Default for EntropyConfig {
     fn default() -> Self {
-        Self { source: default_entropy_source() }
+        Self { source: default_entropy_source(), dream_perturbation: false }
     }
 }
 
@@ -500,6 +505,10 @@ pub fn apply_coupling_env_from_config(cfg: &KannakaConfig) {
 pub fn apply_entropy_env_from_config(cfg: &KannakaConfig) {
     if std::env::var_os("KANNAKA_ENTROPY_SOURCE").is_none() {
         std::env::set_var("KANNAKA_ENTROPY_SOURCE", &cfg.entropy.source);
+    }
+    // T1.4: bridge [entropy].dream_perturbation → KANNAKA_DREAM_ENTROPY (env wins).
+    if std::env::var_os("KANNAKA_DREAM_ENTROPY").is_none() && cfg.entropy.dream_perturbation {
+        std::env::set_var("KANNAKA_DREAM_ENTROPY", "1");
     }
 }
 

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -302,23 +302,34 @@ impl EntropySelection {
             EntropySelection::Reservoir => Box::new(ReservoirSource::new()),
         }
     }
+}
 
-    /// The provenance LABEL of the configured source WITHOUT drawing — for T1.4
-    /// stamping (record which entropy regime seeded a dream/Ξ) that must NOT
-    /// change the deterministic dynamics or consume reservoir bytes. `Prng` →
-    /// `prng://`; `Reservoir` → `reservoir://configured` (a regime marker with no
-    /// QPU chain — the real chain attaches only when T1.5 wires actual
-    /// consumption into the dream).
-    pub fn provenance_label(self) -> Provenance {
-        match self {
-            EntropySelection::Prng => Provenance::prng(),
-            EntropySelection::Reservoir => Provenance {
-                source: "reservoir://configured".to_string(),
-                qpu_jobs: Vec::new(),
-                devices: Vec::new(),
-            },
-        }
+/// T1.4 (#474): whether dreams/Ξ perturbations actually CONSUME entropy from the
+/// configured source (and therefore record its provenance). **Default OFF** —
+/// set `KANNAKA_DREAM_ENTROPY=1|on|true` (config `[entropy].dream_perturbation`).
+///
+/// Deliberately decoupled from [`EntropySelection`]: "which source" and "whether
+/// dreams draw from it" are independent. Off ⇒ the dream stays byte-identically
+/// deterministic and records NO provenance (an honest absence, not a false
+/// `prng://` stamp). On ⇒ the dream draws, its dynamics depend on the entropy,
+/// and every stamped chain is TRUE (prng:// or reservoir://+QPU job). T1.5's
+/// dogfood config is `[entropy].source = reservoir` + this gate ON.
+pub fn dream_entropy_enabled() -> bool {
+    std::env::var("KANNAKA_DREAM_ENTROPY")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Derive a deterministic 64-bit seed from drawn entropy bytes (little-endian
+/// fold). Makes the gated dream perturbation a reproducible function of the
+/// entropy it drew — same bytes ⇒ same perturbation.
+pub fn seed_from_bytes(bytes: &[u8]) -> u64 {
+    let mut seed = 0u64;
+    for (i, &b) in bytes.iter().enumerate() {
+        seed ^= (b as u64) << ((i % 8) * 8);
+        seed = seed.rotate_left(7).wrapping_add(0x9E37_79B9_7F4A_7C15);
     }
+    seed
 }
 
 /// The configured entropy source. Defaults to [`PrngSource`].

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -33,10 +33,15 @@ pub struct Provenance {
     /// `reservoir://<mode>` where mode is `raw` or `drbg-expand`.
     pub source: String,
     /// QPU job ids in the entropy chain (empty for a PRNG source).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ///
+    /// NB: no `skip_serializing_if` — this type is bincode-serialized inside
+    /// `WavefrontMeta` (T1.4), and bincode is positional/non-self-describing, so
+    /// conditionally omitting a field would desync the on-disk layout. Every
+    /// field is always written; JSON just carries the (possibly empty) arrays.
+    #[serde(default)]
     pub qpu_jobs: Vec<String>,
     /// QPU devices in the chain (empty for a PRNG source).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub devices: Vec<String>,
 }
 
@@ -297,6 +302,23 @@ impl EntropySelection {
             EntropySelection::Reservoir => Box::new(ReservoirSource::new()),
         }
     }
+
+    /// The provenance LABEL of the configured source WITHOUT drawing — for T1.4
+    /// stamping (record which entropy regime seeded a dream/Ξ) that must NOT
+    /// change the deterministic dynamics or consume reservoir bytes. `Prng` →
+    /// `prng://`; `Reservoir` → `reservoir://configured` (a regime marker with no
+    /// QPU chain — the real chain attaches only when T1.5 wires actual
+    /// consumption into the dream).
+    pub fn provenance_label(self) -> Provenance {
+        match self {
+            EntropySelection::Prng => Provenance::prng(),
+            EntropySelection::Reservoir => Provenance {
+                source: "reservoir://configured".to_string(),
+                qpu_jobs: Vec::new(),
+                devices: Vec::new(),
+            },
+        }
+    }
 }
 
 /// The configured entropy source. Defaults to [`PrngSource`].
@@ -341,9 +363,13 @@ mod tests {
         assert!(!back.is_prng());
         assert_eq!(back.source, "reservoir://drbg-expand");
 
-        // PRNG provenance omits the empty QPU vecs from the wire.
+        // All fields always serialize (bincode-safety: no skip_serializing_if),
+        // and a bincode round-trip is exact — the property WavefrontMeta relies on.
+        let bin = bincode::serialize(&p).unwrap();
+        let back_bin: Provenance = bincode::deserialize(&bin).unwrap();
+        assert_eq!(p, back_bin);
         let sp = serde_json::to_string(&Provenance::prng()).unwrap();
-        assert!(!sp.contains("qpu_jobs"), "empty vecs skipped: {sp}");
+        assert!(sp.contains("qpu_jobs"), "empty vecs still present (bincode-safe): {sp}");
     }
 
     #[test]
@@ -381,6 +407,24 @@ mod tests {
     fn bits_to_bytes_pads_truncated_low_bits() {
         // 12 bits → 2 bytes; the last nibble's low 4 bits are zero-padded.
         assert_eq!(bits_to_bytes("101000001111", 12), vec![0b1010_0000, 0b1111_0000]);
+    }
+
+    /// Live end-to-end smoke against a real reservoir + the kannaka-quantum CLI.
+    /// `#[ignore]`d so CI never runs it (it needs the Python CLI on PATH and
+    /// consumes real, paid QPU entropy). Run manually:
+    ///   cargo test --lib entropy::tests::reservoir_source_live_smoke -- --ignored --nocapture
+    #[test]
+    #[ignore = "live: needs kannaka-quantum CLI + a non-empty reservoir; consumes real entropy"]
+    fn reservoir_source_live_smoke() {
+        let mut s = ReservoirSource::new();
+        let d = s.draw(128).expect("live reservoir draw");
+        assert!(!d.bytes.is_empty(), "got entropy bytes");
+        assert!(d.provenance.source.starts_with("reservoir://"), "reservoir provenance");
+        assert!(!d.provenance.qpu_jobs.is_empty(), "carries a QPU job chain");
+        println!(
+            "LIVE ReservoirSource draw -> bytes={} source={} qpu_jobs={:?} devices={:?}",
+            d.bytes.len(), d.provenance.source, d.provenance.qpu_jobs, d.provenance.devices
+        );
     }
 
     #[test]

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -964,16 +964,38 @@ impl HrmStore {
     pub fn dream(&mut self, cycles: usize, initial_temperature: Option<f32>) -> crate::medium::DreamReport {
         if self.chiral.is_some() {
             // Chiral dream: right hemisphere only (deep dream)
-            let chiral = self.chiral.as_mut().unwrap();
-            let report = chiral.dream(true, cycles);
+            let report = self.chiral.as_mut().unwrap().dream(true, cycles);
+            self.stamp_dream_provenance();
             self.rebuild_cache().ok();
             self.mark_dirty();
             self.log_spiral_telemetry();
             report
         } else {
             let report = self.medium.dream(cycles, initial_temperature);
+            self.stamp_dream_provenance();
             self.mark_dirty();
             report
+        }
+    }
+
+    /// T1.4 (#474): stamp the configured entropy source's provenance on the
+    /// wavefronts THIS dream produced (hallucinations) that don't already carry
+    /// it. Purely additive — it touches only new dream products' metadata, never
+    /// the (deterministic) dynamics, and consumes no entropy. Under the default
+    /// PrngSource this stamps `prng://`; the real QPU provenance chain attaches
+    /// once T1.5 wires actual reservoir consumption into the dream. Pre-existing
+    /// memories (not dream-born this cycle) keep `None` ⇒ `prng://legacy`.
+    fn stamp_dream_provenance(&mut self) {
+        let label = crate::entropy::EntropySelection::from_env().provenance_label();
+        let metadata = if let Some(ref mut chiral) = self.chiral {
+            &mut chiral.right.metadata
+        } else {
+            &mut self.medium.store.metadata
+        };
+        for m in metadata.iter_mut() {
+            if m.hallucinated && m.provenance.is_none() {
+                m.provenance = Some(label.clone());
+            }
         }
     }
 
@@ -1414,6 +1436,10 @@ impl HrmStore {
             // Flat medium: use Medium's eigenstructure annealing
             self.medium.dream(cycles, temperature)
         };
+
+        // T1.4: stamp entropy provenance on this dream's products (hallucinations)
+        // before the sync/save persists them.
+        self.stamp_dream_provenance();
 
         // Rebuild cache and sync after dreaming
         self.sync_medium_from_chiral();
@@ -1938,6 +1964,24 @@ impl MediumBackend for HrmStore {
 
     fn is_chiral(&self) -> bool {
         Self::is_chiral(self)
+    }
+
+    fn provenance_of(&self, id: &Uuid) -> Option<crate::entropy::Provenance> {
+        if let Some(ref chiral) = self.chiral {
+            chiral
+                .right
+                .id_to_index
+                .get(id)
+                .and_then(|&i| chiral.right.metadata.get(i))
+                .and_then(|m| m.provenance.clone())
+        } else {
+            self.medium
+                .store
+                .id_to_index
+                .get(id)
+                .and_then(|&i| self.medium.store.metadata.get(i))
+                .and_then(|m| m.provenance.clone())
+        }
     }
 
     fn consolidate_resonance(&mut self, opts: &ConsolidateOpts) -> ConsolidateReport {
@@ -2852,5 +2896,44 @@ mod tests {
         // Sanity: the 4 dups collapse to one carrier and the cold ShortTerm evicts.
         assert_eq!(plan.would_absorb, 3);
         assert_eq!(plan.would_evict, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // T1.4 (#474) — entropy provenance stamped on dream products.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dream_stamps_provenance_on_hallucinations_only() {
+        let mut store =
+            HrmStore::new(make_test_pipeline(), NamedTempFile::new().unwrap().path().to_path_buf());
+        // A dream product (hallucinated) and an ordinary memory.
+        let mut v = vec![0.0f32; WAVEFRONT_DIM]; v[0] = 1.0;
+        let hallu = insert_ctl(&mut store, v, "dream product", 1.0, 0.0, Tier::LongTerm, 0);
+        let mut v2 = vec![0.0f32; WAVEFRONT_DIM]; v2[1] = 1.0;
+        let ordinary = insert_ctl(&mut store, v2, "ordinary", 1.0, 0.0, Tier::LongTerm, 0);
+
+        // Mark the first as dream-born in the authoritative metadata.
+        let idx = store.medium.get_wavefront_index(&hallu).unwrap();
+        store.medium.store.metadata[idx].hallucinated = true;
+
+        assert_eq!(store.provenance_of(&hallu), None, "unstamped before dream");
+
+        store.stamp_dream_provenance();
+
+        // Default (prng) source stamps prng:// on the hallucination.
+        assert_eq!(
+            store.provenance_of(&hallu),
+            Some(crate::entropy::Provenance::prng()),
+            "dream product carries the configured (prng) provenance"
+        );
+        // The ordinary memory is never a dream product ⇒ stays legacy (None).
+        assert_eq!(
+            store.provenance_of(&ordinary), None,
+            "non-dream memory keeps None ⇒ prng://legacy"
+        );
+
+        // Idempotent: a second dream doesn't overwrite an existing stamp.
+        store.stamp_dream_provenance();
+        assert_eq!(store.provenance_of(&hallu), Some(crate::entropy::Provenance::prng()));
     }
 }

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -268,8 +268,35 @@ fn compute_merge_grouping(
     grouping
 }
 
+/// T1.4 (#474) gated dream-entropy core — **deterministic given `bytes`**: seed a
+/// PRNG from the drawn entropy, apply a small entropy-seeded phase jitter to the
+/// dream's hallucinated products, and stamp the TRUE `prov` on them. Returns how
+/// many were perturbed. Split out from the live draw so the entropy→dynamics
+/// mapping is unit-tested with fixed bytes (reproducibility) without a source.
+fn apply_entropy_perturbation(
+    metadata: &mut [crate::medium::types::WavefrontMeta],
+    phases: &mut [f32],
+    bytes: &[u8],
+    prov: &crate::entropy::Provenance,
+) -> usize {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(crate::entropy::seed_from_bytes(bytes));
+    let mut count = 0;
+    for (i, m) in metadata.iter_mut().enumerate() {
+        if m.hallucinated {
+            let jitter = (rng.gen::<f32>() - 0.5) * 0.1; // ±0.05 rad, entropy-seeded
+            if let Some(p) = phases.get_mut(i) {
+                *p += jitter;
+            }
+            m.provenance = Some(prov.clone());
+            count += 1;
+        }
+    }
+    count
+}
+
 /// HRM-backed memory store that implements the MediumBackend trait.
-/// 
+///
 /// This wraps a Medium and provides the familiar MediumBackend interface,
 /// allowing HRM to be the sole storage backend.
 pub struct HrmStore {
@@ -965,37 +992,51 @@ impl HrmStore {
         if self.chiral.is_some() {
             // Chiral dream: right hemisphere only (deep dream)
             let report = self.chiral.as_mut().unwrap().dream(true, cycles);
-            self.stamp_dream_provenance();
+            self.apply_dream_entropy();
             self.rebuild_cache().ok();
             self.mark_dirty();
             self.log_spiral_telemetry();
             report
         } else {
             let report = self.medium.dream(cycles, initial_temperature);
-            self.stamp_dream_provenance();
+            self.apply_dream_entropy();
             self.mark_dirty();
             report
         }
     }
 
-    /// T1.4 (#474): stamp the configured entropy source's provenance on the
-    /// wavefronts THIS dream produced (hallucinations) that don't already carry
-    /// it. Purely additive — it touches only new dream products' metadata, never
-    /// the (deterministic) dynamics, and consumes no entropy. Under the default
-    /// PrngSource this stamps `prng://`; the real QPU provenance chain attaches
-    /// once T1.5 wires actual reservoir consumption into the dream. Pre-existing
-    /// memories (not dream-born this cycle) keep `None` ⇒ `prng://legacy`.
-    fn stamp_dream_provenance(&mut self) {
-        let label = crate::entropy::EntropySelection::from_env().provenance_label();
-        let metadata = if let Some(ref mut chiral) = self.chiral {
-            &mut chiral.right.metadata
-        } else {
-            &mut self.medium.store.metadata
-        };
-        for m in metadata.iter_mut() {
-            if m.hallucinated && m.provenance.is_none() {
-                m.provenance = Some(label.clone());
+    /// T1.4 (#474): GATED dream-entropy participation. When
+    /// `KANNAKA_DREAM_ENTROPY` is enabled, draw from the configured
+    /// [`EntropySource`](crate::entropy::EntropySource), let this dream's products
+    /// (hallucinations) genuinely depend on the drawn entropy (a small
+    /// entropy-seeded phase jitter), and stamp the TRUE provenance of what was
+    /// consumed (`prng://` or `reservoir://` + QPU job chain).
+    ///
+    /// **Default OFF** ⇒ no draw, no jitter, no stamp: the dream is
+    /// byte-identically deterministic and records an HONEST absence of provenance
+    /// (`None` ⇒ `prng://legacy`), never a false `prng://` claim about entropy
+    /// that was not consumed. A draw failure (e.g. empty reservoir) logs loudly
+    /// and leaves the cycle deterministic — never a silent fabricated stamp.
+    fn apply_dream_entropy(&mut self) {
+        if !crate::entropy::dream_entropy_enabled() {
+            return;
+        }
+        let mut source = crate::entropy::default_source();
+        let draw = match source.draw(256) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!(
+                    "[entropy] dream draw failed ({e}); this dream stays deterministic and records no provenance"
+                );
+                return;
             }
+        };
+        if let Some(ref mut chiral) = self.chiral {
+            if let Some(ph) = chiral.right.phase.as_slice_mut() {
+                apply_entropy_perturbation(&mut chiral.right.metadata, ph, &draw.bytes, &draw.provenance);
+            }
+        } else if let Some(ph) = self.medium.store.phase.as_slice_mut() {
+            apply_entropy_perturbation(&mut self.medium.store.metadata, ph, &draw.bytes, &draw.provenance);
         }
     }
 
@@ -1437,9 +1478,10 @@ impl HrmStore {
             self.medium.dream(cycles, temperature)
         };
 
-        // T1.4: stamp entropy provenance on this dream's products (hallucinations)
-        // before the sync/save persists them.
-        self.stamp_dream_provenance();
+        // T1.4: gated dream-entropy participation (default off = deterministic,
+        // no provenance). When enabled, consumes entropy + stamps its true
+        // provenance on this dream's products before the sync/save persists them.
+        self.apply_dream_entropy();
 
         // Rebuild cache and sync after dreaming
         self.sync_medium_from_chiral();
@@ -2899,41 +2941,65 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // T1.4 (#474) — entropy provenance stamped on dream products.
+    // T1.4 (#474) — gated dream entropy: default-off determinism + honest,
+    // reproducible provenance only when a draw actually occurs.
     // -----------------------------------------------------------------------
 
     #[test]
-    fn dream_stamps_provenance_on_hallucinations_only() {
+    fn dream_entropy_gate_off_is_deterministic_and_records_no_provenance() {
+        // Default (KANNAKA_DREAM_ENTROPY unset) ⇒ apply_dream_entropy is a no-op:
+        // no draw, no jitter, no stamp — the honest absence, never a false prng://.
         let mut store =
             HrmStore::new(make_test_pipeline(), NamedTempFile::new().unwrap().path().to_path_buf());
-        // A dream product (hallucinated) and an ordinary memory.
         let mut v = vec![0.0f32; WAVEFRONT_DIM]; v[0] = 1.0;
-        let hallu = insert_ctl(&mut store, v, "dream product", 1.0, 0.0, Tier::LongTerm, 0);
-        let mut v2 = vec![0.0f32; WAVEFRONT_DIM]; v2[1] = 1.0;
-        let ordinary = insert_ctl(&mut store, v2, "ordinary", 1.0, 0.0, Tier::LongTerm, 0);
-
-        // Mark the first as dream-born in the authoritative metadata.
+        let hallu = insert_ctl(&mut store, v, "dream product", 1.0, 0.3, Tier::LongTerm, 0);
         let idx = store.medium.get_wavefront_index(&hallu).unwrap();
         store.medium.store.metadata[idx].hallucinated = true;
+        let phase_before = store.medium.store.phase[idx];
 
-        assert_eq!(store.provenance_of(&hallu), None, "unstamped before dream");
+        store.apply_dream_entropy(); // gate off (default)
 
-        store.stamp_dream_provenance();
-
-        // Default (prng) source stamps prng:// on the hallucination.
+        assert_eq!(store.provenance_of(&hallu), None, "no provenance stamped when gate off");
         assert_eq!(
-            store.provenance_of(&hallu),
-            Some(crate::entropy::Provenance::prng()),
-            "dream product carries the configured (prng) provenance"
+            store.medium.store.phase[idx], phase_before,
+            "phase unchanged — dream stays byte-identically deterministic"
         );
-        // The ordinary memory is never a dream product ⇒ stays legacy (None).
-        assert_eq!(
-            store.provenance_of(&ordinary), None,
-            "non-dream memory keeps None ⇒ prng://legacy"
-        );
+    }
 
-        // Idempotent: a second dream doesn't overwrite an existing stamp.
-        store.stamp_dream_provenance();
-        assert_eq!(store.provenance_of(&hallu), Some(crate::entropy::Provenance::prng()));
+    #[test]
+    fn entropy_perturbation_is_reproducible_and_honest() {
+        use crate::entropy::Provenance;
+        use crate::medium::types::WavefrontMeta;
+
+        let prov = Provenance::reservoir("drbg-expand", vec!["job-x".into()], vec!["dev".into()]);
+        let mk = || {
+            let mut h = WavefrontMeta::new(uuid::Uuid::new_v4(), "hallu".into());
+            h.hallucinated = true;
+            let ordinary = WavefrontMeta::new(uuid::Uuid::new_v4(), "ordinary".into());
+            vec![h, ordinary]
+        };
+        let bytes = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        // Same bytes ⇒ identical perturbation (reproducible dynamics).
+        let (mut ma, mut pa) = (mk(), vec![0.5f32, 0.5]);
+        let (mut mb, mut pb) = (mk(), vec![0.5f32, 0.5]);
+        let ca = apply_entropy_perturbation(&mut ma, &mut pa, &bytes, &prov);
+        let cb = apply_entropy_perturbation(&mut mb, &mut pb, &bytes, &prov);
+        assert_eq!(ca, 1, "only the hallucination is perturbed");
+        assert_eq!(cb, 1);
+        assert_eq!(pa, pb, "same entropy ⇒ same phase jitter (reproducible)");
+
+        // Honest stamping: the TRUE drawn provenance on the hallucination only.
+        assert_eq!(ma[0].provenance.as_ref().unwrap().source, "reservoir://drbg-expand");
+        assert_eq!(ma[0].provenance.as_ref().unwrap().qpu_jobs, vec!["job-x".to_string()]);
+        assert_eq!(ma[1].provenance, None, "a non-hallucination is never stamped");
+        assert_ne!(pa[0], 0.5, "the hallucination's phase actually jittered");
+        assert_eq!(pa[1], 0.5, "the ordinary wavefront's phase is untouched");
+
+        // Different bytes ⇒ different jitter: the dynamics genuinely depend on
+        // the drawn entropy (not a cosmetic stamp).
+        let (mut mc, mut pc) = (mk(), vec![0.5f32, 0.5]);
+        apply_entropy_perturbation(&mut mc, &mut pc, &[42u8; 10], &prov);
+        assert_ne!(pa[0], pc[0], "different entropy ⇒ different dream perturbation");
     }
 }

--- a/src/medium/chiral_persistence.rs
+++ b/src/medium/chiral_persistence.rs
@@ -50,6 +50,7 @@ impl From<WavefrontMetaLegacy> for WavefrontMeta {
             effective_at: None,
             observed_at: None,
             expires_at: None,
+            provenance: None,
         }
     }
 }
@@ -87,6 +88,7 @@ impl From<WavefrontMetaPreTier> for WavefrontMeta {
             effective_at: None,
             observed_at: None,
             expires_at: None,
+            provenance: None,
         }
     }
 }
@@ -127,8 +129,82 @@ impl From<WavefrontMetaPreTemporal> for WavefrontMeta {
             effective_at: None,
             observed_at: None,
             expires_at: None,
+            provenance: None,
         }
     }
+}
+
+/// Pre-provenance WavefrontMeta (after Wave 3 temporal fields, before Quantum-
+/// Wave T1.4 `provenance`). Matches the on-disk layout of every `.hrm` written
+/// between the temporal addition and the provenance addition — the newest legacy
+/// shape. First fallback step in the
+/// new → pre-provenance → pre-temporal → pre-tier → legacy chain: an old file
+/// lacks the trailing provenance bytes, so it fails the new-struct deserialize
+/// and decodes here with `provenance` defaulting to `None` (⇒ `prng://legacy`).
+#[derive(Deserialize)]
+pub(crate) struct WavefrontMetaPreProvenance {
+    pub id: Uuid,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub hallucinated: bool,
+    pub is_self_referential: bool,
+    #[serde(default)]
+    pub modality: Modality,
+    #[serde(default)]
+    pub tier: crate::medium::types::Tier,
+    #[serde(default)]
+    pub effective_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub observed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl From<WavefrontMetaPreProvenance> for WavefrontMeta {
+    fn from(p: WavefrontMetaPreProvenance) -> Self {
+        WavefrontMeta {
+            id: p.id,
+            content: p.content,
+            tags: p.tags,
+            created_at: p.created_at,
+            hallucinated: p.hallucinated,
+            is_self_referential: p.is_self_referential,
+            sga_class: None,
+            fano_group: None,
+            category: None,
+            modality: p.modality,
+            tier: p.tier,
+            effective_at: p.effective_at,
+            observed_at: p.observed_at,
+            expires_at: p.expires_at,
+            provenance: None,
+        }
+    }
+}
+
+/// Decode a bincode wavefront-metadata blob through the full backward-compat
+/// fallback chain: new → pre-provenance (T1.4) → pre-temporal → pre-tier →
+/// legacy. Old `.hrm` files lack the newest trailing bytes, so they fail the
+/// new-struct decode and drop to the matching older shape (missing fields
+/// default). Shared by both the chiral and flat read paths so the chain has one
+/// definition.
+pub(crate) fn decode_wavefront_metadata(bytes: &[u8]) -> Result<Vec<WavefrontMeta>, MediumError> {
+    if let Ok(m) = bincode::deserialize::<Vec<WavefrontMeta>>(bytes) {
+        return Ok(m);
+    }
+    if let Ok(pre) = bincode::deserialize::<Vec<WavefrontMetaPreProvenance>>(bytes) {
+        return Ok(pre.into_iter().map(Into::into).collect());
+    }
+    if let Ok(pre) = bincode::deserialize::<Vec<WavefrontMetaPreTemporal>>(bytes) {
+        return Ok(pre.into_iter().map(Into::into).collect());
+    }
+    if let Ok(pre) = bincode::deserialize::<Vec<WavefrontMetaPreTier>>(bytes) {
+        return Ok(pre.into_iter().map(Into::into).collect());
+    }
+    let legacy: Vec<WavefrontMetaLegacy> =
+        bincode::deserialize(bytes).map_err(MediumError::Serialization)?;
+    Ok(legacy.into_iter().map(Into::into).collect())
 }
 
 /// Verify the trailing 32-byte blake3 checksum on a .hrm file.
@@ -534,28 +610,7 @@ impl ChiralMedium {
         }
         let mut meta_bytes = vec![0u8; meta_len];
         r.read_exact(&mut meta_bytes)?;
-        let metadata: Vec<WavefrontMeta> = match bincode::deserialize(&meta_bytes) {
-            Ok(m) => m,
-            Err(_) => {
-                // Task 3.2b: pre-temporal format (has tier, lacks the temporal
-                // fields). Newest legacy shape — try it before older layouts.
-                match bincode::deserialize::<Vec<WavefrontMetaPreTemporal>>(&meta_bytes) {
-                    Ok(pre) => pre.into_iter().map(|p| p.into()).collect(),
-                    Err(_) => {
-                        // ADR-0031: pre-tier format (has modality, lacks tier).
-                        match bincode::deserialize::<Vec<WavefrontMetaPreTier>>(&meta_bytes) {
-                            Ok(pre) => pre.into_iter().map(|p| p.into()).collect(),
-                            Err(_) => {
-                                // Pre-NCS format: no modality and no tier — defaults.
-                                let legacy: Vec<WavefrontMetaLegacy> = bincode::deserialize(&meta_bytes)
-                                    .map_err(|e| MediumError::Serialization(e))?;
-                                legacy.into_iter().map(|l| l.into()).collect()
-                            }
-                        }
-                    }
-                }
-            }
-        };
+        let metadata: Vec<WavefrontMeta> = decode_wavefront_metadata(&meta_bytes)?;
 
         // #362: section sizes come from independent sources — `n` (the on-disk
         // count) sizes wavefronts/energy/frequency/phase/timestamps, while the
@@ -653,6 +708,76 @@ mod tests {
         let bytes = bincode::serialize(&vec![m]).unwrap();
         let back: Vec<WavefrontMeta> = bincode::deserialize(&bytes).unwrap();
         assert_eq!(back[0].tier, Tier::Pinned);
+    }
+
+    // Quantum-Wave T1.4 (#474): locks the bincode back-compat invariant for the
+    // `provenance` field. Pre-provenance metadata bytes (modality + tier +
+    // temporal, NO provenance — every .hrm written before this change) MUST fail
+    // the new-struct deserialize and succeed via the WavefrontMetaPreProvenance
+    // fallback with provenance defaulting to None (⇒ prng://legacy). A regression
+    // here would silently corrupt existing HRM files.
+    #[test]
+    fn preprovenance_metadata_decodes_via_fallback_with_none_provenance() {
+        use chrono::{DateTime, Utc};
+        use serde::Serialize;
+        use uuid::Uuid;
+
+        // Exact on-disk layout of pre-provenance WavefrontMeta.
+        #[derive(Serialize)]
+        struct OldMeta {
+            id: Uuid,
+            content: String,
+            tags: Vec<String>,
+            created_at: DateTime<Utc>,
+            hallucinated: bool,
+            is_self_referential: bool,
+            modality: Modality,
+            tier: Tier,
+            effective_at: Option<DateTime<Utc>>,
+            observed_at: Option<DateTime<Utc>>,
+            expires_at: Option<DateTime<Utc>>,
+        }
+        let old = vec![OldMeta {
+            id: Uuid::nil(),
+            content: "legacy".to_string(),
+            tags: vec![],
+            created_at: Utc::now(),
+            hallucinated: true,
+            is_self_referential: false,
+            modality: Modality::Audio,
+            tier: Tier::Pinned,
+            effective_at: None,
+            observed_at: None,
+            expires_at: None,
+        }];
+        let bytes = bincode::serialize(&old).unwrap();
+
+        // New struct (with provenance) must NOT decode old bytes — this is what
+        // makes the loader fall through to the pre-provenance path.
+        assert!(bincode::deserialize::<Vec<WavefrontMeta>>(&bytes).is_err());
+
+        // The full fallback chain decodes it, preserving every older field and
+        // defaulting provenance to None.
+        let decoded = decode_wavefront_metadata(&bytes).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].content, "legacy");
+        assert_eq!(decoded[0].tier, Tier::Pinned);
+        assert!(decoded[0].hallucinated);
+        assert_eq!(decoded[0].provenance, None, "old record ⇒ None ⇒ prng://legacy");
+    }
+
+    #[test]
+    fn new_metadata_roundtrips_provenance() {
+        let mut m = WavefrontMeta::new(uuid::Uuid::nil(), "x".to_string());
+        m.provenance = Some(crate::entropy::Provenance::reservoir(
+            "drbg-expand",
+            vec!["job-1".to_string()],
+            vec!["dev".to_string()],
+        ));
+        let bytes = bincode::serialize(&vec![m.clone()]).unwrap();
+        // New format decodes directly (no fallback needed).
+        let back = decode_wavefront_metadata(&bytes).unwrap();
+        assert_eq!(back[0].provenance, m.provenance);
     }
 
     // Wave 3 Task 3.2b: locks the bincode back-compat invariant for the temporal

--- a/src/medium/persistence.rs
+++ b/src/medium/persistence.rs
@@ -437,19 +437,8 @@ impl Medium {
         // Fall back through the legacy layouts for flat v1 files written before
         // newer fields were appended (mirrors the chiral read path):
         // new → pre-temporal (Task 3.2b) → pre-tier (ADR-0031).
-        let metadata: Vec<WavefrontMeta> = match bincode::deserialize(&metadata_bytes) {
-            Ok(m) => m,
-            Err(_) => {
-                match bincode::deserialize::<Vec<super::chiral_persistence::WavefrontMetaPreTemporal>>(&metadata_bytes) {
-                    Ok(pre) => pre.into_iter().map(|p| p.into()).collect(),
-                    Err(_) => {
-                        let pre: Vec<super::chiral_persistence::WavefrontMetaPreTier> =
-                            bincode::deserialize(&metadata_bytes)?;
-                        pre.into_iter().map(|p| p.into()).collect()
-                    }
-                }
-            }
-        };
+        let metadata: Vec<WavefrontMeta> =
+            super::chiral_persistence::decode_wavefront_metadata(&metadata_bytes)?;
 
         // Consciousness state (for info, not essential for loading)
         let mut len_bytes = [0u8; 4];

--- a/src/medium/types.rs
+++ b/src/medium/types.rs
@@ -514,6 +514,15 @@ pub struct WavefrontMeta {
     /// When the fact is known to stop being true (None = no known expiry).
     #[serde(default)]
     pub expires_at: Option<DateTime<Utc>>,
+    /// Quantum-Wave T1.4 (#474): provenance of the entropy that seeded the
+    /// dream/Ξ that last wrote this wavefront. `None` for records written before
+    /// provenance existed (loaded via the `WavefrontMetaPreProvenance` fallback)
+    /// ⇒ treated as `prng://legacy`. This is now the LAST serialized field — the
+    /// bincode fallback chain relies on `.hrm` files written before this change
+    /// lacking these trailing bytes, so they fail the new-struct deserialize and
+    /// drop to `WavefrontMetaPreProvenance`.
+    #[serde(default)]
+    pub provenance: Option<crate::entropy::Provenance>,
 }
 
 impl WavefrontMeta {
@@ -533,6 +542,7 @@ impl WavefrontMeta {
             effective_at: None,
             observed_at: None,
             expires_at: None,
+            provenance: None,
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -234,6 +234,15 @@ pub trait MediumBackend: Send + Sync {
         false
     }
 
+    /// Quantum-Wave T1.4 (#474): provenance of the entropy that last seeded a
+    /// dream/Ξ touching this wavefront, read from the canonical
+    /// `WavefrontMeta.provenance`. `None` ⇒ never stamped ⇒ `prng://legacy`.
+    /// Default `None`; HrmStore reads the authoritative metadata. Surfaced via
+    /// CLI inspect (`export-json`).
+    fn provenance_of(&self, _id: &Uuid) -> Option<crate::entropy::Provenance> {
+        None
+    }
+
     /// ADR-0036 Phase 1: flush per-memory reactivation counts to the sidecar.
     /// Default no-op; HrmStore writes `.reactivation.json` (sidecar only, safe
     /// under readonly). Called by the serve daemon and CLI `recall` so recall


### PR DESCRIPTION
Closes #474. QW Track 1 (T1.4), builds on T1.3 (#482). AC amendment agreed with the team lead: https://github.com/NickFlach/kannaka-memory/issues/474#issuecomment-4861145837

## Summary

Records the `Provenance` of the entropy that seeded a dream — **honestly**: only when a real draw occurred. Provenance is an optional field in the v2 chiral format (**no migration**, old `.hrm` files load unchanged), and dreams consume entropy **only** behind a default-off gate, so the default dream stays byte-identically deterministic.

## Design (b + gated-draw hybrid, per review)

1. **Persistence (unconditional).** `WavefrontMeta.provenance: Option<Provenance>` appended as the new LAST serialized field + a new `WavefrontMetaPreProvenance` fallback ⇒ absent = `None` = `prng://legacy`. Same append-trailing + fallback-struct pattern as `tier`/temporal; the whole chain (`new → pre-provenance → pre-temporal → pre-tier → legacy`) is consolidated into one shared `decode_wavefront_metadata` used by both the chiral and flat read paths (was duplicated).
2. **Gated draw** — `KANNAKA_DREAM_ENTROPY` / `[entropy].dream_perturbation`, **DEFAULT OFF**, decoupled from `[entropy].source` ("which source" vs "whether dreams draw" are independent). OFF ⇒ no draw, no jitter, no stamp — the dream is byte-identically deterministic and records an **honest absence** of provenance, never a false `prng://` claim. ON ⇒ the dream draws from the configured source, its hallucinated products' phases genuinely depend on the drawn entropy (a small entropy-seeded jitter), and each stamped chain is TRUE (`prng://` or `reservoir://` + QPU `job_id`). A draw failure (e.g. empty reservoir) logs loudly and leaves the cycle deterministic — never a fabricated stamp.
3. **CLI inspect.** `export-json` emits per-memory `provenance` via new `MediumBackend::provenance_of`.
4. **Bincode-safety.** Dropped `skip_serializing_if` from `Provenance` (now bincode-serialized inside `WavefrontMeta`; conditionally-omitted fields desync a positional format) + a bincode round-trip assertion.

Honesty rule (why not the literal AC): the dream/Ξ dynamics are currently fully deterministic (verified — no `rand` draw in those paths), so a `prng://` stamp on a dream that consumed nothing would be a false record. So AC "new dreams carry provenance" now reads "**when entropy participation is enabled (`KANNAKA_DREAM_ENTROPY=1`)**". T1.5's dogfood config = `source=reservoir` + gate ON is where the real QPU-seeded chain goes live.

## Testing

- default-off determinism: `apply_dream_entropy` is a no-op — phase unchanged, provenance `None`.
- gated perturbation reproducible + honest given fixed drawn bytes: only hallucinations stamped with the TRUE provenance, phase actually jitters, different bytes ⇒ different perturbation.
- persistence: pre-provenance bytes decode via fallback with `None`; new format round-trips provenance.
- All **27** existing persistence back-compat tests still pass. Also lands `reservoir_source_live_smoke` (`#[ignore]`d) — the real-Rigetti `ReservoirSource` check posted on #473. `cargo check --all-targets` + `cargo clippy --lib --bin kannaka` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)