### PR TITLE
feat(qubo): ConsolidationSolver trait + ClassicalAnneal default (ADR-0038 T3.3)

### DIFF
--- a/src/qubo/mod.rs
+++ b/src/qubo/mod.rs
@@ -18,8 +18,13 @@
 
 pub mod emit;
 pub mod problem;
+pub mod solver;
 
 pub use problem::{
     dream_merge_problem, ConsolidationProblem, Constraint, MergeCandidate, Metadata, ProblemBuilder,
     VarKind, Variable, FORMAT,
+};
+pub use solver::{
+    ClassicalAnneal, ConsolidationSolution, ConsolidationSolver, SolveBudget, SolveError,
+    EXACT_THRESHOLD,
 };

--- a/src/qubo/solver.rs
+++ b/src/qubo/solver.rs
@@ -1,0 +1,335 @@
+//! T3.3 — the `ConsolidationSolver` trait and the default `ClassicalAnneal`
+//! (ADR-0038 §Decision.2-3).
+//!
+//! A solver takes a [`ConsolidationProblem`] and a [`SolveBudget`] and returns a
+//! [`ConsolidationSolution`] the engine treats as **advisory** (it re-scores
+//! before applying — T3.5). [`ClassicalAnneal`] is exhaustive below 20 variables
+//! (`exact: true`) and otherwise simulated annealing with restarts, its RNG
+//! seeded from the [`EntropySource`] trait (T1.3) so even the classical solver's
+//! stochasticity carries entropy provenance, recorded in the solution.
+
+use std::fmt;
+use std::time::{Duration, Instant};
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use crate::entropy::{seed_from_bytes, EntropySource, PrngSource, Provenance};
+
+use super::problem::ConsolidationProblem;
+
+/// Below this many variables `ClassicalAnneal` solves exhaustively (`exact`).
+pub const EXACT_THRESHOLD: usize = 20;
+
+/// Wall-time / cost budget for a solve. `max_cost_usd` is 0.0 for classical
+/// solvers; a subprocess/quantum solver (T3.4) passes it through as a credit cap.
+#[derive(Debug, Clone, Copy)]
+pub struct SolveBudget {
+    pub wall_time: Duration,
+    pub max_cost_usd: f64,
+}
+
+impl Default for SolveBudget {
+    fn default() -> Self {
+        Self { wall_time: Duration::from_secs(5), max_cost_usd: 0.0 }
+    }
+}
+
+/// A solver's answer. `assignment` is advisory — the engine re-scores it against
+/// its own objective before applying (ADR-0038 review decision 2).
+#[derive(Debug, Clone)]
+pub struct ConsolidationSolution {
+    pub assignment: Vec<bool>,
+    pub energy: f64,
+    /// Provenance: which solver produced this.
+    pub solver: String,
+    /// Exhaustive (`true`) vs heuristic (`false`).
+    pub exact: bool,
+    /// For sampling solvers: `(assignment, energy, count)` per distinct sample.
+    pub samples: Option<Vec<(Vec<bool>, f64, u32)>>,
+    /// T3.3 (#479): provenance of the entropy that seeded the solve. `prng://…`
+    /// for the software default; `reservoir://…` + a QPU chain once T1.5 lands.
+    pub provenance: Provenance,
+}
+
+/// Why a solve failed.
+#[derive(Debug, Clone)]
+pub enum SolveError {
+    /// The problem's `linear`/`quadratic` reference a variable id out of range,
+    /// etc. (carries [`ConsolidationProblem::validate`]'s message).
+    Invalid(String),
+}
+
+impl fmt::Display for SolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SolveError::Invalid(m) => write!(f, "invalid problem: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SolveError {}
+
+/// The solver seam (ADR-0038 §Decision.2). `ClassicalAnneal` is native; a
+/// quantum backend is wrapped as a subprocess solver (T3.4).
+pub trait ConsolidationSolver {
+    fn name(&self) -> &str;
+    fn solve(
+        &self,
+        problem: &ConsolidationProblem,
+        budget: SolveBudget,
+    ) -> Result<ConsolidationSolution, SolveError>;
+}
+
+/// Simulated annealing with restarts; exhaustive below [`EXACT_THRESHOLD`].
+///
+/// The seed is drawn ONCE (at construction) from an [`EntropySource`] so
+/// `solve` stays `&self` and reproducible: the same seed yields the same
+/// assignment. The draw's [`Provenance`] is recorded into every solution.
+#[derive(Debug, Clone)]
+pub struct ClassicalAnneal {
+    seed: u64,
+    provenance: Provenance,
+    restarts: u32,
+    /// Sweeps (flip attempts = iters × n) per restart.
+    iters_per_var: u32,
+}
+
+impl Default for ClassicalAnneal {
+    /// Seeded from the software PRNG (`prng://`). Never fails.
+    fn default() -> Self {
+        Self::from_entropy(&mut PrngSource::new())
+    }
+}
+
+impl ClassicalAnneal {
+    /// Draw a 64-bit seed from `src`, recording its provenance. If the source
+    /// errors (e.g. an empty reservoir), fall back to the software PRNG and
+    /// record its (honest `prng://`) provenance rather than failing a dream.
+    pub fn from_entropy(src: &mut dyn EntropySource) -> Self {
+        let (seed, provenance) = match src.draw(64) {
+            Ok(d) => (seed_from_bytes(&d.bytes), d.provenance),
+            Err(_) => {
+                let d = PrngSource::new().draw(64).expect("PrngSource never fails");
+                (seed_from_bytes(&d.bytes), d.provenance)
+            }
+        };
+        Self { seed, provenance, restarts: 32, iters_per_var: 400 }
+    }
+
+    /// Deterministic constructor for tests / reproduction: a fixed seed, with
+    /// `prng://legacy` provenance (no entropy was drawn).
+    pub fn with_seed(seed: u64) -> Self {
+        Self { seed, provenance: Provenance::legacy(), restarts: 32, iters_per_var: 400 }
+    }
+
+    pub fn with_schedule(mut self, restarts: u32, iters_per_var: u32) -> Self {
+        self.restarts = restarts.max(1);
+        self.iters_per_var = iters_per_var.max(1);
+        self
+    }
+
+    /// Exhaustive minimum over all 2ⁿ assignments (for n < [`EXACT_THRESHOLD`]).
+    fn exhaustive(problem: &ConsolidationProblem) -> (Vec<bool>, f64) {
+        let n = problem.num_vars();
+        let mut best = vec![false; n];
+        let mut best_e = f64::INFINITY;
+        for mask in 0u64..(1u64 << n) {
+            let x: Vec<bool> = (0..n).map(|i| (mask >> i) & 1 == 1).collect();
+            let e = problem.energy(&x);
+            if e < best_e {
+                best_e = e;
+                best = x;
+            }
+        }
+        (best, best_e)
+    }
+
+    /// One annealing run from a random start; returns the best state seen.
+    fn anneal_once(&self, problem: &ConsolidationProblem, rng: &mut ChaCha8Rng) -> (Vec<bool>, f64) {
+        let n = problem.num_vars();
+        let mut x: Vec<bool> = (0..n).map(|_| rng.gen_bool(0.5)).collect();
+        let mut e = problem.energy(&x);
+        let mut best = x.clone();
+        let mut best_e = e;
+
+        let (t0, t1) = (2.0_f64, 0.01_f64);
+        let total = (self.iters_per_var as usize).saturating_mul(n).max(1);
+        for it in 0..total {
+            let frac = it as f64 / total as f64;
+            let temp = t0 * (t1 / t0).powf(frac);
+            let flip = rng.gen_range(0..n);
+            x[flip] = !x[flip];
+            let e2 = problem.energy(&x);
+            let de = e2 - e;
+            if de <= 0.0 || rng.gen::<f64>() < (-de / temp).exp() {
+                e = e2;
+                if e < best_e {
+                    best_e = e;
+                    best.copy_from_slice(&x);
+                }
+            } else {
+                x[flip] = !x[flip]; // reject: revert the flip
+            }
+        }
+        (best, best_e)
+    }
+}
+
+impl ConsolidationSolver for ClassicalAnneal {
+    fn name(&self) -> &str {
+        "ClassicalAnneal"
+    }
+
+    fn solve(
+        &self,
+        problem: &ConsolidationProblem,
+        budget: SolveBudget,
+    ) -> Result<ConsolidationSolution, SolveError> {
+        problem.validate().map_err(SolveError::Invalid)?;
+        let n = problem.num_vars();
+
+        // Empty problem: the empty assignment, energy 0, trivially exact.
+        if n == 0 {
+            return Ok(ConsolidationSolution {
+                assignment: Vec::new(),
+                energy: 0.0,
+                solver: self.name().to_string(),
+                exact: true,
+                samples: None,
+                provenance: self.provenance.clone(),
+            });
+        }
+
+        if n < EXACT_THRESHOLD {
+            let (assignment, energy) = Self::exhaustive(problem);
+            return Ok(ConsolidationSolution {
+                assignment,
+                energy,
+                solver: self.name().to_string(),
+                exact: true,
+                samples: None,
+                provenance: self.provenance.clone(),
+            });
+        }
+
+        // Heuristic: SA with restarts, deterministic in `self.seed`. Each restart
+        // gets its own stream (seed ⊕ restart index) so restarts don't correlate.
+        let start = Instant::now();
+        let mut best: Vec<bool> = Vec::new();
+        let mut best_e = f64::INFINITY;
+        let mut samples: Vec<(Vec<bool>, f64, u32)> = Vec::new();
+        for r in 0..self.restarts {
+            let mut rng = ChaCha8Rng::seed_from_u64(self.seed ^ (r as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            let (x, e) = self.anneal_once(problem, &mut rng);
+            samples.push((x.clone(), e, 1));
+            if e < best_e {
+                best_e = e;
+                best = x;
+            }
+            // Respect the wall-time budget between restarts (best-effort).
+            if start.elapsed() >= budget.wall_time {
+                break;
+            }
+        }
+
+        Ok(ConsolidationSolution {
+            assignment: best,
+            energy: best_e,
+            solver: self.name().to_string(),
+            exact: false,
+            samples: Some(samples),
+            provenance: self.provenance.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qubo::problem::{ProblemBuilder, VarKind};
+
+    fn attraction_pair() -> ConsolidationProblem {
+        // linear [-1,-1], quadratic(0,1)=-3 → optimum both-true, energy -5.
+        let mut b = ProblemBuilder::new("t");
+        let x = b.add_variable(VarKind::Merge, "a");
+        let y = b.add_variable(VarKind::Merge, "b");
+        b.set_linear(x, -1.0);
+        b.set_linear(y, -1.0);
+        b.add_quadratic(x, y, -3.0);
+        b.build()
+    }
+
+    #[test]
+    fn exact_below_threshold_finds_global_optimum() {
+        let p = attraction_pair();
+        let s = ClassicalAnneal::with_seed(1);
+        let sol = s.solve(&p, SolveBudget::default()).unwrap();
+        assert!(sol.exact);
+        assert_eq!(sol.assignment, vec![true, true]);
+        assert_eq!(sol.energy, -5.0);
+        assert!(sol.samples.is_none());
+    }
+
+    #[test]
+    fn empty_problem_is_exact_zero() {
+        let p = ProblemBuilder::new("empty").build();
+        let sol = ClassicalAnneal::default().solve(&p, SolveBudget::default()).unwrap();
+        assert!(sol.exact);
+        assert_eq!(sol.energy, 0.0);
+        assert!(sol.assignment.is_empty());
+    }
+
+    #[test]
+    fn anneal_solves_large_ferromagnet_to_optimum() {
+        // 22 vars (> EXACT_THRESHOLD), all-negative linear + negative chain: the
+        // optimum is all-true. SA must reach it (no frustration).
+        let mut b = ProblemBuilder::new("ferro");
+        let v: Vec<usize> = (0..22)
+            .map(|i| {
+                let id = b.add_variable(VarKind::Merge, format!("m{i}"));
+                b.set_linear(id, -0.5);
+                id
+            })
+            .collect();
+        for i in 0..v.len() - 1 {
+            b.add_quadratic(v[i], v[i + 1], -1.0);
+        }
+        let p = b.build();
+        let opt = -0.5 * 22.0 + -1.0 * 21.0;
+        let sol = ClassicalAnneal::with_seed(7).solve(&p, SolveBudget::default()).unwrap();
+        assert!(!sol.exact, "22 > threshold ⇒ heuristic");
+        assert!(sol.samples.is_some());
+        assert!(
+            (sol.energy - opt).abs() < 1e-9,
+            "SA energy {} != optimum {opt}",
+            sol.energy
+        );
+    }
+
+    #[test]
+    fn same_seed_is_deterministic() {
+        let mut b = ProblemBuilder::new("ferro");
+        for i in 0..24 {
+            let id = b.add_variable(VarKind::Merge, format!("m{i}"));
+            b.set_linear(id, -0.5);
+            if i > 0 {
+                b.add_quadratic(i - 1, i, -1.0);
+            }
+        }
+        let p = b.build();
+        let a = ClassicalAnneal::with_seed(42).solve(&p, SolveBudget::default()).unwrap();
+        let c = ClassicalAnneal::with_seed(42).solve(&p, SolveBudget::default()).unwrap();
+        assert_eq!(a.assignment, c.assignment);
+        assert_eq!(a.energy, c.energy);
+    }
+
+    #[test]
+    fn provenance_recorded_from_entropy_source() {
+        let sol = ClassicalAnneal::from_entropy(&mut PrngSource::new())
+            .solve(&attraction_pair(), SolveBudget::default())
+            .unwrap();
+        assert!(sol.provenance.is_prng(), "PRNG-seeded solve carries prng:// provenance");
+        assert_eq!(sol.solver, "ClassicalAnneal");
+    }
+}

--- a/tests/qubo_solver.rs
+++ b/tests/qubo_solver.rs
@@ -1,0 +1,118 @@
+//! T3.3 solver acceptance against the golden corpus (ADR-0038 §Validation, #479).
+//!
+//!   - `ClassicalAnneal` finds the **optimum** on every exact-solvable golden
+//!     file (< 20 vars ⇒ exhaustive, `exact: true`);
+//!   - and ≥ 95% of optimal energy on the larger files (SA with restarts);
+//!   - solutions carry entropy provenance; a fixed seed is reproducible.
+
+use std::path::PathBuf;
+
+use kannaka_memory::entropy::PrngSource;
+use kannaka_memory::qubo::{
+    ClassicalAnneal, ConsolidationProblem, ConsolidationSolver, SolveBudget,
+};
+use serde::Deserialize;
+
+fn dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("qubo")
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestEntry {
+    file: String,
+    num_vars: usize,
+    exact_solvable: bool,
+    optimum_energy: f64,
+    #[allow(dead_code)]
+    optimum_assignment: Vec<bool>,
+    #[allow(dead_code)]
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    files: Vec<ManifestEntry>,
+}
+
+fn load_manifest() -> Manifest {
+    let s = std::fs::read_to_string(dir().join("manifest.json"))
+        .expect("tests/qubo/manifest.json — run `cargo run --example gen_qubo_corpus`");
+    serde_json::from_str(&s).expect("parse manifest.json")
+}
+
+fn load_problem(file: &str) -> ConsolidationProblem {
+    let s = std::fs::read_to_string(dir().join(file)).unwrap_or_else(|_| panic!("read {file}"));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {file}: {e}"))
+}
+
+#[test]
+fn classical_anneal_hits_optimum_on_exact_files() {
+    let solver = ClassicalAnneal::with_seed(0xC0FFEE);
+    for e in load_manifest().files.into_iter().filter(|e| e.exact_solvable) {
+        let p = load_problem(&e.file);
+        let sol = solver.solve(&p, SolveBudget::default()).unwrap();
+        assert!(sol.exact, "{}: <20 vars must solve exactly", e.file);
+        assert!(
+            (sol.energy - e.optimum_energy).abs() < 1e-9,
+            "{}: solver energy {} != optimum {}",
+            e.file,
+            sol.energy,
+            e.optimum_energy
+        );
+        // The returned assignment actually achieves the reported energy.
+        assert!((p.energy(&sol.assignment) - sol.energy).abs() < 1e-9, "{}: energy mismatch", e.file);
+    }
+}
+
+#[test]
+fn classical_anneal_within_95pct_on_large_files() {
+    let solver = ClassicalAnneal::with_seed(0xBEEF);
+    let large: Vec<_> = load_manifest().files.into_iter().filter(|e| !e.exact_solvable).collect();
+    assert!(!large.is_empty(), "corpus should have large files");
+    for e in large {
+        let p = load_problem(&e.file);
+        assert!(e.num_vars >= 20, "{}: large file should be >=20 vars", e.file);
+        let sol = solver.solve(&p, SolveBudget::default()).unwrap();
+        assert!(!sol.exact, "{}: >=20 vars is heuristic", e.file);
+        // Can't do better than the true optimum (known by construction here).
+        assert!(
+            sol.energy >= e.optimum_energy - 1e-9,
+            "{}: energy {} beats documented optimum {} — corpus bug",
+            e.file,
+            sol.energy,
+            e.optimum_energy
+        );
+        // ≥95% of optimal energy. Optima here are negative, so achieving at least
+        // 95% of the magnitude means solved/optimum >= 0.95.
+        let quality = if e.optimum_energy == 0.0 {
+            if sol.energy == 0.0 { 1.0 } else { 0.0 }
+        } else {
+            sol.energy / e.optimum_energy
+        };
+        assert!(
+            quality >= 0.95,
+            "{}: quality {:.4} < 0.95 (solved {}, optimum {})",
+            e.file,
+            quality,
+            sol.energy,
+            e.optimum_energy
+        );
+    }
+}
+
+#[test]
+fn solutions_carry_provenance_and_are_reproducible() {
+    let p = load_problem("12-large-ferromagnet.json");
+
+    // Entropy-seeded solve records the source's provenance.
+    let seeded = ClassicalAnneal::from_entropy(&mut PrngSource::new());
+    let sol = seeded.solve(&p, SolveBudget::default()).unwrap();
+    assert!(sol.provenance.is_prng(), "PRNG-seeded solve carries prng:// provenance");
+    assert_eq!(sol.solver, "ClassicalAnneal");
+
+    // A fixed seed is deterministic across constructions.
+    let a = ClassicalAnneal::with_seed(99).solve(&p, SolveBudget::default()).unwrap();
+    let b = ClassicalAnneal::with_seed(99).solve(&p, SolveBudget::default()).unwrap();
+    assert_eq!(a.assignment, b.assignment);
+    assert_eq!(a.energy, b.energy);
+}


### PR DESCRIPTION
## T3.3 — ConsolidationSolver trait + `ClassicalAnneal` default

Closes #479. Adds the solver seam over the `kannaka-qubo/1` boundary (T3.2, #484)
and the classical default. Depends on #484 (merged).

### Trait (`src/qubo/solver.rs`)
`ConsolidationSolver::solve(&self, problem, budget) -> ConsolidationSolution`
per ADR-0038 §Decision.2, with `SolveBudget { wall_time, max_cost_usd }` and
`ConsolidationSolution { assignment, energy, solver, exact, samples, provenance }`.

`provenance` is an addition over the ADR's struct sketch to satisfy #479's
"provenance recorded in solutions" — it carries the `entropy::Provenance` of the
bits that seeded the solve.

### `ClassicalAnneal`
- **Exhaustive below 20 vars** (`exact: true`) — the global optimum.
- **Otherwise simulated annealing with restarts** (`exact: false`), each restart
  a decorrelated stream; per-restart bests recorded in `samples`.
- **Seeded from `EntropySource` (T1.3).** The 64-bit seed is drawn once at
  construction (so `solve` stays `&self` and reproducible), its `Provenance`
  recorded into every solution — even classical stochasticity carries entropy
  provenance, `reservoir://` once T1.5 lands. `from_entropy` falls back to the
  software PRNG (honest `prng://`) if a reservoir source errors, so a dream
  never fails. RNG is `ChaCha8Rng` (the codebase's deterministic-RNG choice), so
  a fixed seed is byte-reproducible across platforms.

The engine's advisory posture (re-score before apply) is unchanged; the apply
path is T3.5, not here.

### Acceptance (`tests/qubo_solver.rs`, against the T3.2 golden corpus)
- **Optimum on all 10 exact-solvable files** (exhaustive).
- **≥95% of optimal energy on both large files** — in fact 100% (a 24-var
  independent problem and a 20-var ferromagnet, both SA-easy with known optima).
- **Provenance recorded** (PRNG-seeded solve → `prng://`); a fixed seed is
  deterministic across constructions.

Plus solver unit tests (exact optimum, empty problem, 22-var ferromagnet SA →
optimum, determinism, provenance). `cargo test` (lib `qubo::solver` +
`qubo_solver`), `cargo check --all-targets`, `cargo clippy --lib --bin kannaka`
all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
