### PR TITLE
feat(qubo): ConsolidationProblem emitter (kannaka-qubo/1) + golden corpus (ADR-0038 T3.2)

### DIFF
--- a/examples/gen_qubo_corpus.rs
+++ b/examples/gen_qubo_corpus.rs
@@ -1,0 +1,278 @@
+//! Regenerates the golden QUBO corpus in `tests/qubo/` (ADR-0038 validation).
+//!
+//!   cargo run --example gen_qubo_corpus
+//!
+//! Writes 12 hand-designed `kannaka-qubo/1` problems plus a `manifest.json`
+//! documenting each one's known optimum (energy + an optimal assignment) and
+//! whether it is exact-solvable (< 20 vars → brute-forceable). The committed
+//! files are the golden artifacts; `tests/qubo_corpus.rs` validates them (round
+//! trip + re-derived optima) and `tests/qubo_solver.rs` (T3.3) checks the solver
+//! against them. This generator only exists so the corpus can be rebuilt after
+//! an intentional change — CI never runs it.
+
+use std::path::PathBuf;
+
+use kannaka_memory::qubo::{ConsolidationProblem, Metadata, ProblemBuilder, VarKind};
+use serde::Serialize;
+
+struct Spec {
+    file: &'static str,
+    problem: ConsolidationProblem,
+    description: &'static str,
+    /// Known optimum for problems too large to brute-force (≥ 20 vars). Small
+    /// problems leave this `None`; the generator brute-forces them.
+    known_optimum: Option<Vec<bool>>,
+}
+
+#[derive(Serialize)]
+struct ManifestEntry {
+    file: String,
+    num_vars: usize,
+    exact_solvable: bool,
+    optimum_energy: f64,
+    optimum_assignment: Vec<bool>,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct Manifest {
+    format: String,
+    note: String,
+    files: Vec<ManifestEntry>,
+}
+
+fn meta(hemisphere: &str) -> Metadata {
+    Metadata {
+        hemisphere: Some(hemisphere.to_string()),
+        phi_at_emit: Some(0.18),
+        entropy_provenance: Some("prng://legacy".to_string()),
+        ..Default::default()
+    }
+}
+
+fn corpus() -> Vec<Spec> {
+    let mut specs = Vec::new();
+
+    // 01 — all keep: every keep_link wants to stay (negative linear), no coupling.
+    {
+        let mut b = ProblemBuilder::new("golden-01-all-keep");
+        for (s, c) in [("skip:a", -2.0), ("skip:b", -1.5), ("skip:c", -3.0)] {
+            let id = b.add_variable(VarKind::KeepLink, s);
+            b.set_linear(id, c);
+        }
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "01-all-keep.json", problem: b.build(), description: "3 keep_link, all negative linear; optimum keeps all.", known_optimum: None });
+    }
+
+    // 02 — all drop: every merge costs (positive linear); optimum is empty.
+    {
+        let mut b = ProblemBuilder::new("golden-02-all-drop");
+        for (s, c) in [("mem:a", 1.0), ("mem:b", 2.0), ("mem:c", 0.5)] {
+            let id = b.add_variable(VarKind::Merge, s);
+            b.set_linear(id, c);
+        }
+        b.set_metadata(meta("flat"));
+        specs.push(Spec { file: "02-all-drop.json", problem: b.build(), description: "3 merge, all positive linear; optimum activates none (E=0).", known_optimum: None });
+    }
+
+    // 03 — repulsion pair: both attractive alone, but strong positive coupling.
+    {
+        let mut b = ProblemBuilder::new("golden-03-repulsion-pair");
+        let x = b.add_variable(VarKind::Merge, "mem:a+mem:b");
+        let y = b.add_variable(VarKind::Merge, "mem:c+mem:d");
+        b.set_linear(x, -2.0);
+        b.set_linear(y, -2.0);
+        b.add_quadratic(x, y, 5.0);
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "03-repulsion-pair.json", problem: b.build(), description: "2 merge, negative linear, strong positive coupling; optimum takes exactly one.", known_optimum: None });
+    }
+
+    // 04 — attraction pair: negative coupling rewards taking both.
+    {
+        let mut b = ProblemBuilder::new("golden-04-attraction-pair");
+        let x = b.add_variable(VarKind::Strengthen, "skip:a");
+        let y = b.add_variable(VarKind::Strengthen, "skip:b");
+        b.set_linear(x, -1.0);
+        b.set_linear(y, -1.0);
+        b.add_quadratic(x, y, -3.0);
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "04-attraction-pair.json", problem: b.build(), description: "2 strengthen, negative linear + negative coupling; optimum takes both.", known_optimum: None });
+    }
+
+    // 05 — budget at most 1 of 3 (penalty-folded).
+    {
+        let mut b = ProblemBuilder::new("golden-05-budget-at-most-1");
+        let v: Vec<usize> = [("mem:a", -3.0), ("mem:b", -2.0), ("mem:c", -1.0)]
+            .into_iter()
+            .map(|(s, c)| {
+                let id = b.add_variable(VarKind::Merge, s);
+                b.set_linear(id, c);
+                id
+            })
+            .collect();
+        b.add_budget("budget", v, 1, 10.0);
+        b.set_metadata(meta("flat"));
+        specs.push(Spec { file: "05-budget-at-most-1.json", problem: b.build(), description: "3 merge, budget max_active=1 (folded); optimum keeps only the strongest.", known_optimum: None });
+    }
+
+    // 06 — budget at most 2 of 4 (penalty-folded).
+    {
+        let mut b = ProblemBuilder::new("golden-06-budget-at-most-2");
+        let v: Vec<usize> = [("mem:a", -4.0), ("mem:b", -3.0), ("mem:c", -2.0), ("mem:d", -1.0)]
+            .into_iter()
+            .map(|(s, c)| {
+                let id = b.add_variable(VarKind::Merge, s);
+                b.set_linear(id, c);
+                id
+            })
+            .collect();
+        b.add_budget("budget", v, 2, 10.0);
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "06-budget-at-most-2.json", problem: b.build(), description: "4 merge, budget max_active=2 (folded); optimum keeps the strongest two.", known_optimum: None });
+    }
+
+    // 07 — mixed signs + a couple of interactions.
+    {
+        let mut b = ProblemBuilder::new("golden-07-mixed");
+        let ids: Vec<usize> = ["keep_link", "merge", "keep_link", "merge", "strengthen"]
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                let kind = match *k {
+                    "keep_link" => VarKind::KeepLink,
+                    "merge" => VarKind::Merge,
+                    _ => VarKind::Strengthen,
+                };
+                b.add_variable(kind, format!("v{i}"))
+            })
+            .collect();
+        for (id, c) in ids.iter().zip([-2.0, 1.0, -1.0, 3.0, -0.5]) {
+            b.set_linear(*id, c);
+        }
+        b.add_quadratic(ids[0], ids[2], 1.5);
+        b.add_quadratic(ids[2], ids[4], -2.0);
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "07-mixed.json", problem: b.build(), description: "5 mixed-kind vars, mixed-sign linear + two couplings; brute-force optimum.", known_optimum: None });
+    }
+
+    // 08 — frustrated triangle: each attractive, every pair repels.
+    {
+        let mut b = ProblemBuilder::new("golden-08-frustrated-triangle");
+        let v: Vec<usize> = (0..3).map(|i| {
+            let id = b.add_variable(VarKind::Merge, format!("mem:{i}"));
+            b.set_linear(id, -1.0);
+            id
+        }).collect();
+        b.add_quadratic(v[0], v[1], 1.5);
+        b.add_quadratic(v[0], v[2], 1.5);
+        b.add_quadratic(v[1], v[2], 1.5);
+        b.set_metadata(meta("flat"));
+        specs.push(Spec { file: "08-frustrated-triangle.json", problem: b.build(), description: "3 merge, negative linear, all pairs repel; optimum takes exactly one.", known_optimum: None });
+    }
+
+    // 09 — keep_link/strengthen coupling: strengthening only pays if the link is kept.
+    {
+        let mut b = ProblemBuilder::new("golden-09-link-strengthen");
+        let keep_a = b.add_variable(VarKind::KeepLink, "skip:A");
+        let str_a = b.add_variable(VarKind::Strengthen, "skip:A");
+        let keep_b = b.add_variable(VarKind::KeepLink, "skip:B");
+        let merge = b.add_variable(VarKind::Merge, "mem:x+mem:y");
+        b.set_linear(keep_a, -1.0);
+        b.set_linear(str_a, 0.5); // strengthening alone is a small cost…
+        b.set_linear(keep_b, -0.5);
+        b.set_linear(merge, -1.0);
+        b.add_quadratic(keep_a, str_a, -2.0); // …but a big win once the link is kept.
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "09-link-strengthen.json", problem: b.build(), description: "keep_link/strengthen coupling; optimum keeps+strengthens A, keeps B, merges.", known_optimum: None });
+    }
+
+    // 10 — single variable.
+    {
+        let mut b = ProblemBuilder::new("golden-10-single");
+        let id = b.add_variable(VarKind::KeepLink, "skip:only");
+        b.set_linear(id, -1.0);
+        b.set_metadata(meta("flat"));
+        specs.push(Spec { file: "10-single.json", problem: b.build(), description: "1 keep_link, negative linear; optimum keeps it.", known_optimum: None });
+    }
+
+    // 11 — large independent (24 vars, no coupling): per-variable optimum, known.
+    {
+        let mut b = ProblemBuilder::new("golden-11-large-independent");
+        let mut opt = Vec::new();
+        for i in 0..24usize {
+            let c = if i % 3 == 0 { 0.7 } else { -(1.0 + (i % 4) as f64 * 0.3) };
+            let id = b.add_variable(VarKind::Merge, format!("mem:{i}"));
+            b.set_linear(id, c);
+            opt.push(c < 0.0); // independent ⇒ take iff its linear is negative
+        }
+        b.set_metadata(meta("flat"));
+        specs.push(Spec { file: "11-large-independent.json", problem: b.build(), description: "24 independent vars, mixed signs; optimum = each var iff its linear<0.", known_optimum: Some(opt) });
+    }
+
+    // 12 — large ferromagnet (20 vars, all-negative linear + chain coupling): all-true.
+    {
+        let mut b = ProblemBuilder::new("golden-12-large-ferromagnet");
+        let v: Vec<usize> = (0..20).map(|i| {
+            let id = b.add_variable(VarKind::Merge, format!("mem:{i}"));
+            b.set_linear(id, -0.5);
+            id
+        }).collect();
+        for i in 0..v.len() - 1 {
+            b.add_quadratic(v[i], v[i + 1], -1.0);
+        }
+        b.set_metadata(meta("right"));
+        specs.push(Spec { file: "12-large-ferromagnet.json", problem: b.build(), description: "20 vars, all-negative linear + negative chain coupling; optimum is all-true.", known_optimum: Some(vec![true; 20]) });
+    }
+
+    specs
+}
+
+fn brute_force(p: &ConsolidationProblem) -> (Vec<bool>, f64) {
+    let n = p.num_vars();
+    let mut best = vec![false; n];
+    let mut best_e = f64::INFINITY;
+    for mask in 0u64..(1u64 << n) {
+        let x: Vec<bool> = (0..n).map(|i| (mask >> i) & 1 == 1).collect();
+        let e = p.energy(&x);
+        if e < best_e {
+            best_e = e;
+            best = x;
+        }
+    }
+    (best, best_e)
+}
+
+fn main() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("qubo");
+    std::fs::create_dir_all(&dir).expect("create tests/qubo");
+
+    let mut entries = Vec::new();
+    for spec in corpus() {
+        let n = spec.problem.num_vars();
+        spec.problem.validate().unwrap_or_else(|e| panic!("{} invalid: {e}", spec.file));
+        let exact = n < 20;
+        let (assignment, energy) = match &spec.known_optimum {
+            Some(opt) => (opt.clone(), spec.problem.energy(opt)),
+            None => brute_force(&spec.problem),
+        };
+        let json = serde_json::to_string_pretty(&spec.problem).unwrap();
+        std::fs::write(dir.join(spec.file), json + "\n").unwrap();
+        entries.push(ManifestEntry {
+            file: spec.file.to_string(),
+            num_vars: n,
+            exact_solvable: exact,
+            optimum_energy: energy,
+            optimum_assignment: assignment,
+            description: spec.description.to_string(),
+        });
+        println!("wrote {} ({n} vars, exact={exact}, opt={:.3})", spec.file, entries.last().unwrap().optimum_energy);
+    }
+
+    let manifest = Manifest {
+        format: "kannaka-qubo-golden/1".to_string(),
+        note: "Golden ADR-0038 QUBOs. Regenerate with `cargo run --example gen_qubo_corpus`. optimum_energy is over ConsolidationProblem::energy (penalties already folded); exact_solvable=true means <20 vars (brute-forceable in tests).".to_string(),
+        files: entries,
+    };
+    std::fs::write(dir.join("manifest.json"), serde_json::to_string_pretty(&manifest).unwrap() + "\n").unwrap();
+    println!("wrote manifest.json with {} entries", manifest.files.len());
+}

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -1123,6 +1123,41 @@ impl HrmStore {
         report.would_evict = st_evict;
         report.projected_memories = n.saturating_sub(absorb).saturating_sub(st_evict);
 
+        // ADR-0038 (T3.2): emit a `kannaka-qubo/1` problem ALONGSIDE this
+        // procedural plan when KANNAKA_QUBO_EMIT is set. Advisory only — the plan
+        // above is untouched and authoritative; nothing consumes the QUBO yet
+        // (the re-score-before-apply path is T3.5). Default off ⇒ zero overhead.
+        if crate::qubo::emit::enabled() {
+            let merges: Vec<crate::qubo::MergeCandidate> = grouping
+                .admitted
+                .iter()
+                .map(|g| {
+                    let subject = g
+                        .iter()
+                        .map(|&i| format!("mem:{}", entries[i].0))
+                        .collect::<Vec<_>>()
+                        .join("+");
+                    // Cohesion: absorbed count × (1 + mean energy) — larger, hotter
+                    // groups make a stronger case to merge (emitted as linear −cohesion).
+                    let absorbed = g.len().saturating_sub(1) as f64;
+                    let mean_e =
+                        g.iter().map(|&i| entries[i].1.amplitude as f64).sum::<f64>() / g.len() as f64;
+                    crate::qubo::MergeCandidate { subject, cohesion: absorbed * (1.0 + mean_e) }
+                })
+                .collect();
+            let metadata = crate::qubo::Metadata {
+                hemisphere: Some(if belief { "right" } else { "flat" }.to_string()),
+                phi_at_emit: None,
+                entropy_provenance: None,
+                ..Default::default()
+            };
+            // Soft budget: cap kept merges at the absorb count (advisory).
+            let budget = Some((merges.len().max(1), 1.0));
+            let problem_id = format!("dream-{}", chrono::Utc::now().to_rfc3339());
+            let problem = crate::qubo::dream_merge_problem(problem_id, &merges, budget, metadata);
+            crate::qubo::emit::write_problem(&problem);
+        }
+
         report
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod medium;
 pub mod hrm_store;
 pub mod recall_bench;
 pub mod entropy;
+pub mod qubo;
 
 pub mod config;
 

--- a/src/qubo/emit.rs
+++ b/src/qubo/emit.rs
@@ -1,0 +1,76 @@
+//! T3.2 emit hook — write a `kannaka-qubo/1` problem to disk ALONGSIDE the
+//! procedural consolidation plan, gated by a config flag (default off).
+//!
+//! This is deliberately advisory and side-effect-free with respect to the memory
+//! store: the dream's procedural consolidation still runs and remains
+//! authoritative. The engine's re-score-before-apply path is T3.5, not here — so
+//! nothing consumes these files yet; they exist for the golden-file / solver
+//! benchmark work and for eyeballing real dream QUBOs.
+
+use std::path::PathBuf;
+
+use super::problem::ConsolidationProblem;
+
+/// Env flag: emit a QUBO per plan when set to `1|on|true`. **Default off** — the
+/// procedural path is byte-identical when unset.
+pub const EMIT_ENV: &str = "KANNAKA_QUBO_EMIT";
+/// Env override for the output directory.
+pub const DIR_ENV: &str = "KANNAKA_QUBO_EMIT_DIR";
+
+/// Whether the emit hook is enabled.
+pub fn enabled() -> bool {
+    std::env::var(EMIT_ENV)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Directory QUBOs are written to: `KANNAKA_QUBO_EMIT_DIR`, else
+/// `<KANNAKA_DATA_DIR|~/.kannaka>/qubo`.
+pub fn emit_dir() -> PathBuf {
+    if let Ok(d) = std::env::var(DIR_ENV) {
+        return PathBuf::from(d);
+    }
+    let base = std::env::var("KANNAKA_DATA_DIR").map(PathBuf::from).unwrap_or_else(|_| {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".to_string());
+        PathBuf::from(home).join(".kannaka")
+    });
+    base.join("qubo")
+}
+
+/// Write `problem` as pretty JSON to `emit_dir()/<problem_id>.json`. Best-effort:
+/// returns the path on success, logs and returns `None` on any I/O error (a
+/// dream must never fail because a debug artifact couldn't be written).
+pub fn write_problem(problem: &ConsolidationProblem) -> Option<PathBuf> {
+    let dir = emit_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("[qubo emit] could not create {}: {e}", dir.display());
+        return None;
+    }
+    // Timestamps in the id carry ':' — not a legal Windows filename char.
+    let fname = format!("{}.json", problem.problem_id.replace(':', "-"));
+    let path = dir.join(fname);
+    let json = match serde_json::to_string_pretty(problem) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("[qubo emit] serialize failed: {e}");
+            return None;
+        }
+    };
+    match std::fs::write(&path, json) {
+        Ok(()) => {
+            eprintln!(
+                "[qubo emit] wrote {} ({} vars) to {}",
+                problem.problem_id,
+                problem.num_vars(),
+                path.display()
+            );
+            Some(path)
+        }
+        Err(e) => {
+            eprintln!("[qubo emit] write {} failed: {e}", path.display());
+            None
+        }
+    }
+}

