### PR TITLE
research(L5): warmup-cycles ruled out analytically — no new axes 2026-07-04T14

### DIFF
--- a/experiments/notes/2026-07-04T14-no-new-axes.md
+++ b/experiments/notes/2026-07-04T14-no-new-axes.md
@@ -1,0 +1,53 @@
+# 2026-07-04T14 — No new axes: warmup-cycles option ruled out analytically
+
+## Orientation summary
+
+- git log confirms latest commits are lab/QUBO features (T1.3, T1.4, T3.2, T3.3), not L5 physics
+- TSV tail: best fitness 0.056631, 3-run avg 0.056686 (irx + DREAM_GRAVITY=0.25)
+- All 6 research questions confirmed answered (2026-06-28 notes)
+- Three subsequent fires (2026-06-29, -30, 2026-07-01) all confirmed structural floor
+
+## One new analysis: warmup-cycles (option 3 from 2026-07-01 notes)
+
+The 2026-07-01 notes flagged "warmup cycles before measurement" as the most tractable
+remaining structural option. This fire evaluates it analytically before burning a trial slot.
+
+**Mechanism**: skip the first M=1 cycles of engine_flat (the spike), measure cycles 1–4.
+Produces amp_deltas[1:] ≈ [0.183, 0.003, 0.010, ε] (from observed [4.169, 0.183, 0.003, 0.010]).
+
+DFT of [0.183, 0.003, 0.010, ε≈0.002] — 4-point formula X[k]:
+- |X[1]|² = (x0-x2)² + (x3-x1)² = (0.183−0.010)² + (0.002−0.003)² = 0.173² + 0.001² ≈ 0.02993
+- |X[2]|² = (x0−x1+x2−x3)² = (0.183−0.003+0.010−0.002)² = 0.188² ≈ 0.03534
+
+carrier = max(0.02993, 0.03534) / (0.02993 + 0.03534) = 0.03534 / 0.06527 ≈ 0.541
+
+**Predicted improvement**: 0.541 − 0.527 = 0.014 in carrier_emergence
+**Fitness delta**: 0.10 × 0.014 = 0.0014 — well below 0.005 threshold.
+
+The warmup shifts the dominant DFT bin from k=1 (2 Hz) to k=2 (4 Hz) — both in-band —
+but the total power split stays near 50/50 because x[0]=0.183 is still 18× the equilibrium
+values. The regime is "spike at index 0 → equal bin power," same structural issue, just
+at 1/23 of the original spike amplitude.
+
+**Decision: skip this trial.** Analytic bound rules it out without running cargo.
+
+## Why no other hypotheses exist
+
+The env-var space is fully mapped:
+- DRIVE_A, DRIVE_FREQ_HZ, DRIVE_SCOPE, DRIVE_TOP_FRAC: exhausted
+- DREAM_MODE (unset vs interference_relax): irx is optimal
+- DREAM_GRAVITY: 0.25 is Pareto optimum (transfer V-shape confirmed at 0.20/0.25)
+- KURAMOTO_COUPLING: irrelevant under irx (stage_sync bypassed)
+
+Carrier floor (0.527) is structural: cycle-0 consolidation spike is ~23× equilibrium.
+Transfer floor (0.9652): mathematical, chiral_perturbation=0.15 is load-bearing.
+Xi floor (0.9796): max possible gain 0.003, below 0.005 threshold.
+
+## Current empirical optimum (unchanged)
+
+```
+DRIVE_A=0.1 DRIVE_SCOPE=all DRIVE_TOP_FRAC=1.0 DREAM_MODE=interference_relax DREAM_GRAVITY=0.25
+```
+3-run avg fitness: **0.056686** (carrier_e=0.5265, transfer=0.9652, xi=0.9796, R=0.867, query_gravity=0.862)
+
+## No code changes. No new TSV rows.


### PR DESCRIPTION
## Summary

L5 autoresearch fire 2026-07-04T14. No trials run; no code changed.

**Hypothesis evaluated this fire**: warmup-cycles approach (flagged in 2026-07-01 notes as the last remaining structural option for carrier_emergence improvement).

**Analytic result**: skipping the cycle-0 spike and measuring cycles 1–4 gives predicted carrier_emergence ≈ 0.541 vs current 0.527, a fitness delta of ~0.0014 — below the 0.005 improvement threshold. The dominant DFT bin shifts from k=1 (2 Hz) to k=2 (4 Hz), but the power split stays near 50/50 because cycle-1 delta (0.183) is still ~18× equilibrium values. Same structural regime, smaller spike.

**Decision**: no trial needed. Analytic bound rules it out.

## State of L5

- Current optimum: `DRIVE_A=0.1 DRIVE_SCOPE=all DRIVE_TOP_FRAC=1.0 DREAM_MODE=interference_relax DREAM_GRAVITY=0.25`
- 3-run avg fitness: **0.056686**
- All 6 research questions answered; structural floors confirmed across 4 consecutive fires since 2026-06-28

## Files changed

- `experiments/notes/2026-07-04T14-no-new-axes.md` — notes only, no code, no TSV rows

---
_Generated by [Claude Code](https://claude.ai/code/session_019hwZHwkcB5pxE2Gm2ArW9J)_