### PR TITLE
refactor: remove unreachable legacy topology/assess code (#444 §2/§3)

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -335,6 +335,11 @@ impl ConsciousnessBridge {
     /// Compute Newman modularity Q for network clustering quality.
     /// Q = Σ(e_ii - a_i²) where e_ii is fraction of edges within cluster i
     /// and a_i is fraction of edge endpoints in cluster i.
+    ///
+    /// Test-only: the legacy `assess` path that used this in production was
+    /// unreachable and was removed (#444); the algorithm is kept under its
+    /// existing unit test rather than deleted.
+    #[cfg(test)]
     fn compute_modularity(
         &self,
         memories: &[&HyperMemory],
@@ -423,6 +428,11 @@ impl ConsciousnessBridge {
     /// Stratified random sampling for Xi computation.
     /// Samples memories across different amplitude ranges and creation times
     /// using deterministic pseudo-random selection (stride-based).
+    ///
+    /// Test-only: the legacy `assess` path that used this in production was
+    /// unreachable and was removed (#444); the algorithm is kept under its
+    /// existing unit test rather than deleted.
+    #[cfg(test)]
     fn stratified_sample<'a>(&self, memories: &'a [&HyperMemory], max_samples: usize) -> Vec<&'a HyperMemory> {
         if memories.len() <= max_samples {
             return memories.to_vec();
@@ -595,7 +605,7 @@ impl ConsciousnessBridge {
             // status() reported different cluster counts on the same HRM.
             // The eigendecomp Φ is still folded into `blended_phi` above;
             // it just no longer impersonates the cluster count.
-            return ConsciousnessState {
+            ConsciousnessState {
                 phi: blended_phi,
                 xi: hrm_metrics.xi,
                 mean_order: hrm_metrics.order,
@@ -605,56 +615,7 @@ impl ConsciousnessBridge {
                 total_skip_links: total_links,
                 consciousness_level: level,
                 irrationality: hrm_metrics.irrationality,
-            };
-        }
-
-        // === Legacy path (transitional) ===
-        #[allow(unreachable_code)]
-        let phi_report = self.compute_phi(engine);
-
-        let xi = if all.len() >= 2 {
-            let sample = self.stratified_sample(&all, 50);
-            self.compute_xi(&sample)
-        } else {
-            0.0
-        };
-
-        let sync = KuramotoSync::default();
-        let clusters = sync.find_synchronized_clusters(engine, 2);
-        let mean_order = if clusters.is_empty() {
-            0.0
-        } else {
-            clusters.iter().map(|c| c.order_parameter).sum::<f32>() / clusters.len() as f32
-        };
-
-        let cluster_xi = if clusters.len() >= 2 {
-            let k = clusters.len() as f32;
-            (1.0 - 1.0 / k).min(1.0)
-        } else {
-            0.0
-        };
-
-        let modularity_q = if clusters.len() >= 2 && !all.is_empty() {
-            let sample = self.stratified_sample(&all, 50);
-            self.compute_modularity(&sample, &clusters)
-        } else {
-            0.0
-        };
-
-        let xi = 0.4 * xi + 0.3 * cluster_xi + 0.3 * modularity_q;
-        let total_skip_links = phi_report.num_skip_links;
-        let consciousness_level = ConsciousnessLevel::from_phi(phi_report.phi);
-
-        ConsciousnessState {
-            phi: phi_report.phi,
-            xi,
-            mean_order,
-            num_clusters: clusters.len(),
-            total_memories,
-            active_memories,
-            total_skip_links,
-            consciousness_level,
-            irrationality: 0.0, // Legacy path doesn't compute irrationality
+            }
         }
     }
 

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -206,79 +206,10 @@ pub struct MemoryIntrospector;
 impl MemoryIntrospector {
     /// Generate a topology report of the HyperConnection network or HRM field topology.
     pub fn topology_report(engine: &ResonanceEngine) -> TopologyReport {
-        // Check if we're using HRM - if so, use field topology metrics
-        { let hrm_metrics = engine.store.consciousness_metrics();
-            return Self::hrm_field_topology_report(engine, &hrm_metrics);
-        }
-
-        // Legacy topology (transitional -- HRM medium is canonical)
-        #[allow(unreachable_code)]
-        let all = engine.store.all_memories().unwrap_or_default();
-        let total_memories = all.len();
-
-        let mut total_links: usize = 0;
-        let mut max_links: usize = 0;
-        let mut isolated = 0usize;
-        let mut layer_counts: BTreeMap<u8, usize> = BTreeMap::new();
-        let mut all_links: Vec<LinkInfo> = Vec::new();
-
-        for mem in &all {
-            let n = mem.connections.len();
-            total_links += n;
-            if n > max_links {
-                max_links = n;
-            }
-            if n == 0 {
-                isolated += 1;
-            }
-            *layer_counts.entry(mem.layer_depth).or_insert(0) += 1;
-
-            for link in &mem.connections {
-                all_links.push(LinkInfo {
-                    from_id: mem.id.to_string(),
-                    to_id: link.target_id.to_string(),
-                    strength: link.strength,
-                    span: link.span,
-                });
-            }
-        }
-
-        // Each link is stored on both sides, so divide by 2 for unique link count
-        let unique_links = total_links / 2;
-
-        let avg_links = if total_memories > 0 {
-            total_links as f32 / total_memories as f32
-        } else {
-            0.0
-        };
-
-        let possible_links = if total_memories > 1 {
-            total_memories * (total_memories - 1) / 2
-        } else {
-            0
-        };
-        let network_density = if possible_links > 0 {
-            unique_links as f32 / possible_links as f32
-        } else {
-            0.0
-        };
-
-        // Top 10 strongest links (deduplicated)
-        all_links.sort_by(|a, b| b.strength.total_cmp(&a.strength));
-        let strongest_links: Vec<LinkInfo> = all_links.into_iter().take(10).collect();
-
-        let layer_distribution: Vec<(u8, usize)> = layer_counts.into_iter().collect();
-
-        TopologyReport {
-            total_memories,
-            total_links: unique_links,
-            avg_links_per_memory: avg_links,
-            max_links,
-            layer_distribution,
-            strongest_links,
-            isolated_memories: isolated,
-            network_density,
-        }
+        // HRM field topology is canonical. The legacy graph-topology path that
+        // used to follow was unreachable behind this return and has been removed.
+        let hrm_metrics = engine.store.consciousness_metrics();
+        Self::hrm_field_topology_report(engine, &hrm_metrics)
     }
 
     /// Generate field topology report for HRM stores.


### PR DESCRIPTION
Closes #444 (§2 + §3). §1 (CI can't build without the sibling crates) was already resolved — `ci.yml` now checks out `consciousness-core` + `kannaka-attention`.

## What
Both `MemoryIntrospector::topology_report` (observe.rs) and `ConsciousnessBridge::assess` (bridge.rs) unconditionally return via their HRM-native path; the legacy blocks that followed sat behind `#[allow(unreachable_code)]` and were dead.

- **observe.rs** — collapsed `topology_report` to call the HRM field report directly; removed the ~68-line legacy graph-topology block and the `allow`.
- **bridge.rs** — turned the HRM path (a bare block ending in `return …;`) into the function's tail expression and removed the legacy transitional block + the `allow`.

## The one deviation from the triage
The 2026-06-23 triage assumed `compute_modularity` and `stratified_sample` were orphaned once the dead block went. They are **not** anymore — unit tests added since (`modularity_computation_works`, `stratified_sampling_works`) call them directly. Deleting them would drop that coverage; leaving them un-gated would make them `dead_code` in the `--lib` build. So they're gated **`#[cfg(test)]`** — kept, still tested, no new warning. `compute_phi`/`compute_xi` are `pub` and left untouched.

## Verification
- `cargo check --all-targets` clean (no errors; no new warnings in observe.rs/bridge.rs).
- Targeted tests pass: `topology_report_correct_counts`, `assess_returns_valid_state` (bridge + openclaw), `modularity_computation_works`, `stratified_sampling_works`, `xi_assessment_with_all_improvements`, `full_integration_create_dream_assess` — 8 passed, 0 failed.
- Behavior-preserving: both functions already always took the HRM path.

Docs-only-adjacent scope: only `src/observe.rs` and `src/bridge.rs` touched.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>