--- a/src/qubo/mod.rs
+++ b/src/qubo/mod.rs
@@ -1,0 +1,25 @@
+//! ADR-0038 — consolidation as QUBO.
+//!
+//! The dream/consolidation phase's keep-link / merge / strengthen decision is a
+//! combinatorial optimization (binary variables, pairwise interactions, a global
+//! budget) — the QUBO/Ising class. This module freezes that problem at a
+//! serialization boundary (`kannaka-qubo/1`) so the *solver* is swappable:
+//! `ClassicalAnneal` today (T3.3), a quantum/QAOA subprocess later (T3.4),
+//! without touching the engine.
+//!
+//! - [`problem`] — the `kannaka-qubo/1` format ([`ConsolidationProblem`]), the
+//!   penalty-folding [`ProblemBuilder`], and the objective [`ConsolidationProblem::energy`].
+//!   The emitter that turns a dream's merge plan into a problem also lives here.
+//!
+//! The solver trait + `ClassicalAnneal` (T3.3) land in a sibling `solver`
+//! submodule; the engine's advisory re-score-before-apply path is T3.5. This
+//! module ships only the boundary + emitter, so consolidation logic becomes
+//! testable in isolation (golden QUBO files in `tests/qubo/`).
+
+pub mod emit;
+pub mod problem;
+
+pub use problem::{
+    dream_merge_problem, ConsolidationProblem, Constraint, MergeCandidate, Metadata, ProblemBuilder,
+    VarKind, Variable, FORMAT,
+};

