### PR TITLE
feat(lab): register lab_qos_swarm_bridge agent tool

### DIFF
--- a/src/bin/handlers/agent.rs
+++ b/src/bin/handlers/agent.rs
@@ -782,7 +782,7 @@ mod tests {
     #[test]
     fn phase5_lab_tools_land_in_the_free_mutation_tier() {
         let empty = std::collections::HashSet::new();
-        for name in ["lab_exec", "lab_qos_boot", "lab_watch", "lab_qos_watch"] {
+        for name in ["lab_exec", "lab_qos_boot", "lab_watch", "lab_qos_watch", "lab_qos_swarm_bridge"] {
             assert!(
                 lab_tools::is_lab_tool(name),
                 "{name} must route to dispatch_lab_tool"

--- a/src/lab_tools.rs
+++ b/src/lab_tools.rs
@@ -59,6 +59,7 @@ pub fn is_lab_tool(name: &str) -> bool {
             | "lab_qos_boot"
             | "lab_watch"
             | "lab_qos_watch"
+            | "lab_qos_swarm_bridge"
     )
 }
 
@@ -456,6 +457,27 @@ pub fn lab_tools() -> Vec<Tool> {
                 "required": ["ssh_alias"]
             }),
         },
+        Tool {
+            name: "lab_qos_swarm_bridge",
+            description: "Join a booted QuantumOS instance to the NATS swarm under its OWN Lamport-signed \
+                          boot identity. QuantumOS's ring-3 swarm service emits a signed attestation on COM2 \
+                          as it boots; this tails that COM2 log (from lab_qos_boot's com2_log), verifies the \
+                          attestation, and ONLY if it verifies joins the swarm as qos-<qseed> — refusing to \
+                          join on a bad attestation, so peer-presence is backed by a genuine signed boot. \
+                          Runs locally on the user's desktop against the local kannaka + ~/.kannaka-nats.env. \
+                          Returns the joined agent-id and a background join_pid holding presence; confirm with \
+                          `kannaka swarm peers`. Graphical flow only (needs COM2, which the graphical boot wires).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ssh_alias": { "type": "string", "description": "From lab_ssh_configure." },
+                    "session": { "type": "string", "default": "qos", "description": "Boot session id (from lab_qos_boot) — selects the COM2 log." },
+                    "qseed": { "type": "string", "description": "The qseed hex from lab_qos_boot's return; cross-checked against the attestation and used to derive the agent-id. Omit to skip the cross-check and derive the id from the attestation." },
+                    "agent_id": { "type": "string", "description": "Override the derived qos-<qseed> agent-id." }
+                },
+                "required": ["ssh_alias"]
+            }),
+        },
     ]
 }
 
@@ -754,6 +776,18 @@ pub fn dispatch_lab_tool(name: &str, input: &Value) -> (String, bool) {
             push_str_opt(&mut args, "--session", input, "session");
             push_int(&mut args, "--web-port", input, "web_port");
             push_int(&mut args, "--monitor-port", input, "monitor_port");
+        }
+        "lab_qos_swarm_bridge" => {
+            let alias = match req_str(input, "ssh_alias") {
+                Ok(s) => s,
+                Err(e) => return (e, true),
+            };
+            args.push("lab-qos-swarm-bridge".into());
+            args.push("--ssh-alias".into());
+            args.push(alias);
+            push_str_opt(&mut args, "--session", input, "session");
+            push_str_opt(&mut args, "--qseed", input, "qseed");
+            push_str_opt(&mut args, "--agent-id", input, "agent_id");
         }
         // Local, not a bridge call: opens a window on the user's own desktop.
         "lab_watch" => {


### PR DESCRIPTION
Third and final piece of the QuantumOS swarm-embassy flow (Option B). The `/qos --graphical` prompt (kannaka-tui #23) names `lab_qos_swarm_bridge` and the kannaka-quantum CLI (#29) provides `lab-qos-swarm-bridge`, but this registry didn't know the tool name — so the agent had nothing to dispatch at step 5.

Registers it as a **free-mutation-tier local tool** (not paid, not auto-allowed read-only, asked by default / allowed in yolo / refused in plan), mirroring `lab_qos_watch`: schema + a dispatch arm that shells to the `lab-qos-swarm-bridge` CLI subcommand with `--ssh-alias/--session/--qseed/--agent-id`, and pins it in the phase5 tier test.

Compiles clean; `phase5_lab_tools_land_in_the_free_mutation_tier` passes with the new tool in the array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)