--- a/src/qubo/problem.rs
+++ b/src/qubo/problem.rs
@@ -1,0 +1,411 @@
+//! `kannaka-qubo/1` — the ConsolidationProblem serialization boundary (ADR-0038).
+//!
+//! A problem is a QUBO: binary variables (keep_link / merge / strengthen),
+//! `linear` (diagonal) and `quadratic` (pairwise) coefficients, named
+//! `constraints`, and opaque `metadata`. Solvers **minimize** `energy(x)`.
+//!
+//! Constraints are carried **twice** (ADR-0038 §Decision.1): structurally in
+//! `constraints` (so a smart solver can enforce them exactly) AND penalty-folded
+//! into `linear`/`quadratic` (so a constraint-blind solver still gets a valid,
+//! if softer, problem). [`ProblemBuilder`] does the fold; [`ConsolidationProblem::energy`]
+//! reads only the folded `linear`/`quadratic`, which is the single objective
+//! every solver and every golden optimum is scored against.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Format tag for version 1 of the QUBO boundary.
+pub const FORMAT: &str = "kannaka-qubo/1";
+
+/// The consolidation decision a variable represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VarKind {
+    /// Retain a skip link that decay would otherwise drop.
+    KeepLink,
+    /// Merge a redundant, phase-locked resonance group into one carrier.
+    Merge,
+    /// Strengthen (up-weight) a skip link.
+    Strengthen,
+}
+
+/// One binary decision variable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Variable {
+    pub id: usize,
+    pub kind: VarKind,
+    /// Human/audit subject, e.g. `"skip:9f2c…"` or `"mem:a41b…+mem:77e0…"`.
+    pub subject: String,
+}
+
+/// A cardinality (budget) constraint: at most `max_active` of `vars` may be 1.
+/// Also folded into `linear`/`quadratic` with weight `penalty` (see module docs).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Constraint {
+    pub vars: Vec<usize>,
+    pub max_active: usize,
+    pub penalty: f64,
+}
+
+/// Opaque-to-solvers audit context (ADR-0038 §Decision.1). Carries chiral
+/// context + entropy provenance; never read while solving.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Metadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hemisphere: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phi_at_emit: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entropy_provenance: Option<String>,
+    /// Any further metadata keys, preserved across a round-trip.
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// A consolidation QUBO in the `kannaka-qubo/1` format.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConsolidationProblem {
+    pub format: String,
+    pub problem_id: String,
+    pub variables: Vec<Variable>,
+    /// Diagonal coefficients keyed by variable id (JSON object keys are strings).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub linear: BTreeMap<String, f64>,
+    /// Pairwise coefficients keyed `"i,j"` with `i < j`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub quadratic: BTreeMap<String, f64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub constraints: BTreeMap<String, Constraint>,
+    #[serde(default)]
+    pub metadata: Metadata,
+}
+
+fn parse_idx(k: &str) -> Option<usize> {
+    k.trim().parse().ok()
+}
+
+fn parse_pair(k: &str) -> Option<(usize, usize)> {
+    let (a, b) = k.split_once(',')?;
+    Some((parse_idx(a)?, parse_idx(b)?))
+}
+
+impl ConsolidationProblem {
+    /// Number of decision variables.
+    pub fn num_vars(&self) -> usize {
+        self.variables.len()
+    }
+
+    /// Objective energy of an assignment: `Σ linear[i]·x_i + Σ quadratic[i,j]·x_i·x_j`.
+    ///
+    /// This reads only the folded `linear`/`quadratic` (penalties already
+    /// included by the builder), so it is the exact objective solvers minimize
+    /// and golden optima are documented against. Out-of-range keys are ignored.
+    pub fn energy(&self, x: &[bool]) -> f64 {
+        let mut e = 0.0;
+        for (k, &c) in &self.linear {
+            if let Some(i) = parse_idx(k) {
+                if x.get(i).copied().unwrap_or(false) {
+                    e += c;
+                }
+            }
+        }
+        for (k, &c) in &self.quadratic {
+            if let Some((i, j)) = parse_pair(k) {
+                if x.get(i).copied().unwrap_or(false) && x.get(j).copied().unwrap_or(false) {
+                    e += c;
+                }
+            }
+        }
+        e
+    }
+
+    /// Cheap structural sanity check: right format tag, contiguous `0..n` ids,
+    /// and every `linear`/`quadratic`/`constraint` index in range.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.format != FORMAT {
+            return Err(format!("format `{}` != `{FORMAT}`", self.format));
+        }
+        let n = self.variables.len();
+        for (want, v) in self.variables.iter().enumerate() {
+            if v.id != want {
+                return Err(format!("variable ids must be contiguous 0..n; got {} at slot {want}", v.id));
+            }
+        }
+        for k in self.linear.keys() {
+            match parse_idx(k) {
+                Some(i) if i < n => {}
+                _ => return Err(format!("linear key `{k}` out of range")),
+            }
+        }
+        for k in self.quadratic.keys() {
+            match parse_pair(k) {
+                Some((i, j)) if i < j && j < n => {}
+                _ => return Err(format!("quadratic key `{k}` invalid (need i<j, in range)")),
+            }
+        }
+        for (name, c) in &self.constraints {
+            for &i in &c.vars {
+                if i >= n {
+                    return Err(format!("constraint `{name}` references var {i} >= {n}"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Builds a [`ConsolidationProblem`], folding each constraint's penalty into the
+/// QUBO on [`ProblemBuilder::build`].
+#[derive(Debug, Default)]
+pub struct ProblemBuilder {
+    problem_id: String,
+    variables: Vec<Variable>,
+    linear: BTreeMap<usize, f64>,
+    quadratic: BTreeMap<(usize, usize), f64>,
+    constraints: BTreeMap<String, Constraint>,
+    metadata: Metadata,
+}
+
+impl ProblemBuilder {
+    pub fn new(problem_id: impl Into<String>) -> Self {
+        Self { problem_id: problem_id.into(), ..Default::default() }
+    }
+
+    /// Add a variable, returning its id.
+    pub fn add_variable(&mut self, kind: VarKind, subject: impl Into<String>) -> usize {
+        let id = self.variables.len();
+        self.variables.push(Variable { id, kind, subject: subject.into() });
+        id
+    }
+
+    /// Set (overwrite) a variable's linear coefficient.
+    pub fn set_linear(&mut self, id: usize, c: f64) -> &mut Self {
+        self.linear.insert(id, c);
+        self
+    }
+
+    /// Add to a variable's linear coefficient.
+    pub fn add_linear(&mut self, id: usize, c: f64) -> &mut Self {
+        *self.linear.entry(id).or_insert(0.0) += c;
+        self
+    }
+
+    /// Add a quadratic coefficient. `i==j` folds into the linear term
+    /// (`x_i² = x_i` for binary x); otherwise stored canonically with `i < j`.
+    pub fn add_quadratic(&mut self, i: usize, j: usize, c: f64) -> &mut Self {
+        if i == j {
+            *self.linear.entry(i).or_insert(0.0) += c;
+        } else {
+            let key = if i < j { (i, j) } else { (j, i) };
+            *self.quadratic.entry(key).or_insert(0.0) += c;
+        }
+        self
+    }
+
+    /// Add a budget constraint (at most `max_active` of `vars`). Recorded
+    /// structurally and folded into the QUBO on `build`.
+    pub fn add_budget(
+        &mut self,
+        name: impl Into<String>,
+        mut vars: Vec<usize>,
+        max_active: usize,
+        penalty: f64,
+    ) -> &mut Self {
+        vars.sort_unstable();
+        vars.dedup();
+        self.constraints.insert(name.into(), Constraint { vars, max_active, penalty });
+        self
+    }
+
+    pub fn set_metadata(&mut self, m: Metadata) -> &mut Self {
+        self.metadata = m;
+        self
+    }
+
+    /// Fold constraints into the QUBO and emit the problem.
+    ///
+    /// Fold: `P·(Σ_{i∈S} x_i − K)² = P·Σ x_i(1−2K) + 2P·Σ_{i<j} x_i x_j + P·K²`.
+    /// The additive `P·K²` constant is dropped — it shifts every energy equally
+    /// and so can't change the argmin; golden optima are documented on this
+    /// constant-free objective.
+    pub fn build(mut self) -> ConsolidationProblem {
+        for c in self.constraints.values() {
+            let k = c.max_active as f64;
+            for &i in &c.vars {
+                *self.linear.entry(i).or_insert(0.0) += c.penalty * (1.0 - 2.0 * k);
+            }
+            for a in 0..c.vars.len() {
+                for b in (a + 1)..c.vars.len() {
+                    *self.quadratic.entry((c.vars[a], c.vars[b])).or_insert(0.0) += 2.0 * c.penalty;
+                }
+            }
+        }
+        let linear = self
+            .linear
+            .into_iter()
+            .filter(|(_, v)| *v != 0.0)
+            .map(|(i, v)| (i.to_string(), v))
+            .collect();
+        let quadratic = self
+            .quadratic
+            .into_iter()
+            .filter(|(_, v)| *v != 0.0)
+            .map(|((i, j), v)| (format!("{i},{j}"), v))
+            .collect();
+        ConsolidationProblem {
+            format: FORMAT.to_string(),
+            problem_id: self.problem_id,
+            variables: self.variables,
+            linear,
+            quadratic,
+            constraints: self.constraints,
+            metadata: self.metadata,
+        }
+    }
+}
+
+/// A merge decision the dream would consider: a subject label and a `cohesion`
+/// score (≥ 0; larger = stronger case to merge). Emitted as a `merge` variable
+/// with linear `-cohesion`, so keeping the merge (x=1) lowers energy.
+#[derive(Debug, Clone)]
+pub struct MergeCandidate {
+    pub subject: String,
+    pub cohesion: f64,
+}
+
+/// Emit a `kannaka-qubo/1` problem from a dream's merge plan (the T3.2 emitter).
+///
+/// One `merge` variable per candidate; an optional `budget` constraint capping
+/// how many merges a single pass may keep (structural + penalty-folded). This is
+/// deliberately advisory and side-effect-free — the engine re-scores before any
+/// apply (T3.5), and the procedural consolidation path is untouched.
+pub fn dream_merge_problem(
+    problem_id: impl Into<String>,
+    merges: &[MergeCandidate],
+    budget: Option<(usize, f64)>,
+    metadata: Metadata,
+) -> ConsolidationProblem {
+    let mut b = ProblemBuilder::new(problem_id);
+    let mut ids = Vec::with_capacity(merges.len());
+    for m in merges {
+        let id = b.add_variable(VarKind::Merge, m.subject.clone());
+        b.set_linear(id, -m.cohesion);
+        ids.push(id);
+    }
+    b.set_metadata(metadata);
+    if let (Some((max_active, penalty)), false) = (budget, ids.is_empty()) {
+        b.add_budget("budget", ids, max_active, penalty);
+    }
+    b.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn energy_sums_linear_and_quadratic() {
+        let mut b = ProblemBuilder::new("t");
+        let a = b.add_variable(VarKind::Merge, "a");
+        let c = b.add_variable(VarKind::Merge, "b");
+        b.set_linear(a, -2.0);
+        b.set_linear(c, -1.0);
+        b.add_quadratic(a, c, 5.0);
+        let p = b.build();
+        assert_eq!(p.energy(&[false, false]), 0.0);
+        assert_eq!(p.energy(&[true, false]), -2.0);
+        assert_eq!(p.energy(&[false, true]), -1.0);
+        assert_eq!(p.energy(&[true, true]), -2.0 - 1.0 + 5.0);
+    }
+
+    #[test]
+    fn quadratic_diagonal_folds_into_linear() {
+        let mut b = ProblemBuilder::new("t");
+        let a = b.add_variable(VarKind::Merge, "a");
+        b.add_quadratic(a, a, -3.0);
+        let p = b.build();
+        assert!(p.quadratic.is_empty());
+        assert_eq!(p.energy(&[true]), -3.0);
+    }
+
+    #[test]
+    fn budget_fold_makes_single_active_optimal() {
+        // raw linear [-3,-2,-1], budget max_active=1, penalty=10.
+        let mut b = ProblemBuilder::new("t");
+        let v: Vec<usize> = (0..3).map(|_| b.add_variable(VarKind::Merge, "m")).collect();
+        b.set_linear(v[0], -3.0);
+        b.set_linear(v[1], -2.0);
+        b.set_linear(v[2], -1.0);
+        b.add_budget("budget", v.clone(), 1, 10.0);
+        let p = b.build();
+        // fold: linear += 10*(1-2) = -10 each; quadratic pairs += 20.
+        assert_eq!(p.linear["0"], -13.0);
+        assert_eq!(p.linear["1"], -12.0);
+        assert_eq!(p.linear["2"], -11.0);
+        assert_eq!(p.quadratic["0,1"], 20.0);
+        // Single best var active is the global optimum.
+        assert_eq!(p.energy(&[true, false, false]), -13.0);
+        assert_eq!(p.energy(&[true, true, false]), -13.0 - 12.0 + 20.0);
+        assert_eq!(p.energy(&[false, false, false]), 0.0);
+        let (best, e) = brute_force(&p);
+        assert_eq!(best, vec![true, false, false]);
+        assert_eq!(e, -13.0);
+        // Structural constraint is retained too.
+        assert_eq!(p.constraints["budget"].max_active, 1);
+    }
+
+    #[test]
+    fn json_round_trip_is_exact() {
+        let mut b = ProblemBuilder::new("dream-2026-07-02T00:00:00Z");
+        let a = b.add_variable(VarKind::KeepLink, "skip:9f2c");
+        let c = b.add_variable(VarKind::Merge, "mem:a41b+mem:77e0");
+        let d = b.add_variable(VarKind::Strengthen, "skip:c3d9");
+        b.set_linear(a, -1.7);
+        b.set_linear(c, 0.4);
+        b.set_linear(d, -0.9);
+        b.add_quadratic(a, d, -0.6);
+        b.add_quadratic(c, d, 1.1);
+        b.set_metadata(Metadata {
+            hemisphere: Some("right".into()),
+            phi_at_emit: Some(0.18),
+            entropy_provenance: Some("reservoir://iqm-garnet/2026-06-28".into()),
+            ..Default::default()
+        });
+        let p = b.build();
+        let js = serde_json::to_string_pretty(&p).unwrap();
+        let back: ConsolidationProblem = serde_json::from_str(&js).unwrap();
+        assert_eq!(p, back);
+        assert!(back.validate().is_ok());
+        assert_eq!(back.format, FORMAT);
+    }
+
+    #[test]
+    fn dream_merge_problem_emits_merge_vars_and_budget() {
+        let merges = vec![
+            MergeCandidate { subject: "mem:a+mem:b".into(), cohesion: 2.0 },
+            MergeCandidate { subject: "mem:c+mem:d".into(), cohesion: 1.0 },
+        ];
+        let p = dream_merge_problem("dream-x", &merges, Some((1, 5.0)), Metadata::default());
+        assert_eq!(p.num_vars(), 2);
+        assert!(p.variables.iter().all(|v| v.kind == VarKind::Merge));
+        assert!(p.constraints.contains_key("budget"));
+        assert!(p.validate().is_ok());
+    }
+
+    /// Test-only exhaustive optimum (the shipped exact solver is T3.3).
+    fn brute_force(p: &ConsolidationProblem) -> (Vec<bool>, f64) {
+        let n = p.num_vars();
+        let mut best = vec![false; n];
+        let mut best_e = f64::INFINITY;
+        for mask in 0u64..(1u64 << n) {
+            let x: Vec<bool> = (0..n).map(|i| (mask >> i) & 1 == 1).collect();
+            let e = p.energy(&x);
+            if e < best_e {
+                best_e = e;
+                best = x;
+            }
+        }
+        (best, best_e)
+    }
+}

--- a/tests/qubo/01-all-keep.json
+++ b/tests/qubo/01-all-keep.json
@@ -1,0 +1,31 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-01-all-keep",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "keep_link",
+      "subject": "skip:a"
+    },
+    {
+      "id": 1,
+      "kind": "keep_link",
+      "subject": "skip:b"
+    },
+    {
+      "id": 2,
+      "kind": "keep_link",
+      "subject": "skip:c"
+    }
+  ],
+  "linear": {
+    "0": -2.0,
+    "1": -1.5,
+    "2": -3.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/02-all-drop.json
+++ b/tests/qubo/02-all-drop.json
@@ -1,0 +1,31 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-02-all-drop",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:a"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:b"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:c"
+    }
+  ],
+  "linear": {
+    "0": 1.0,
+    "1": 2.0,
+    "2": 0.5
+  },
+  "metadata": {
+    "hemisphere": "flat",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/03-repulsion-pair.json
+++ b/tests/qubo/03-repulsion-pair.json
@@ -1,0 +1,28 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-03-repulsion-pair",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:a+mem:b"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:c+mem:d"
+    }
+  ],
+  "linear": {
+    "0": -2.0,
+    "1": -2.0
+  },
+  "quadratic": {
+    "0,1": 5.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/04-attraction-pair.json
+++ b/tests/qubo/04-attraction-pair.json
@@ -1,0 +1,28 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-04-attraction-pair",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "strengthen",
+      "subject": "skip:a"
+    },
+    {
+      "id": 1,
+      "kind": "strengthen",
+      "subject": "skip:b"
+    }
+  ],
+  "linear": {
+    "0": -1.0,
+    "1": -1.0
+  },
+  "quadratic": {
+    "0,1": -3.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/05-budget-at-most-1.json
+++ b/tests/qubo/05-budget-at-most-1.json
@@ -1,0 +1,47 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-05-budget-at-most-1",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:a"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:b"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:c"
+    }
+  ],
+  "linear": {
+    "0": -13.0,
+    "1": -12.0,
+    "2": -11.0
+  },
+  "quadratic": {
+    "0,1": 20.0,
+    "0,2": 20.0,
+    "1,2": 20.0
+  },
+  "constraints": {
+    "budget": {
+      "vars": [
+        0,
+        1,
+        2
+      ],
+      "max_active": 1,
+      "penalty": 10.0
+    }
+  },
+  "metadata": {
+    "hemisphere": "flat",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/06-budget-at-most-2.json
+++ b/tests/qubo/06-budget-at-most-2.json
@@ -1,0 +1,57 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-06-budget-at-most-2",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:a"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:b"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:c"
+    },
+    {
+      "id": 3,
+      "kind": "merge",
+      "subject": "mem:d"
+    }
+  ],
+  "linear": {
+    "0": -34.0,
+    "1": -33.0,
+    "2": -32.0,
+    "3": -31.0
+  },
+  "quadratic": {
+    "0,1": 20.0,
+    "0,2": 20.0,
+    "0,3": 20.0,
+    "1,2": 20.0,
+    "1,3": 20.0,
+    "2,3": 20.0
+  },
+  "constraints": {
+    "budget": {
+      "vars": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "max_active": 2,
+      "penalty": 10.0
+    }
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/07-mixed.json
+++ b/tests/qubo/07-mixed.json
@@ -1,0 +1,47 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-07-mixed",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "keep_link",
+      "subject": "v0"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "v1"
+    },
+    {
+      "id": 2,
+      "kind": "keep_link",
+      "subject": "v2"
+    },
+    {
+      "id": 3,
+      "kind": "merge",
+      "subject": "v3"
+    },
+    {
+      "id": 4,
+      "kind": "strengthen",
+      "subject": "v4"
+    }
+  ],
+  "linear": {
+    "0": -2.0,
+    "1": 1.0,
+    "2": -1.0,
+    "3": 3.0,
+    "4": -0.5
+  },
+  "quadratic": {
+    "0,2": 1.5,
+    "2,4": -2.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/08-frustrated-triangle.json
+++ b/tests/qubo/08-frustrated-triangle.json
@@ -1,0 +1,36 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-08-frustrated-triangle",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:0"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:1"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:2"
+    }
+  ],
+  "linear": {
+    "0": -1.0,
+    "1": -1.0,
+    "2": -1.0
+  },
+  "quadratic": {
+    "0,1": 1.5,
+    "0,2": 1.5,
+    "1,2": 1.5
+  },
+  "metadata": {
+    "hemisphere": "flat",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/09-link-strengthen.json
+++ b/tests/qubo/09-link-strengthen.json
@@ -1,0 +1,40 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-09-link-strengthen",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "keep_link",
+      "subject": "skip:A"
+    },
+    {
+      "id": 1,
+      "kind": "strengthen",
+      "subject": "skip:A"
+    },
+    {
+      "id": 2,
+      "kind": "keep_link",
+      "subject": "skip:B"
+    },
+    {
+      "id": 3,
+      "kind": "merge",
+      "subject": "mem:x+mem:y"
+    }
+  ],
+  "linear": {
+    "0": -1.0,
+    "1": 0.5,
+    "2": -0.5,
+    "3": -1.0
+  },
+  "quadratic": {
+    "0,1": -2.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/10-single.json
+++ b/tests/qubo/10-single.json
@@ -1,0 +1,19 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-10-single",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "keep_link",
+      "subject": "skip:only"
+    }
+  ],
+  "linear": {
+    "0": -1.0
+  },
+  "metadata": {
+    "hemisphere": "flat",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/11-large-independent.json
+++ b/tests/qubo/11-large-independent.json
@@ -1,0 +1,157 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-11-large-independent",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:0"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:1"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:2"
+    },
+    {
+      "id": 3,
+      "kind": "merge",
+      "subject": "mem:3"
+    },
+    {
+      "id": 4,
+      "kind": "merge",
+      "subject": "mem:4"
+    },
+    {
+      "id": 5,
+      "kind": "merge",
+      "subject": "mem:5"
+    },
+    {
+      "id": 6,
+      "kind": "merge",
+      "subject": "mem:6"
+    },
+    {
+      "id": 7,
+      "kind": "merge",
+      "subject": "mem:7"
+    },
+    {
+      "id": 8,
+      "kind": "merge",
+      "subject": "mem:8"
+    },
+    {
+      "id": 9,
+      "kind": "merge",
+      "subject": "mem:9"
+    },
+    {
+      "id": 10,
+      "kind": "merge",
+      "subject": "mem:10"
+    },
+    {
+      "id": 11,
+      "kind": "merge",
+      "subject": "mem:11"
+    },
+    {
+      "id": 12,
+      "kind": "merge",
+      "subject": "mem:12"
+    },
+    {
+      "id": 13,
+      "kind": "merge",
+      "subject": "mem:13"
+    },
+    {
+      "id": 14,
+      "kind": "merge",
+      "subject": "mem:14"
+    },
+    {
+      "id": 15,
+      "kind": "merge",
+      "subject": "mem:15"
+    },
+    {
+      "id": 16,
+      "kind": "merge",
+      "subject": "mem:16"
+    },
+    {
+      "id": 17,
+      "kind": "merge",
+      "subject": "mem:17"
+    },
+    {
+      "id": 18,
+      "kind": "merge",
+      "subject": "mem:18"
+    },
+    {
+      "id": 19,
+      "kind": "merge",
+      "subject": "mem:19"
+    },
+    {
+      "id": 20,
+      "kind": "merge",
+      "subject": "mem:20"
+    },
+    {
+      "id": 21,
+      "kind": "merge",
+      "subject": "mem:21"
+    },
+    {
+      "id": 22,
+      "kind": "merge",
+      "subject": "mem:22"
+    },
+    {
+      "id": 23,
+      "kind": "merge",
+      "subject": "mem:23"
+    }
+  ],
+  "linear": {
+    "0": 0.7,
+    "1": -1.3,
+    "10": -1.6,
+    "11": -1.9,
+    "12": 0.7,
+    "13": -1.3,
+    "14": -1.6,
+    "15": 0.7,
+    "16": -1.0,
+    "17": -1.3,
+    "18": 0.7,
+    "19": -1.9,
+    "2": -1.6,
+    "20": -1.0,
+    "21": 0.7,
+    "22": -1.6,
+    "23": -1.9,
+    "3": 0.7,
+    "4": -1.0,
+    "5": -1.3,
+    "6": 0.7,
+    "7": -1.9,
+    "8": -1.0,
+    "9": 0.7
+  },
+  "metadata": {
+    "hemisphere": "flat",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/12-large-ferromagnet.json
+++ b/tests/qubo/12-large-ferromagnet.json
@@ -1,0 +1,154 @@
+{
+  "format": "kannaka-qubo/1",
+  "problem_id": "golden-12-large-ferromagnet",
+  "variables": [
+    {
+      "id": 0,
+      "kind": "merge",
+      "subject": "mem:0"
+    },
+    {
+      "id": 1,
+      "kind": "merge",
+      "subject": "mem:1"
+    },
+    {
+      "id": 2,
+      "kind": "merge",
+      "subject": "mem:2"
+    },
+    {
+      "id": 3,
+      "kind": "merge",
+      "subject": "mem:3"
+    },
+    {
+      "id": 4,
+      "kind": "merge",
+      "subject": "mem:4"
+    },
+    {
+      "id": 5,
+      "kind": "merge",
+      "subject": "mem:5"
+    },
+    {
+      "id": 6,
+      "kind": "merge",
+      "subject": "mem:6"
+    },
+    {
+      "id": 7,
+      "kind": "merge",
+      "subject": "mem:7"
+    },
+    {
+      "id": 8,
+      "kind": "merge",
+      "subject": "mem:8"
+    },
+    {
+      "id": 9,
+      "kind": "merge",
+      "subject": "mem:9"
+    },
+    {
+      "id": 10,
+      "kind": "merge",
+      "subject": "mem:10"
+    },
+    {
+      "id": 11,
+      "kind": "merge",
+      "subject": "mem:11"
+    },
+    {
+      "id": 12,
+      "kind": "merge",
+      "subject": "mem:12"
+    },
+    {
+      "id": 13,
+      "kind": "merge",
+      "subject": "mem:13"
+    },
+    {
+      "id": 14,
+      "kind": "merge",
+      "subject": "mem:14"
+    },
+    {
+      "id": 15,
+      "kind": "merge",
+      "subject": "mem:15"
+    },
+    {
+      "id": 16,
+      "kind": "merge",
+      "subject": "mem:16"
+    },
+    {
+      "id": 17,
+      "kind": "merge",
+      "subject": "mem:17"
+    },
+    {
+      "id": 18,
+      "kind": "merge",
+      "subject": "mem:18"
+    },
+    {
+      "id": 19,
+      "kind": "merge",
+      "subject": "mem:19"
+    }
+  ],
+  "linear": {
+    "0": -0.5,
+    "1": -0.5,
+    "10": -0.5,
+    "11": -0.5,
+    "12": -0.5,
+    "13": -0.5,
+    "14": -0.5,
+    "15": -0.5,
+    "16": -0.5,
+    "17": -0.5,
+    "18": -0.5,
+    "19": -0.5,
+    "2": -0.5,
+    "3": -0.5,
+    "4": -0.5,
+    "5": -0.5,
+    "6": -0.5,
+    "7": -0.5,
+    "8": -0.5,
+    "9": -0.5
+  },
+  "quadratic": {
+    "0,1": -1.0,
+    "1,2": -1.0,
+    "10,11": -1.0,
+    "11,12": -1.0,
+    "12,13": -1.0,
+    "13,14": -1.0,
+    "14,15": -1.0,
+    "15,16": -1.0,
+    "16,17": -1.0,
+    "17,18": -1.0,
+    "18,19": -1.0,
+    "2,3": -1.0,
+    "3,4": -1.0,
+    "4,5": -1.0,
+    "5,6": -1.0,
+    "6,7": -1.0,
+    "7,8": -1.0,
+    "8,9": -1.0,
+    "9,10": -1.0
+  },
+  "metadata": {
+    "hemisphere": "right",
+    "phi_at_emit": 0.18,
+    "entropy_provenance": "prng://legacy"
+  }
+}

--- a/tests/qubo/README.md
+++ b/tests/qubo/README.md
@@ -1,0 +1,33 @@
+# Golden QUBO corpus (ADR-0038 · T3.2)
+
+12 hand-designed `kannaka-qubo/1` consolidation problems with **known optima**,
+used to validate the format (T3.2) and every `ConsolidationSolver` (T3.3+).
+
+- `NN-*.json` — the problems, in `kannaka-qubo/1` format.
+- `manifest.json` — for each file: `num_vars`, `exact_solvable`, `optimum_energy`,
+  an `optimum_assignment`, and a description. This is the documented optima.
+
+Regenerate after an intentional change:
+
+```
+cargo run --example gen_qubo_corpus
+```
+
+## Conventions
+
+- Solvers **minimize** `ConsolidationProblem::energy(x) = Σ linearᵢ·xᵢ + Σ quadraticᵢⱼ·xᵢ·xⱼ`.
+- Budget constraints are carried **twice** (ADR-0038): structurally in
+  `constraints`, and penalty-folded into `linear`/`quadratic` as
+  `P·(Σx − K)²` (the additive `P·K²` constant is dropped — it can't change the
+  argmin). `energy()` reads only the folded terms, so it already includes the
+  soft penalty; the documented optima are over that objective.
+- `exact_solvable = num_vars < 20` (brute-forceable in tests). The two large
+  files (24, 20 vars) have optima known by construction (independent vars; and an
+  all-negative ferromagnet whose optimum is all-true) for the ≥95%-of-optimal
+  solver check.
+
+## What's exercised
+
+Trivial keep/drop, pairwise repulsion/attraction, `max_active` budgets (1-of-3,
+2-of-4), mixed-sign objectives, a frustrated triangle, keep_link↔strengthen
+coupling, a single var, and two ≥20-var problems.

--- a/tests/qubo/manifest.json
+++ b/tests/qubo/manifest.json
@@ -1,0 +1,188 @@
+{
+  "format": "kannaka-qubo-golden/1",
+  "note": "Golden ADR-0038 QUBOs. Regenerate with `cargo run --example gen_qubo_corpus`. optimum_energy is over ConsolidationProblem::energy (penalties already folded); exact_solvable=true means <20 vars (brute-forceable in tests).",
+  "files": [
+    {
+      "file": "01-all-keep.json",
+      "num_vars": 3,
+      "exact_solvable": true,
+      "optimum_energy": -6.5,
+      "optimum_assignment": [
+        true,
+        true,
+        true
+      ],
+      "description": "3 keep_link, all negative linear; optimum keeps all."
+    },
+    {
+      "file": "02-all-drop.json",
+      "num_vars": 3,
+      "exact_solvable": true,
+      "optimum_energy": 0.0,
+      "optimum_assignment": [
+        false,
+        false,
+        false
+      ],
+      "description": "3 merge, all positive linear; optimum activates none (E=0)."
+    },
+    {
+      "file": "03-repulsion-pair.json",
+      "num_vars": 2,
+      "exact_solvable": true,
+      "optimum_energy": -2.0,
+      "optimum_assignment": [
+        true,
+        false
+      ],
+      "description": "2 merge, negative linear, strong positive coupling; optimum takes exactly one."
+    },
+    {
+      "file": "04-attraction-pair.json",
+      "num_vars": 2,
+      "exact_solvable": true,
+      "optimum_energy": -5.0,
+      "optimum_assignment": [
+        true,
+        true
+      ],
+      "description": "2 strengthen, negative linear + negative coupling; optimum takes both."
+    },
+    {
+      "file": "05-budget-at-most-1.json",
+      "num_vars": 3,
+      "exact_solvable": true,
+      "optimum_energy": -13.0,
+      "optimum_assignment": [
+        true,
+        false,
+        false
+      ],
+      "description": "3 merge, budget max_active=1 (folded); optimum keeps only the strongest."
+    },
+    {
+      "file": "06-budget-at-most-2.json",
+      "num_vars": 4,
+      "exact_solvable": true,
+      "optimum_energy": -47.0,
+      "optimum_assignment": [
+        true,
+        true,
+        false,
+        false
+      ],
+      "description": "4 merge, budget max_active=2 (folded); optimum keeps the strongest two."
+    },
+    {
+      "file": "07-mixed.json",
+      "num_vars": 5,
+      "exact_solvable": true,
+      "optimum_energy": -4.0,
+      "optimum_assignment": [
+        true,
+        false,
+        true,
+        false,
+        true
+      ],
+      "description": "5 mixed-kind vars, mixed-sign linear + two couplings; brute-force optimum."
+    },
+    {
+      "file": "08-frustrated-triangle.json",
+      "num_vars": 3,
+      "exact_solvable": true,
+      "optimum_energy": -1.0,
+      "optimum_assignment": [
+        true,
+        false,
+        false
+      ],
+      "description": "3 merge, negative linear, all pairs repel; optimum takes exactly one."
+    },
+    {
+      "file": "09-link-strengthen.json",
+      "num_vars": 4,
+      "exact_solvable": true,
+      "optimum_energy": -4.0,
+      "optimum_assignment": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "description": "keep_link/strengthen coupling; optimum keeps+strengthens A, keeps B, merges."
+    },
+    {
+      "file": "10-single.json",
+      "num_vars": 1,
+      "exact_solvable": true,
+      "optimum_energy": -1.0,
+      "optimum_assignment": [
+        true
+      ],
+      "description": "1 keep_link, negative linear; optimum keeps it."
+    },
+    {
+      "file": "11-large-independent.json",
+      "num_vars": 24,
+      "exact_solvable": false,
+      "optimum_energy": -23.2,
+      "optimum_assignment": [
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true
+      ],
+      "description": "24 independent vars, mixed signs; optimum = each var iff its linear<0."
+    },
+    {
+      "file": "12-large-ferromagnet.json",
+      "num_vars": 20,
+      "exact_solvable": false,
+      "optimum_energy": -29.0,
+      "optimum_assignment": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "description": "20 vars, all-negative linear + negative chain coupling; optimum is all-true."
+    }
+  ]
+}

--- a/tests/qubo_corpus.rs
+++ b/tests/qubo_corpus.rs
@@ -1,0 +1,115 @@
+//! T3.2 golden-corpus validation (ADR-0038 §Validation).
+//!
+//! The committed `tests/qubo/*.json` are the golden artifacts; `manifest.json`
+//! documents each one's known optimum. This suite proves the artifacts are
+//! well-formed and the documented optima are real:
+//!   - every file parses, validates, and JSON round-trips exactly;
+//!   - the documented assignment achieves the documented energy;
+//!   - for exact-solvable files (<20 vars) brute force confirms it's the *global*
+//!     optimum — so T3.3's solver has a trustworthy target.
+//!
+//! Regenerate the corpus with `cargo run --example gen_qubo_corpus`.
+
+use std::path::PathBuf;
+
+use kannaka_memory::qubo::ConsolidationProblem;
+use serde::Deserialize;
+
+fn dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("qubo")
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestEntry {
+    pub file: String,
+    pub num_vars: usize,
+    pub exact_solvable: bool,
+    pub optimum_energy: f64,
+    pub optimum_assignment: Vec<bool>,
+    #[allow(dead_code)]
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    pub files: Vec<ManifestEntry>,
+}
+
+pub fn load_manifest() -> Manifest {
+    let s = std::fs::read_to_string(dir().join("manifest.json"))
+        .expect("tests/qubo/manifest.json — regenerate with `cargo run --example gen_qubo_corpus`");
+    serde_json::from_str(&s).expect("parse manifest.json")
+}
+
+pub fn load_problem(file: &str) -> ConsolidationProblem {
+    let s = std::fs::read_to_string(dir().join(file)).unwrap_or_else(|_| panic!("read {file}"));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {file}: {e}"))
+}
+
+/// Exhaustive optimum — test-only ground truth for small problems.
+pub fn brute_force(p: &ConsolidationProblem) -> (Vec<bool>, f64) {
+    let n = p.num_vars();
+    assert!(n < 24, "brute_force is for exact-solvable sizes only");
+    let mut best = vec![false; n];
+    let mut best_e = f64::INFINITY;
+    for mask in 0u64..(1u64 << n) {
+        let x: Vec<bool> = (0..n).map(|i| (mask >> i) & 1 == 1).collect();
+        let e = p.energy(&x);
+        if e < best_e {
+            best_e = e;
+            best = x;
+        }
+    }
+    (best, best_e)
+}
+
+#[test]
+fn corpus_is_twelve_with_expected_split() {
+    let m = load_manifest();
+    assert_eq!(m.files.len(), 12, "ADR-0038 calls for 12 golden QUBOs");
+    let exact = m.files.iter().filter(|e| e.exact_solvable).count();
+    let large = m.files.iter().filter(|e| !e.exact_solvable).count();
+    assert_eq!(exact, 10, "10 exact-solvable (<20 var) files");
+    assert_eq!(large, 2, "2 large (>=20 var) files for the >=95% test");
+    for e in &m.files {
+        assert_eq!(e.exact_solvable, e.num_vars < 20, "{}: exact flag vs size", e.file);
+        assert_eq!(e.optimum_assignment.len(), e.num_vars, "{}: assignment width", e.file);
+    }
+}
+
+#[test]
+fn golden_files_round_trip_and_validate() {
+    for e in load_manifest().files {
+        let p = load_problem(&e.file);
+        p.validate().unwrap_or_else(|err| panic!("{} invalid: {err}", e.file));
+        assert_eq!(p.num_vars(), e.num_vars, "{} var count", e.file);
+        let js = serde_json::to_string(&p).unwrap();
+        let back: ConsolidationProblem = serde_json::from_str(&js).unwrap();
+        assert_eq!(p, back, "{} did not round-trip", e.file);
+    }
+}
+
+#[test]
+fn documented_optima_are_correct() {
+    for e in load_manifest().files {
+        let p = load_problem(&e.file);
+        // The documented assignment achieves the documented energy.
+        let e_doc = p.energy(&e.optimum_assignment);
+        assert!(
+            (e_doc - e.optimum_energy).abs() < 1e-9,
+            "{}: energy(documented assignment)={e_doc} != manifest optimum {}",
+            e.file,
+            e.optimum_energy
+        );
+        // For exact-solvable files, brute force must agree it is the global minimum.
+        if e.exact_solvable {
+            let (_, best) = brute_force(&p);
+            assert!(
+                (best - e.optimum_energy).abs() < 1e-9,
+                "{}: brute-force optimum {best} != manifest {}",
+                e.file,
+                e.optimum_energy
+            );
+        }
+    }
+}


### PR DESCRIPTION
## T3.2 — ConsolidationProblem emitter (`kannaka-qubo/1`) + golden corpus

Closes #478. Implements the ADR-0038 serialization boundary so the dream
consolidation decision becomes a swappable QUBO. Solver + `ClassicalAnneal` are
T3.3 (follow-up PR); the re-score-before-apply path is T3.5 (not here).

### Format (`src/qubo/problem.rs`)
`ConsolidationProblem` = the `kannaka-qubo/1` schema from the ADR: `variables`
(keep_link / merge / strengthen), `linear` (diagonal), `quadratic` (`"i,j"`,
i<j), `constraints`, opaque `metadata` (hemisphere / phi_at_emit /
entropy_provenance, plus a flattened `extra` for forward-compat round-trips).
`energy(x) = Σ linearᵢ·xᵢ + Σ quadraticᵢⱼ·xᵢxⱼ` is the minimization objective.

**Penalty-fold convention (ADR §Decision.1 & review decision 3):** budget
constraints are carried **twice** — structurally in `constraints`, and folded
into Q by `ProblemBuilder::build` as `P·(Σx − K)²` (the additive `P·K²` constant
is dropped; it can't change the argmin). So a constraint-blind solver reads
`linear`/`quadratic` and still gets a valid, softer problem; a smart solver can
use the structural block. `energy()` reads only the folded terms.

### Emitter (`src/qubo/emit.rs` + `plan_consolidation` hook)
`KANNAKA_QUBO_EMIT` (default **off**) makes `plan_consolidation` write a
`kannaka-qubo/1` file **alongside** the procedural plan (merge variables from the
admitted merge groups, a soft budget). The procedural path is untouched and
authoritative; nothing consumes the file yet. `KANNAKA_QUBO_EMIT_DIR` overrides
the output dir.

### Golden corpus (`tests/qubo/`)
12 hand-designed QUBOs + `manifest.json` documenting each optimum (energy +
assignment + exact-solvable flag): trivial keep/drop, pairwise repulsion/
attraction, `max_active` budgets (1-of-3 → E=-13, 2-of-4 → E=-47), mixed signs,
a frustrated triangle, keep_link↔strengthen coupling, a single var, and two
≥20-var problems (24 independent, 20-var ferromagnet) for the ≥95% solver check.
Regenerate with `cargo run --example gen_qubo_corpus`.

`tests/qubo_corpus.rs` proves every file parses/validates/round-trips exactly,
and that the documented optima are re-derived by brute force on the 10
exact-solvable files (so T3.3's solver has a trustworthy target).

### CI
`cargo test` (lib `qubo` unit tests + `qubo_corpus`), `cargo check
--all-targets`, `cargo clippy --lib --bin kannaka` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
