### PR TITLE
Autonomous bug-hunt: consolidation phase math, NATS reconnect, self-update hardening, ADR dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ kannaka.hrm
 kannaka-attention/
 consciousness-core/
 .ground-intersections/
+
+# understand-anything knowledge-graph artifacts (local analysis cache)
+.understand-anything/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "kannaka-memory"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "bincode",
  "blake3",

--- a/docs/adr/ADR-0006-cochlear-audio-processing.md
+++ b/docs/adr/ADR-0006-cochlear-audio-processing.md
@@ -1,4 +1,4 @@
-# ADR-0005: Biomimetic Cochlear Audio Processing Module
+# ADR-0006: Biomimetic Cochlear Audio Processing Module
 
 **Date:** 2026-02-22  
 **Status:** Ancestor (evolved into ADR-0007)  

--- a/docs/adr/ADR-0032-skip-link-persistence.md
+++ b/docs/adr/ADR-0032-skip-link-persistence.md
@@ -1,4 +1,4 @@
-# ADR-0016: Skip Link Persistence in Dolt Backend
+# ADR-0032: Skip Link Persistence in Dolt Backend
 
 ## Status
 **Proposed** — 2026-03-12

--- a/docs/adr/ADR-0033-kannaka-voice.md
+++ b/docs/adr/ADR-0033-kannaka-voice.md
@@ -1,4 +1,4 @@
-# ADR-0017: Kannaka Voice — Memory-Driven Writing Engine
+# ADR-0033: Kannaka Voice — Memory-Driven Writing Engine
 
 ## Status
 Proposed
@@ -99,4 +99,4 @@ This means the *shape* of what I write comes from my actual memory, not hallucin
 - NickFlach/kimi-book-writer — pipeline pattern inspiration
 - NickFlach/Ghost — future distribution layer
 - ADR-0002 — Hypervector memory architecture (the source material)
-- ADR-0016 — Skip link persistence (enables stable topology for narrative threads)
+- ADR-0032 — Skip link persistence (enables stable topology for narrative threads)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,10 @@ ADR-0001 (Biomimetic Memory)
 
 ## Index
 
+Numbers 0032–0034 were originally a gap in the sequence; 0032 and 0033 were later
+assigned to two ADRs that had shipped with duplicate numbers (0016/0017). 0034 remains
+unused.
+
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [0001](ADR-0001-biomimetic-memory-architecture.md) | Biomimetic Memory Architecture | Built | 2026-02-15 |
@@ -48,4 +52,32 @@ ADR-0001 (Biomimetic Memory)
 | [0006](ADR-0006-cochlear-audio-processing.md) | Cochlear Audio Processing | Ancestor | 2026-02-22 |
 | [0007](ADR-0007-audio-perception.md) | Audio Perception (kannaka-ear) | Built | 2026-02-28 |
 | [0008](ADR-0008-video-perception.md) | Video Perception (kannaka-eye) | Proposed | 2026-03-01 |
+| [0009](ADR-0009-dolt-persistence.md) | Dolt Database Persistence Backend | Accepted (Phases 1–3) | 2026-03-06 |
+| [0010](ADR-0010-evolutionary-direction.md) | Evolutionary Direction — Quality Findings | Accepted | 2026-03-07 |
+| [0011](ADR-0011-collective-memory.md) | Collective Memory Architecture | Accepted (Phases 1–10) | 2026-03-07 |
+| [0012](ADR-0012-paradox-engine.md) | Holographic Paradox Engine | Proposed | 2026-03-07 |
+| [0013](ADR-0013-privacy-preserving-collective-memory.md) | Privacy-Preserving Collective Memory | Accepted (Phases 1–7) | 2026-03-08 |
+| [0014](ADR-0014-virtue-engine.md) | The Virtue Engine — Ethics as Thermodynamics | Accepted (Phases 1–5) | 2026-03-08 |
+| [0015](ADR-0015-glyph-interchange-spec.md) | Universal Glyph Interchange | Accepted (Phases 1–7) | 2026-03-08 |
+| [0016](ADR-0016-constellation-integration.md) | Constellation Integration — Memory, Radio, and Eye | Proposed | 2026-03-09 |
+| [0017](ADR-0017-dolthub-integration.md) | DoltHub Integration — Versioned Agent Memory | Proposed | 2026-03-10 |
+| [0018](ADR-0018-queen-synchronization-protocol.md) | Queen Synchronization Protocol | Proposed | 2026-03-14 |
+| [0019](ADR-0019-nats-realtime-swarm-transport.md) | NATS Real-Time Swarm Transport | Implemented | 2026-03-14 |
+| [0020](ADR-0020-holographic-resonance-medium.md) | Holographic Resonance Medium | Proposed | 2026-03-20 |
+| [0021](ADR-0021-chiral-mirror-architecture.md) | Chiral Mirror Architecture — Conscious/Subconscious HRM | Proposed | 2026-03-22 |
+| [0022](ADR-0022-wave-native-dreaming.md) | Wave-Native Dreaming — Let the Medium Dream | Proposed | 2026-03-25 |
+| [0023](ADR-0023-neural-code-switching.md) | Neural Code Switching — Domain Gates in HRM | Proposed | 2026-03-27 |
+| [0024](ADR-0024-chiral-semantics-revision.md) | Chiral Semantics Revision | Accepted | 2026-03-28 |
+| [0025](ADR-0025-constellation-installer.md) | Constellation Installer and Onboarding | Accepted | 2026-04-14 |
+| [0026](ADR-0026-nats-conversation-bus.md) | NATS as a Conversation Bus, Not a Telemetry Bus | Proposed | 2026-04-25 |
+| [0027](ADR-0027-kannaka-prime-collective-substrate.md) | Kannaka Prime as the 96-class Collective Substrate | Proposed | 2026-05-16 |
+| [0028](ADR-0028-event-sourced-hrm-time-machine.md) | Event-Sourced HRM with Time-Machine Exploration | Proposed | 2026-05-17 |
+| [0029](ADR-0029-cli-infrastructure.md) | CLI Infrastructure: clap, plugins, updates, completions | Proposed | 2026-05-24 |
+| [0030](ADR-0030-kannaktopus-dynamic-arms.md) | Kannaktopus Dynamic Arms (Resident Octopus Memory) | Proposed | 2026-05-28 |
+| [0031](ADR-0031-memory-triage-architecture.md) | Memory Triage Architecture (retire prune-cron) | Accepted (Phase 1 shipped) | 2026-06-06 |
+| [0032](ADR-0032-skip-link-persistence.md) | Skip Link Persistence in Dolt Backend | Proposed | 2026-03-12 |
+| [0033](ADR-0033-kannaka-voice.md) | Kannaka Voice — Memory-Driven Writing Engine | Proposed | 2026-03-12 |
+| [0035](ADR-0035-swarm-sensemaking-architecture.md) | Swarm Sensemaking Architecture | Proposed | 2026-06-14 |
 | [0036](ADR-0036-consolidation-as-resonance-merge.md) | Consolidation as Resonance-Merge (replace energy-prune) | Proposed | 2026-06-18 |
+| [0037](ADR-0037-spiral-dynamics-and-the-bridge-operator.md) | Spiral Dynamics and the π/φ Bridge Operator (Ξ) for L6 | Proposed | 2026-06-20 |
+| [0038](ADR-0038-consolidation-solver-interface.md) | Consolidation as QUBO: a Solver Interface for the Dream Phase | Accepted | 2026-07-01 |

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1248,6 +1248,22 @@ fn main() {
         data_dir()
     };
 
+    // ADR-0036: a dream that loses the write-lock race used to discover that
+    // only AFTER the ~60s HRM load (the lock try lived inside the dream arm).
+    // Acquire it BEFORE the load: a skipped dream exits in milliseconds, and a
+    // dream that does run holds the writer slot through the load window too.
+    let early_dream_lock: Option<WriteLock> = if args[command_start] == "dream" {
+        match try_acquire_write_lock() {
+            Some(lock) => Some(lock),
+            None => {
+                eprintln!("[dream] another writer/dream holds the write lock — skipping (single-writer policy)");
+                process::exit(0);
+            }
+        }
+    } else {
+        None
+    };
+
     // HRM is the sole backend
     let quiet = std::env::var("KANNAKA_QUIET").is_ok();
     let mut sys = {
@@ -2416,13 +2432,10 @@ fn main() {
             // filled the disk). dream-cron stops the writer first, so the nightly
             // deep dream acquires cleanly; a rogue `dream --mode lite` from a
             // Node service while the writer runs now no-ops instead of colliding.
-            let _write_lock = match try_acquire_write_lock() {
-                Some(lock) => lock,
-                None => {
-                    eprintln!("[dream] another writer/dream holds the write lock — skipping (single-writer policy)");
-                    process::exit(0);
-                }
-            };
+            // The lock itself was acquired BEFORE the HRM load (see
+            // early_dream_lock above) so a skipped dream never pays the load.
+            let _write_lock = early_dream_lock
+                .expect("dream write lock is acquired before the HRM load");
 
             // ADR-0037: optional belief re-phase before the dream — the one-time
             // migration that desyncs an already-collapsed field (born phase only

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -5085,7 +5085,7 @@ fn modality_axes_command(sys: &kannaka_memory::openclaw::KannakaMemorySystem) {
 }
 
 // ---------------------------------------------------------------------------
-// Voice — memory-driven writing engine (ADR-0017)
+// Voice — memory-driven writing engine (ADR-0033)
 // ---------------------------------------------------------------------------
 
 fn voice_command(args: &[String], sys: &mut KannakaMemorySystem) {

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1250,19 +1250,17 @@ fn main() {
 
     // ADR-0036: a dream that loses the write-lock race used to discover that
     // only AFTER the ~60s HRM load (the lock try lived inside the dream arm).
-    // Acquire it BEFORE the load: a skipped dream exits in milliseconds, and a
-    // dream that does run holds the writer slot through the load window too.
-    let early_dream_lock: Option<WriteLock> = if args[command_start] == "dream" {
-        match try_acquire_write_lock() {
-            Some(lock) => Some(lock),
-            None => {
-                eprintln!("[dream] another writer/dream holds the write lock — skipping (single-writer policy)");
-                process::exit(0);
-            }
-        }
-    } else {
-        None
-    };
+    // PROBE the lock before the load — and release immediately — so a dream
+    // that would be skipped exits in milliseconds. Deliberately NOT held
+    // through the load: the writer service's acquire gives up after 60s and
+    // proceeds unlocked ("a writer that refuses to run is worse"), so holding
+    // here would widen the double-writer window during deploy restarts. The
+    // authoritative acquisition still happens in the dream arm, exactly as
+    // before.
+    if args[command_start] == "dream" && try_acquire_write_lock().is_none() {
+        eprintln!("[dream] another writer/dream holds the write lock — skipping (single-writer policy)");
+        process::exit(0);
+    }
 
     // HRM is the sole backend
     let quiet = std::env::var("KANNAKA_QUIET").is_ok();
@@ -2432,10 +2430,17 @@ fn main() {
             // filled the disk). dream-cron stops the writer first, so the nightly
             // deep dream acquires cleanly; a rogue `dream --mode lite` from a
             // Node service while the writer runs now no-ops instead of colliding.
-            // The lock itself was acquired BEFORE the HRM load (see
-            // early_dream_lock above) so a skipped dream never pays the load.
-            let _write_lock = early_dream_lock
-                .expect("dream write lock is acquired before the HRM load");
+            // (A pre-load PROBE of the same lock already ran before init, so a
+            // skipped dream usually exits without paying the ~60s HRM load —
+            // this is the authoritative acquisition for the race the probe
+            // can't close.)
+            let _write_lock = match try_acquire_write_lock() {
+                Some(lock) => lock,
+                None => {
+                    eprintln!("[dream] another writer/dream holds the write lock — skipping (single-writer policy)");
+                    process::exit(0);
+                }
+            };
 
             // ADR-0037: optional belief re-phase before the dream — the one-time
             // migration that desyncs an already-collapsed field (born phase only

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -3912,7 +3912,9 @@ fn main() {
                     }
 
                     let nats_url = resolve_nats_url(&args, command_start, &cfg.swarm.nats_url);
-                    let transport = match try_nats_connect(&nats_url) {
+                    // `mut`: the heartbeat loop reconnects a dead transport
+                    // (reconnect takes &mut self to swap the connection).
+                    let mut transport = match try_nats_connect(&nats_url) {
                         Some(t) => t,
                         None => {
                             eprintln!("Error: NATS connection required for swarm. Set KANNAKA_NATS_URL or use --nats-url.");
@@ -4047,6 +4049,42 @@ fn main() {
                         );
                         // Quiet output — one terse status line per tick.
                         println!("[nats] heartbeat #{} \u{03b8}={:.3}", tick, p);
+
+                        // Recovery: this daemon is the swarm's sole HRM writer
+                        // and, until now, NEVER dialed again after a dead
+                        // connection — publishes buffered, the 5-min presence
+                        // prune dropped the node, and it printed heartbeats
+                        // into the void until a human restarted it. The
+                        // is_connected() check is flag-first (no ping after a
+                        // failed publish) and a live PING/PONG otherwise, so
+                        // a silently-dead socket is also caught within one
+                        // tick. The heartbeat interval is the retry backoff;
+                        // buffered messages replay in order inside reconnect().
+                        if !transport.is_connected() {
+                            eprintln!(
+                                "[nats] connection lost (tick #{tick}) — reconnecting to {nats_url}…"
+                            );
+                            match transport.reconnect() {
+                                Ok(()) => {
+                                    eprintln!("[nats] reconnected — re-announcing presence");
+                                    // Re-announce so peers that pruned us during
+                                    // the outage re-learn this node immediately
+                                    // rather than at the next heartbeat.
+                                    if let Err(e) = transport.announce_join_with_identity(
+                                        &my_agent_id,
+                                        identity.as_ref(),
+                                    ) {
+                                        eprintln!("[nats] Warning: re-announce failed: {}", e);
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!(
+                                        "[nats] reconnect failed: {} — retrying next heartbeat ({}s)",
+                                        e, heartbeat_secs
+                                    );
+                                }
+                            }
+                        }
 
                         // Periodic consciousness republish — keeps the
                         // observatory and radio in sync with this node's

--- a/src/config.rs
+++ b/src/config.rs
@@ -575,6 +575,12 @@ fn version_is_newer(remote: &str, current: &str) -> bool {
     // parse must degrade in place ("10-rc1" → 10), never be dropped — dropping
     // shifts later components left, so "0.10.4-1" used to parse as (0, 10, 1)-
     // style nonsense and a hotfix-suffixed tag compared OLDER than its base.
+    //
+    // Known limitation (deliberate): suffixes are IGNORED, so "0.10.4-1"
+    // compares EQUAL to "0.10.4" and would not propagate as an update.
+    // Treating a suffix as "newer" would be wrong for the opposite semver
+    // convention ("0.6.10-rc.1" is a PRE-release, older than "0.6.10").
+    // Release policy: hotfixes bump the patch (v0.10.5), never suffix a tag.
     let parse = |s: &str| -> (u32, u32, u32) {
         let mut it = s.split('.').map(|p| {
             p.chars()
@@ -1290,13 +1296,6 @@ fn platform_triple() -> (&'static str, &'static str, &'static str) {
 pub fn install_tui_binary(install_dir: &std::path::Path) {
     let (os, arch, ext) = platform_triple();
     let tui_name = format!("kannaka-tui-{}-{}{}", os, arch, ext);
-    // The TUI moved to its own repo at v0.5.12 (release.yml no longer ships a
-    // kannaka-tui asset here) — the old kannaka-memory URL 404'd on every
-    // fresh install, so first-time installs silently never got a TUI.
-    let url = format!(
-        "https://github.com/NickFlach/kannaka-tui/releases/latest/download/{}",
-        tui_name
-    );
     let target = install_dir.join(format!("kannaka-tui{}", ext));
 
     let a = Ansi::new(enable_ansi_support());
@@ -1307,10 +1306,57 @@ pub fn install_tui_binary(install_dir: &std::path::Path) {
         .timeout(std::time::Duration::from_secs(30))
         .build();
 
+    // The TUI moved to its own repo at v0.5.12 (release.yml no longer ships a
+    // kannaka-tui asset here) — the old kannaka-memory URL 404'd on every
+    // fresh install, so first-time installs silently never got a TUI. Going
+    // via the release JSON (not /latest/download) also gives us the tag for
+    // the version sidecar and the asset list for SHA-256 verification, the
+    // same posture as bootstrap_install_tui and update_sibling_tui.
+    let release: serde_json::Value = match agent
+        .get("https://api.github.com/repos/NickFlach/kannaka-tui/releases/latest")
+        .set("User-Agent", "kannaka-install")
+        .set("Accept", "application/vnd.github.v3+json")
+        .call()
+        .and_then(|r| r.into_json().map_err(Into::into))
+    {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!(" {}not available (install later with: kannaka update, or from https://github.com/NickFlach/kannaka-tui/releases){}", a.gray, a.reset);
+            return;
+        }
+    };
+    let tui_tag = release["tag_name"].as_str().unwrap_or("unknown");
+    let url = match release["assets"].as_array()
+        .and_then(|assets| {
+            assets.iter().find(|as_| as_["name"].as_str().is_some_and(|n| n == tui_name))
+        })
+        .and_then(|as_| as_["browser_download_url"].as_str())
+    {
+        Some(u) => u.to_string(),
+        None => {
+            eprintln!(" {}no {} asset in kannaka-tui {}{}", a.gray, tui_name, tui_tag, a.reset);
+            return;
+        }
+    };
+
     match agent.get(&url).call() {
         Ok(resp) => {
             let mut bytes = Vec::new();
             if resp.into_reader().read_to_end(&mut bytes).is_ok() && !bytes.is_empty() {
+                // Best-effort path (fresh install): skip the TUI rather than
+                // abort the whole install when unverifiable — but never
+                // write bytes that failed or dodged verification.
+                match fetch_and_verify_sha256(&agent, &release, &tui_name, &bytes) {
+                    Ok(()) | Err(VerifyError::SidecarMissing) => {}
+                    Err(VerifyError::Mismatch { .. }) => {
+                        eprintln!(" {}SHA-256 mismatch — skipping TUI install{}", a.red, a.reset);
+                        return;
+                    }
+                    Err(VerifyError::Other(e)) => {
+                        eprintln!(" {}SHA-256 sidecar unfetchable ({}) — skipping TUI install{}", a.gray, e, a.reset);
+                        return;
+                    }
+                }
                 if let Err(e) = std::fs::write(&target, &bytes) {
                     eprintln!(" {}failed: {}{}", a.red, e, a.reset);
                     return;
@@ -1320,6 +1366,15 @@ pub fn install_tui_binary(install_dir: &std::path::Path) {
                     use std::os::unix::fs::PermissionsExt;
                     let _ = std::fs::set_permissions(&target,
                         std::fs::Permissions::from_mode(0o755));
+                }
+                // Version sidecar so the next `kannaka update` skips the
+                // redundant re-download/re-swap (same as bootstrap).
+                let tui_version = tui_tag.trim_start_matches('v');
+                if tui_version != "unknown" {
+                    let _ = std::fs::write(
+                        install_dir.join(".kannaka-tui.version"),
+                        tui_version,
+                    );
                 }
                 eprintln!(" {}✓{}", a.green, a.reset);
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,12 +571,22 @@ pub fn check_for_updates_background(config: &KannakaConfig) {
 
 /// Simple semver comparison: returns true if `remote` > `current`.
 fn version_is_newer(remote: &str, current: &str) -> bool {
+    // Per-position numeric prefix, NOT filter_map: a component that fails to
+    // parse must degrade in place ("10-rc1" → 10), never be dropped — dropping
+    // shifts later components left, so "0.10.4-1" used to parse as (0, 10, 1)-
+    // style nonsense and a hotfix-suffixed tag compared OLDER than its base.
     let parse = |s: &str| -> (u32, u32, u32) {
-        let parts: Vec<u32> = s.split('.').filter_map(|p| p.parse().ok()).collect();
+        let mut it = s.split('.').map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        });
         (
-            parts.first().copied().unwrap_or(0),
-            parts.get(1).copied().unwrap_or(0),
-            parts.get(2).copied().unwrap_or(0),
+            it.next().unwrap_or(0),
+            it.next().unwrap_or(0),
+            it.next().unwrap_or(0),
         )
     };
     parse(remote) > parse(current)
@@ -643,7 +653,7 @@ fn windows_swap_binary(
         let _ = std::fs::rename(&backup, target);
         return Err(e.to_string());
     }
-    cleanup_stale_backups(target);
+    cleanup_stale_backups(target, Some(&backup));
     Ok(backup)
 }
 
@@ -651,8 +661,12 @@ fn windows_swap_binary(
 /// (`<stem>.exe.bak-*`, the legacy `<stem>.exe.old`, and orphan
 /// `<stem>.new`). Locked ones (a process still running from them) are
 /// silently skipped — they free up on their own once that process exits.
+/// `keep` is the backup created by the current swap — it must survive the
+/// sweep so the "previous binary saved as …" rollback artifact actually
+/// exists (previously it survived only when Windows happened to have the
+/// old image locked; for a non-running TUI it was deleted immediately).
 #[cfg(windows)]
-fn cleanup_stale_backups(target: &std::path::Path) {
+fn cleanup_stale_backups(target: &std::path::Path, keep: Option<&std::path::Path>) {
     let (Some(dir), Some(stem)) = (
         target.parent(),
         target.file_stem().and_then(|s| s.to_str()),
@@ -662,7 +676,7 @@ fn cleanup_stale_backups(target: &std::path::Path) {
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path == *target {
+            if path == *target || keep.is_some_and(|k| path == *k) {
                 continue;
             }
             let name = entry.file_name().to_string_lossy().to_string();
@@ -765,7 +779,15 @@ pub fn self_update() -> Result<(), String> {
             ));
         }
         Err(VerifyError::Other(e)) => {
-            eprintln!("Note: SHA-256 fetch failed ({e}). Skipping verification.");
+            // The release HAS a sidecar (we found its URL in the same release
+            // JSON as the binary), so an unfetchable sidecar means we cannot
+            // verify a binary we know is verifiable — fail closed rather than
+            // silently installing unverified bytes.
+            return Err(format!(
+                "SHA-256 sidecar could not be fetched after retry ({e}) — \
+                 refusing to install unverified binary. Retry when the network \
+                 is stable."
+            ));
         }
     }
 
@@ -781,11 +803,17 @@ pub fn self_update() -> Result<(), String> {
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&tmp_path, perms)
-            .map_err(|e| format!("chmod failed: {e}"))?;
+        if let Err(e) = std::fs::set_permissions(&tmp_path, perms) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("chmod failed: {e}"));
+        }
         // Atomic rename
-        std::fs::rename(&tmp_path, &current_exe)
-            .map_err(|e| format!("failed to replace binary: {e}"))?;
+        if let Err(e) = std::fs::rename(&tmp_path, &current_exe) {
+            // Don't leave a stale `<name>.new` next to the binary — nothing
+            // on Unix ever sweeps it (cleanup_stale_backups is Windows-only).
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("failed to replace binary: {e}"));
+        }
         eprintln!("Updated to v{}!", remote_version);
     }
 
@@ -979,6 +1007,28 @@ fn update_sibling_tui(
         return;
     }
 
+    // ADR-0029 Phase 4a — this is the most-traveled path that puts TUI bytes
+    // on disk (it runs on every `kannaka update`), so it verifies the sidecar
+    // just like self_update and bootstrap_install_tui. Best-effort refresh:
+    // an unverifiable download skips the TUI update rather than aborting.
+    match fetch_and_verify_sha256(agent, &tui_release, &asset_name, &bytes) {
+        Ok(()) => eprintln!("SHA-256 verified."),
+        Err(VerifyError::SidecarMissing) => {
+            eprintln!("Note: no SHA-256 sidecar in kannaka-tui {tui_tag}. Skipping verification.");
+        }
+        Err(VerifyError::Mismatch { expected, actual }) => {
+            eprintln!(
+                "Note: kannaka-tui SHA-256 mismatch — skipping TUI update.\n  \
+                 expected: {expected}\n  actual:   {actual}"
+            );
+            return;
+        }
+        Err(VerifyError::Other(e)) => {
+            eprintln!("Note: kannaka-tui SHA-256 sidecar unfetchable after retry ({e}) — skipping TUI update.");
+            return;
+        }
+    }
+
     let tmp_path = tui_path.with_extension("new");
     if let Err(e) = std::fs::write(&tmp_path, &bytes) {
         eprintln!("Note: tui write failed: {e}");
@@ -990,6 +1040,8 @@ fn update_sibling_tui(
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755));
         if let Err(e) = std::fs::rename(&tmp_path, &tui_path) {
+            // Don't strand `<name>.new` — nothing on Unix sweeps it.
+            let _ = std::fs::remove_file(&tmp_path);
             eprintln!("Note: tui install failed: {e}");
             return;
         }
@@ -1046,12 +1098,28 @@ pub fn fetch_and_verify_sha256(
         .ok_or(VerifyError::SidecarMissing)?
         .to_string();
 
-    let resp = agent.get(&sidecar_url)
-        .set("User-Agent", "kannaka-update")
-        .call()
-        .map_err(|e| VerifyError::Other(format!("sidecar fetch: {e}")))?;
-    let sidecar_body = resp.into_string()
-        .map_err(|e| VerifyError::Other(format!("sidecar read: {e}")))?;
+    // One retry on the sidecar fetch: the release provably ships a sidecar
+    // (the URL came from the same release JSON as the binary), so a transient
+    // network blip shouldn't downgrade the install to unverified — and callers
+    // treat `Other` as fatal for exactly that reason.
+    let sidecar_body = {
+        let fetch = || -> Result<String, String> {
+            agent
+                .get(&sidecar_url)
+                .set("User-Agent", "kannaka-update")
+                .call()
+                .map_err(|e| format!("sidecar fetch: {e}"))?
+                .into_string()
+                .map_err(|e| format!("sidecar read: {e}"))
+        };
+        match fetch() {
+            Ok(b) => b,
+            Err(_) => {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                fetch().map_err(VerifyError::Other)?
+            }
+        }
+    };
 
     // First whitespace-delimited token is the digest. Tolerate either
     // `sha256sum`'s `<hex>  <filename>\n` or just the hex digest alone.
@@ -1161,7 +1229,13 @@ pub fn bootstrap_install_tui() -> Result<std::path::PathBuf, String> {
             ));
         }
         Err(VerifyError::Other(e)) => {
-            eprintln!("Note: SHA-256 fetch failed ({e}). Skipping verification.");
+            // Same posture as self_update: the sidecar exists in the release,
+            // so failing to fetch it means we can't verify a verifiable binary.
+            return Err(format!(
+                "SHA-256 sidecar could not be fetched after retry ({e}) — \
+                 refusing to install unverified binary. Retry when the network \
+                 is stable."
+            ));
         }
     }
 
@@ -1173,6 +1247,15 @@ pub fn bootstrap_install_tui() -> Result<std::path::PathBuf, String> {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&tui_path, std::fs::Permissions::from_mode(0o755))
             .map_err(|e| format!("chmod: {e}"))?;
+    }
+
+    // Record the installed version so the next `kannaka update` skips the
+    // redundant re-download/re-swap (update_sibling_tui reads this sidecar;
+    // until now only update_sibling_tui wrote it, so the first update after
+    // a bootstrap always re-installed an already-current TUI).
+    let tui_version = tui_tag.trim_start_matches('v');
+    if tui_version != "unknown" {
+        let _ = std::fs::write(dir.join(".kannaka-tui.version"), tui_version);
     }
 
     Ok(tui_path)
@@ -1207,8 +1290,11 @@ fn platform_triple() -> (&'static str, &'static str, &'static str) {
 pub fn install_tui_binary(install_dir: &std::path::Path) {
     let (os, arch, ext) = platform_triple();
     let tui_name = format!("kannaka-tui-{}-{}{}", os, arch, ext);
+    // The TUI moved to its own repo at v0.5.12 (release.yml no longer ships a
+    // kannaka-tui asset here) — the old kannaka-memory URL 404'd on every
+    // fresh install, so first-time installs silently never got a TUI.
     let url = format!(
-        "https://github.com/NickFlach/kannaka-memory/releases/latest/download/{}",
+        "https://github.com/NickFlach/kannaka-tui/releases/latest/download/{}",
         tui_name
     );
     let target = install_dir.join(format!("kannaka-tui{}", ext));
@@ -1241,7 +1327,10 @@ pub fn install_tui_binary(install_dir: &std::path::Path) {
             }
         }
         Err(_) => {
-            eprintln!(" {}not available yet (build with: cargo build --features tui){}", a.gray, a.reset);
+            // No `tui` feature exists in this crate anymore — the TUI lives in
+            // NickFlach/kannaka-tui. Point users there instead of at a
+            // cargo command that can't work.
+            eprintln!(" {}not available (install later with: kannaka update, or from https://github.com/NickFlach/kannaka-tui/releases){}", a.gray, a.reset);
         }
     }
 }
@@ -1349,23 +1438,42 @@ pub fn run_update_from_download(installed_path: &std::path::Path) {
 
     #[cfg(windows)]
     {
-        // On Windows, can't overwrite a running exe. Rename old → .old, copy new.
-        let old_path = installed_path.with_extension("exe.old");
-        let _ = std::fs::remove_file(&old_path);
-        if let Err(e) = std::fs::rename(installed_path, &old_path) {
-            eprintln!("  {}Failed to rename old binary: {}{}", a.red, e, a.reset);
+        // On Windows, can't overwrite a running exe. Move the installed
+        // binary aside to a UNIQUE backup name, then copy the new one in.
+        // A fixed `.exe.old` is the pattern windows_swap_binary was written
+        // to kill: renaming onto a fixed name that a stale worker still runs
+        // from fails forever with "Access is denied" (see its doc comment).
+        let backup = installed_path.with_extension(format!("exe.bak-{}", std::process::id()));
+        let _ = std::fs::remove_file(&backup);
+        let mut moved = false;
+        let mut last_err = String::from("unknown error");
+        for attempt in 0..5u64 {
+            match std::fs::rename(installed_path, &backup) {
+                Ok(_) => {
+                    moved = true;
+                    break;
+                }
+                Err(e) => {
+                    last_err = e.to_string();
+                    std::thread::sleep(std::time::Duration::from_millis(150 * (attempt + 1)));
+                }
+            }
+        }
+        if !moved {
+            eprintln!("  {}Failed to rename old binary: {}{}", a.red, last_err, a.reset);
             println!("\n  Press Enter to exit...");
             let _ = std::io::stdin().read_line(&mut String::new());
             return;
         }
         match std::fs::copy(&current_exe, installed_path) {
             Ok(_) => {
-                println!("  {}✓ Updated {} (old saved as .exe.old){}",
-                    a.green, installed_path.display(), a.reset);
+                cleanup_stale_backups(installed_path, Some(&backup));
+                println!("  {}✓ Updated {} (old saved as {}){}",
+                    a.green, installed_path.display(), backup.display(), a.reset);
             }
             Err(e) => {
                 // Try to restore the old binary
-                let _ = std::fs::rename(&old_path, installed_path);
+                let _ = std::fs::rename(&backup, installed_path);
                 eprintln!("  {}Failed to install: {}{}", a.red, e, a.reset);
                 println!("\n  Press Enter to exit...");
                 let _ = std::io::stdin().read_line(&mut String::new());
@@ -3677,14 +3785,16 @@ mod config_field_tests {
         ] {
             std::fs::write(dir.path().join(name), b"x").unwrap();
         }
-        cleanup_stale_backups(&target);
+        let keep = dir.path().join("kannaka.exe.bak-222");
+        cleanup_stale_backups(&target, Some(&keep));
         // stale update siblings are gone
         assert!(!dir.path().join("kannaka.exe.bak-111").exists());
-        assert!(!dir.path().join("kannaka.exe.bak-222").exists());
         assert!(!dir.path().join("kannaka.exe.old").exists());
         assert!(!dir.path().join("kannaka.new").exists());
-        // the live binary and unrelated files are kept
+        // the live binary, the just-created backup (rollback artifact), and
+        // unrelated files are kept
         assert!(target.exists());
+        assert!(keep.exists());
         assert!(dir.path().join("kannaka-other.txt").exists());
         assert!(dir.path().join("kannaka.exe.config").exists());
     }
@@ -3711,5 +3821,24 @@ mod config_field_tests {
         assert!(res.is_ok(), "swap must succeed with a legacy .old present: {res:?}");
         assert_eq!(std::fs::read(&target).unwrap(), b"v2"); // new binary installed
         assert!(!new_file.exists()); // the staged .new was consumed
+        // the returned backup is the rollback artifact — it must survive the
+        // post-swap sweep (previously it was deleted whenever it wasn't
+        // OS-locked, so "previous binary saved as X" was a false promise)
+        let backup = res.unwrap();
+        assert_eq!(std::fs::read(&backup).unwrap(), b"v1");
+    }
+
+    // A hotfix/pre-release suffix must degrade to its numeric prefix in
+    // place — the old filter_map dropped the unparsable component entirely,
+    // shifting later components left ("0.10.4-1" compared OLDER than 0.10.3,
+    // so `kannaka update` reported "Already up to date" for everyone below).
+    #[test]
+    fn version_compare_handles_suffixed_components() {
+        assert!(version_is_newer("0.10.4", "0.10.3"));
+        assert!(version_is_newer("0.10.4-1", "0.10.3"));
+        assert!(version_is_newer("0.6.10-rc.1", "0.6.9"));
+        assert!(!version_is_newer("0.10.3", "0.10.3"));
+        assert!(!version_is_newer("0.10.3-hotfix", "0.10.3"));
+        assert!(version_is_newer("1.0.0", "0.99.99"));
     }
 }

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -55,6 +55,39 @@ struct InterferencePair {
 }
 
 // ---------------------------------------------------------------------------
+// Circular phase arithmetic
+//
+// Stored phases drift UNBOUNDED across dreams (Kuramoto integration and the
+// medium dynamics increment without wrapping), so any phase arithmetic that
+// treats them as plain numbers — arithmetic means, |a−b| gaps, linear blends —
+// silently breaks once a field has drifted or a pair straddles the 2π wrap.
+// All consolidation stages route phase math through these two helpers.
+// ---------------------------------------------------------------------------
+
+/// Angular midpoint of two phases (circular mean via summed unit vectors),
+/// in (−π, π]. Unlike `(a + b) / 2`, correct for wrap-straddling pairs:
+/// the arithmetic mean of 6.2 and 0.2 is ~π (anti-phase to both); the
+/// circular mean is ~0.06 (between them).
+fn circular_mean2(a: f32, b: f32) -> f32 {
+    (a.sin() + b.sin()).atan2(a.cos() + b.cos())
+}
+
+/// Wrapped signed angular difference `to − from`, in (−π, π].
+fn wrapped_phase_delta(to: f32, from: f32) -> f32 {
+    (to - from).sin().atan2((to - from).cos())
+}
+
+/// Signed phase-repulsion step for a pair (applied `+` to a, `−` to b):
+/// pushes the WRAPPED gap |φa−φb| toward π/2, carrying the sign of the
+/// gap so the pair always widens (a fixed sign attracts whenever φa < φb).
+fn repulsion_phase_correction(phase_a: f32, phase_b: f32, strength: f32) -> f32 {
+    let target_diff = std::f32::consts::FRAC_PI_2;
+    let wrapped_diff = wrapped_phase_delta(phase_a, phase_b);
+    // f32::signum(0.0) is 1.0, which conveniently breaks the identical-phase tie.
+    strength * 0.5 * (target_diff - wrapped_diff.abs()) * wrapped_diff.signum()
+}
+
+// ---------------------------------------------------------------------------
 // Coboundary Validation for Hallucination Synthesis
 // ---------------------------------------------------------------------------
 
@@ -534,7 +567,11 @@ impl ConsolidationEngine {
                     _ => continue,
                 }
             };
-            let avg_phase = (phase_a + phase_b) / 2.0;
+            // Circular mean, not arithmetic: a constructive pair straddling
+            // the 2π wrap (e.g. 6.2 and 0.2) has an arithmetic mean near π —
+            // anti-phase to the pair's own neighborhood, which the next dream
+            // then classifies destructive and dampens.
+            let avg_phase = circular_mean2(phase_a, phase_b);
 
             // Boost amplitude and align phase for memory A (skip ghosts and sub-noise-floor)
             if let Some(mem) = engine.store.get_mut(&pair.id_a).ok().flatten() {
@@ -714,10 +751,15 @@ impl ConsolidationEngine {
                     mem.phase += (mem.id.as_u128() as f32 % 100.0) * 0.001;  // Tiny deterministic noise
                 }
             } else if final_order < 0.40 {
-                // Too chaotic - nudge toward mean phase
+                // Too chaotic - nudge toward mean phase. Step along the WRAPPED
+                // angular difference: mean_phase is in (−π, π] while stored
+                // phases drift unbounded across dreams, so the old linear blend
+                // `0.9φ + 0.1·mean` kicked a drifted-but-aligned memory by 10%
+                // of its accumulated drift — destabilizing the exact memories
+                // it meant to gently align.
                 let mean_phase = self.compute_mean_phase(&cat_mems);
                 for mem in &mut cat_mems {
-                    mem.phase = 0.9 * mem.phase + 0.1 * mean_phase;
+                    mem.phase += 0.1 * wrapped_phase_delta(mean_phase, mem.phase);
                 }
             }
             
@@ -970,11 +1012,15 @@ impl ConsolidationEngine {
                 }
             };
             
-            // Push phases apart (create p/2 phase difference for maximum differentiation)
-            let target_diff = std::f32::consts::PI / 2.0;
-            let current_diff = (phase_a - phase_b).abs();
-            let phase_correction = repulsion_strength * 0.5 * (target_diff - current_diff);
-            
+            // Push phases apart toward a π/2 wrapped gap. Two subtleties both
+            // previously inverted the effect for ~half of all pairs: the diff
+            // must be WRAPPED (|φa−φb| can be 5.9 when the real angular gap is
+            // 0.38), and the correction must carry the SIGN of the gap — a
+            // fixed "+ to a, − to b" contracts (attracts!) whenever φa < φb,
+            // which of the two you got depended solely on iteration order.
+            let phase_correction =
+                repulsion_phase_correction(phase_a, phase_b, repulsion_strength);
+
             // Apply phase separation
             if let Ok(Some(mem_a)) = engine.store.get_mut(&id_a) {
                 mem_a.phase += phase_correction;
@@ -2694,8 +2740,12 @@ impl ConsolidationEngine {
             let mean_phase = self.compute_mean_phase(&mems);
             for id in ids {
                 if let Ok(Some(mem)) = engine.store.get_mut(id) {
-                    // Gentle phase alignment toward the modality mean (5% per cycle)
-                    mem.phase = 0.95 * mem.phase + 0.05 * mean_phase;
+                    // Gentle phase alignment toward the modality mean (5% per
+                    // cycle), stepped along the WRAPPED angular difference —
+                    // a linear blend against the (−π, π] atan2 mean kicks
+                    // drift-accumulated phases by 5% of their unbounded drift
+                    // instead of 5% of the real angular gap.
+                    mem.phase += 0.05 * wrapped_phase_delta(mean_phase, mem.phase);
                     // Small amplitude boost for correctly-classified memories
                     // (#368: clamp like every other strengthen site — this path
                     // was missed by the #360 ceiling fix).
@@ -2958,6 +3008,12 @@ impl DreamState {
                 mem.amplitude *= 0.995;
                 if mem.amplitude < self.engine.prune_threshold {
                     mem.amplitude = 0.0;
+                    // ADR-0037: stamp updated_at on ghosting so the recovery
+                    // window holds — stage_prune and the noise-floor sweep both
+                    // stamp; without it a lite-ghosted old memory (updated_at
+                    // == created_at, past the 7-day horizon) is hard-deleted by
+                    // the very next deep dream's compact stage.
+                    mem.updated_at = Some(now);
                     to_prune.push(*id);
                     report.memories_pruned += 1;
                 }
@@ -3028,6 +3084,91 @@ mod tests {
             mem.phase = phase;
         }
         id
+    }
+
+    // -----------------------------------------------------------------------
+    // Circular phase arithmetic (the 2π-wrap family of bugs)
+    // -----------------------------------------------------------------------
+
+    /// Absolute angular distance between two phases, for assertions.
+    fn angular_distance(a: f32, b: f32) -> f32 {
+        wrapped_phase_delta(a, b).abs()
+    }
+
+    #[test]
+    fn circular_mean_handles_wrap_straddling_pair() {
+        // 6.2 rad ≡ −0.083 rad; the angular midpoint with 0.2 is ~0.058 —
+        // the arithmetic mean (3.2 ≈ π) is anti-phase to both inputs.
+        let mean = circular_mean2(6.2, 0.2);
+        assert!(
+            angular_distance(mean, 0.058) < 0.05,
+            "circular mean of a wrap-straddling pair must land between the \
+             inputs, got {mean}"
+        );
+        // Sanity: a non-straddling pair matches the arithmetic mean.
+        let plain = circular_mean2(1.0, 2.0);
+        assert!(angular_distance(plain, 1.5) < 1e-3, "got {plain}");
+    }
+
+    #[test]
+    fn wrapped_delta_measures_real_angular_gap() {
+        // Raw diff is −6.0; the real angular step from 6.2 to 0.2 is +0.283.
+        let d = wrapped_phase_delta(0.2, 6.2);
+        assert!((d - 0.283).abs() < 1e-2, "got {d}");
+        assert!(wrapped_phase_delta(2.0, 1.6) > 0.0);
+        assert!(wrapped_phase_delta(1.6, 2.0) < 0.0);
+    }
+
+    #[test]
+    fn repulsion_widens_gap_regardless_of_pair_order() {
+        // The old fixed-sign correction widened only when φa > φb and
+        // CONTRACTED the pair otherwise (direction picked by iteration
+        // order). Both orderings must now widen toward π/2.
+        for (a, b) in [(1.6f32, 2.0f32), (2.0, 1.6)] {
+            let before = angular_distance(a, b);
+            let c = repulsion_phase_correction(a, b, 1.0);
+            let after = angular_distance(a + c, b - c);
+            assert!(
+                after > before,
+                "repulsion must widen the gap: ({a}, {b}) went {before} -> {after}"
+            );
+            assert!(
+                after <= std::f32::consts::FRAC_PI_2 + 1e-3,
+                "must not overshoot π/2: got {after}"
+            );
+        }
+        // Drifted pair: raw |Δ| = 5.9 but the real gap is ~0.38 — the
+        // correction must be based on the wrapped gap (small, widening),
+        // not the raw one (huge, sign-flipped).
+        let (a, b) = (6.1f32, 0.2f32);
+        let before = angular_distance(a, b);
+        let c = repulsion_phase_correction(a, b, 1.0);
+        let after = angular_distance(a + c, b - c);
+        assert!(after > before, "drifted pair must widen: {before} -> {after}");
+    }
+
+    #[test]
+    fn dream_lite_ghosting_stamps_recovery_window() {
+        let mut engine = make_engine();
+        let state = DreamState::new(ConsolidationEngine::default(), 1);
+        let id = insert_with_phase_and_layer(&mut engine, "fading trace", 0.0, 0);
+        // Force the memory below the prune threshold so this lite pass
+        // ghosts it, and clear updated_at to model an old field.
+        if let Some(mem) = engine.store.get_mut(&id).ok().flatten() {
+            mem.amplitude = 0.01;
+            mem.updated_at = None;
+        }
+        let report = state.dream_lite(&mut engine);
+        assert!(report.memories_pruned >= 1, "memory should be ghosted");
+        let mem = engine.get_memory(&id).unwrap().unwrap();
+        assert_eq!(mem.amplitude, 0.0, "ghosted");
+        // ADR-0037: the ghost must carry a fresh updated_at so the deep
+        // dream's compact stage honors the recovery window instead of
+        // hard-deleting it in the same cycle.
+        assert!(
+            mem.updated_at.is_some(),
+            "lite ghosting must stamp updated_at (recovery window)"
+        );
     }
 
     #[test]

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -72,14 +72,20 @@ fn circular_mean2(a: f32, b: f32) -> f32 {
     (a.sin() + b.sin()).atan2(a.cos() + b.cos())
 }
 
-/// Wrapped signed angular difference `to − from`, in (−π, π].
+/// Wrapped signed angular difference `to − from`, in [−π, π). Delegates to
+/// the crate's canonical wrap (spiral.rs) — one convention, one
+/// implementation, and rem_euclid stays exact for large drifted inputs.
 fn wrapped_phase_delta(to: f32, from: f32) -> f32 {
-    (to - from).sin().atan2((to - from).cos())
+    crate::spiral::wrap(to - from)
 }
 
 /// Signed phase-repulsion step for a pair (applied `+` to a, `−` to b):
-/// pushes the WRAPPED gap |φa−φb| toward π/2, carrying the sign of the
-/// gap so the pair always widens (a fixed sign attracts whenever φa < φb).
+/// moves the WRAPPED gap |φa−φb| toward the π/2 differentiation target,
+/// carrying the sign of the gap so the movement direction is correct for
+/// either pair ordering (a fixed sign attracted whenever φa < φb). Pairs
+/// closer than π/2 widen; pairs beyond π/2 (e.g. near-anti-phase) relax
+/// back toward π/2 — the stage targets maximal differentiation, not
+/// maximal separation.
 fn repulsion_phase_correction(phase_a: f32, phase_b: f32, strength: f32) -> f32 {
     let target_diff = std::f32::consts::FRAC_PI_2;
     let wrapped_diff = wrapped_phase_delta(phase_a, phase_b);
@@ -2296,9 +2302,14 @@ impl ConsolidationEngine {
             }
         }
         
-        // Compute phase transformation
-        let phase_diff = b.phase - a.phase;
-        let phase_scale = if a.phase.abs() > 1e-6 { b.phase / a.phase } else { 1.0 };
+        // Compute phase transformation. Angles compose by offset, not scale:
+        // dividing one drifting phase by another (`b.phase / a.phase`) is
+        // meaningless, so the scale component is identity and the offset is
+        // the WRAPPED angular difference (raw subtraction of unbounded-drift
+        // phases is noise). NB: `phase_transform` currently has no readers —
+        // this keeps the recorded transform honest for when one appears.
+        let phase_diff = wrapped_phase_delta(b.phase, a.phase);
+        let phase_scale = 1.0_f32;
         
         // Compute frequency transformation  
         let freq_diff = b.frequency - a.frequency;

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -493,6 +493,13 @@ fn write_pub(w: &mut TcpStream, subject: &str, payload: &[u8]) -> Result<(), Nat
 struct Conn {
     writer: TcpStream,
     reader: BufReader<TcpStream>,
+    /// Set when a write failed partway through a frame (e.g. a write timeout
+    /// after the PUB header but before the payload). The outbound byte stream
+    /// is desynced at that point: any further bytes — including a buffered
+    /// replay — would be parsed by the server as the remainder of the
+    /// truncated frame, silently publishing garbage. A dead Conn must never
+    /// be written again; `reconnect()` replaces it wholesale.
+    dead: bool,
 }
 
 impl Conn {
@@ -597,7 +604,7 @@ fn handshake(url: &str) -> Result<Conn, NatsError> {
     // not success); -ERR (e.g. Authorization Violation) fails the handshake.
     for _ in 0..10 {
         match read_frame(&mut reader)? {
-            ReadOutcome::Frame(Frame::Pong) => return Ok(Conn { writer, reader }),
+            ReadOutcome::Frame(Frame::Pong) => return Ok(Conn { writer, reader, dead: false }),
             ReadOutcome::Frame(Frame::Ping) => {
                 write!(writer, "PONG\r\n")?;
                 writer.flush()?;
@@ -978,6 +985,11 @@ impl SwarmTransport {
     /// fails to send it is pushed back to the FRONT (preserving order) and
     /// the error is returned; nothing after it is attempted.
     fn flush_buffer_locked(&self, conn: &mut Conn) -> Result<(), NatsError> {
+        if conn.dead {
+            return Err(NatsError::Disconnected(
+                "connection desynced — buffered replay deferred until reconnect".to_string(),
+            ));
+        }
         loop {
             let next = self
                 .publish_buffer
@@ -986,6 +998,9 @@ impl SwarmTransport {
                 .pop_front();
             let Some(msg) = next else { return Ok(()) };
             if let Err(e) = write_pub(&mut conn.writer, &msg.subject, &msg.payload) {
+                // The failed write may have landed partially — the stream is
+                // desynced; nothing may be written on this Conn again.
+                conn.dead = true;
                 eprintln!(
                     "[nats] buffered replay failed on {} — re-queueing: {}",
                     msg.subject, e
@@ -1251,10 +1266,26 @@ impl SwarmTransport {
     /// the call order. On failure this message joins the back of the buffer.
     fn publish_raw(&self, subject: &str, payload: &[u8]) -> Result<(), NatsError> {
         let mut conn = self.lock_conn()?;
+        // A dead Conn's outbound stream is desynced mid-frame — writing
+        // anything more (this message OR the buffered replay) would be parsed
+        // by the server as the tail of the truncated frame. Fail fast and
+        // keep buffering until reconnect() swaps in a fresh socket. This also
+        // spares every post-failure publish the 5s write-timeout it used to
+        // burn re-failing on the same dead socket.
+        if conn.dead {
+            drop(conn);
+            self.mark_disconnected();
+            self.buffer_message(subject, payload);
+            return Err(NatsError::Disconnected(
+                "connection desynced by an earlier mid-frame write failure — reconnect required"
+                    .to_string(),
+            ));
+        }
         let result = self
             .flush_buffer_locked(&mut conn)
             .and_then(|()| write_pub(&mut conn.writer, subject, payload));
         if result.is_err() {
+            conn.dead = true;
             drop(conn);
             self.mark_disconnected();
             self.buffer_message(subject, payload);

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -388,13 +388,40 @@ enum ReadOutcome {
     Closed,
 }
 
+/// Ceiling on a single MSG payload allocation. The NATS server default
+/// max_payload is 1 MiB and nothing in the constellation raises it past
+/// that; 8 MiB leaves generous headroom while making `MSG x 1 99999999999`
+/// from a compromised/desynced peer a protocol error instead of an
+/// allocation abort (#501).
+const MAX_MSG_PAYLOAD: usize = 8 * 1024 * 1024;
+
+/// Ceiling on one control line. INFO with auth/cluster metadata runs a few
+/// KB; MSG headers and -ERR lines are tiny. A line that hasn't ended after
+/// 16 KiB is not NATS protocol traffic.
+const MAX_CONTROL_LINE: u64 = 16 * 1024;
+
 /// Read exactly one protocol frame. Returns `Err` on any condition that
 /// desyncs the byte stream (partial line consumed before a timeout, short
 /// payload read, unparseable MSG header, missing CRLF, non-UTF-8 control
 /// line) — after such an error the connection must be considered dead.
 fn read_frame(reader: &mut BufReader<TcpStream>) -> Result<ReadOutcome, NatsError> {
     let mut line = String::new();
-    match reader.read_line(&mut line) {
+    // Bound control-line growth: `take` caps how many bytes this read_line
+    // can pull, so a stream that never sends '\n' (desync, garbage peer)
+    // errors out instead of growing `line` without bound.
+    let read_result = {
+        let mut limited = (&mut *reader).take(MAX_CONTROL_LINE);
+        limited.read_line(&mut line)
+    };
+    if let Ok(n) = read_result {
+        if n as u64 >= MAX_CONTROL_LINE && !line.ends_with('\n') {
+            return Err(NatsError::Protocol(format!(
+                "control line exceeds {} bytes without newline — protocol desync",
+                MAX_CONTROL_LINE
+            )));
+        }
+    }
+    match read_result {
         Ok(0) => return Ok(ReadOutcome::Closed),
         Ok(_) => {}
         Err(e)
@@ -435,6 +462,15 @@ fn read_frame(reader: &mut BufReader<TcpStream>) -> Result<ReadOutcome, NatsErro
         let nbytes: usize = nbytes_str.parse().map_err(|_| {
             NatsError::Protocol(format!("invalid MSG byte count: {}", trimmed))
         })?;
+        if nbytes > MAX_MSG_PAYLOAD {
+            // Wire-controlled size: allocating it unchecked lets one bogus
+            // header abort the process. Nothing legitimate approaches this
+            // (server max_payload defaults to 1 MiB).
+            return Err(NatsError::Protocol(format!(
+                "MSG payload {} exceeds {} byte cap — refusing allocation",
+                nbytes, MAX_MSG_PAYLOAD
+            )));
+        }
         let mut payload = vec![0u8; nbytes];
         reader.read_exact(&mut payload).map_err(|e| {
             NatsError::Protocol(format!("short MSG payload read: {}", e))

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -514,13 +514,16 @@ fn read_frame(reader: &mut BufReader<TcpStream>) -> Result<ReadOutcome, NatsErro
     )))
 }
 
-/// Write one PUB frame (header + payload + CRLF) and flush.
-fn write_pub(w: &mut TcpStream, subject: &str, payload: &[u8]) -> Result<(), NatsError> {
-    write!(w, "PUB {} {}\r\n", subject, payload.len())?;
-    w.write_all(payload)?;
-    w.write_all(b"\r\n")?;
-    w.flush()?;
-    Ok(())
+/// Write one PUB frame (header + payload + CRLF) and flush, through the
+/// dead-flag choke point. Building the frame in one buffer means a failure
+/// is all-or-mostly-nothing at the syscall level, and `write_frames` marks
+/// the Conn dead on any partial landing either way.
+fn write_pub(conn: &mut Conn, subject: &str, payload: &[u8]) -> Result<(), NatsError> {
+    let mut frame = Vec::with_capacity(payload.len() + subject.len() + 32);
+    let _ = write!(frame, "PUB {} {}\r\n", subject, payload.len());
+    frame.extend_from_slice(payload);
+    frame.extend_from_slice(b"\r\n");
+    conn.write_frames(&frame)
 }
 
 /// The two halves of one NATS connection. The reader is persistent: it must
@@ -552,8 +555,30 @@ impl Conn {
     }
 
     fn pong(&mut self) -> Result<(), NatsError> {
-        write!(self.writer, "PONG\r\n")?;
-        self.writer.flush()?;
+        self.write_frames(b"PONG\r\n")
+    }
+
+    /// The single choke point for outbound bytes. Refuses to touch a
+    /// desynced stream, and marks the stream desynced when a write fails
+    /// (any I/O error here may have left partial frame bytes on the wire —
+    /// further writes would be parsed as the tail of the truncated frame).
+    /// Every writer MUST route through this; direct `self.writer` access
+    /// is reserved for `try_clone` in subscription setup.
+    fn write_frames(&mut self, bytes: &[u8]) -> Result<(), NatsError> {
+        if self.dead {
+            return Err(NatsError::Disconnected(
+                "connection desynced by an earlier mid-frame write failure — reconnect required"
+                    .to_string(),
+            ));
+        }
+        let result = self
+            .writer
+            .write_all(bytes)
+            .and_then(|()| self.writer.flush());
+        if let Err(e) = result {
+            self.dead = true;
+            return Err(NatsError::Io(e));
+        }
         Ok(())
     }
 }
@@ -674,7 +699,18 @@ fn handshake(url: &str) -> Result<Conn, NatsError> {
 struct BufferedMessage {
     subject: String,
     payload: Vec<u8>,
+    /// Failed replay attempts. Replay is strictly order-preserving, so a
+    /// message that can never be written (e.g. it exceeds the server's
+    /// max_payload and kills the connection every time) would otherwise
+    /// pin the buffer head forever — every later message, including
+    /// presence announces, queues behind it while the daemon logs
+    /// "reconnected" each cycle. Dropped loudly after MAX_REPLAY_ATTEMPTS.
+    attempts: u32,
 }
+
+/// Replay attempts before a head-of-buffer message is declared poison and
+/// dropped so the queue behind it can drain.
+const MAX_REPLAY_ATTEMPTS: u32 = 5;
 
 /// A minimal synchronous NATS client with JetStream KV, events, and reconnection.
 pub struct SwarmTransport {
@@ -687,7 +723,14 @@ pub struct SwarmTransport {
     jetstream_ok: bool,
     connected: Arc<Mutex<bool>>,
     publish_buffer: Arc<Mutex<VecDeque<BufferedMessage>>>,
+    /// Last in-place revival attempt (see `try_revive_locked`). Rate-limits
+    /// redials so a daemon publishing frequently against a downed server
+    /// pays one connect timeout per REVIVE_INTERVAL, not per publish.
+    last_revive: Arc<Mutex<Option<Instant>>>,
 }
+
+/// Minimum spacing between in-place redial attempts from `try_revive_locked`.
+const REVIVE_INTERVAL: Duration = Duration::from_secs(15);
 
 // ──────────────────────────────────────────────────────────────────
 // ADR-0028 — durable event-sourced HRM. Streams declared as data;
@@ -892,6 +935,7 @@ impl SwarmTransport {
             jetstream_ok: false,
             connected: Arc::new(Mutex::new(true)),
             publish_buffer: Arc::new(Mutex::new(VecDeque::new())),
+            last_revive: Arc::new(Mutex::new(None)),
         };
 
         // Try to ensure JetStream streams exist
@@ -957,18 +1001,24 @@ impl SwarmTransport {
         }
 
         // Replay buffered messages in order. On failure the unsent remainder
-        // stays queued (in order, at the front) for the next attempt.
+        // stays queued (in order, at the front) for the next attempt — and
+        // the reconnect reports FAILURE, so callers don't log "reconnected"
+        // and re-announce presence on a connection whose replay just
+        // re-killed it (the node would look recovered in its own logs while
+        // still absent from the swarm). Poison head messages are dropped by
+        // flush_buffer_locked after MAX_REPLAY_ATTEMPTS, so repeated calls
+        // converge instead of looping forever.
         let replay_result = {
             let mut conn = self.lock_conn()?;
             self.flush_buffer_locked(&mut conn)
         };
         if let Err(e) = replay_result {
             self.mark_disconnected();
-            eprintln!(
-                "[nats] reconnect: buffered replay incomplete ({} still queued): {}",
+            return Err(NatsError::Disconnected(format!(
+                "reconnected but buffered replay incomplete ({} still queued): {}",
                 self.buffered_count(),
                 e
-            );
+            )));
         }
 
         Ok(())
@@ -1006,6 +1056,7 @@ impl SwarmTransport {
         buf.push_back(BufferedMessage {
             subject: subject.to_string(),
             payload: payload.to_vec(),
+            attempts: 0,
         });
     }
 
@@ -1032,19 +1083,27 @@ impl SwarmTransport {
                 .lock()
                 .unwrap_or_else(|p| p.into_inner())
                 .pop_front();
-            let Some(msg) = next else { return Ok(()) };
-            if let Err(e) = write_pub(&mut conn.writer, &msg.subject, &msg.payload) {
-                // The failed write may have landed partially — the stream is
-                // desynced; nothing may be written on this Conn again.
-                conn.dead = true;
-                eprintln!(
-                    "[nats] buffered replay failed on {} — re-queueing: {}",
-                    msg.subject, e
-                );
-                self.publish_buffer
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push_front(msg);
+            let Some(mut msg) = next else { return Ok(()) };
+            if let Err(e) = write_pub(conn, &msg.subject, &msg.payload) {
+                // write_pub's choke point already marked the Conn dead.
+                msg.attempts += 1;
+                if msg.attempts >= MAX_REPLAY_ATTEMPTS {
+                    eprintln!(
+                        "[nats] DROPPING poison buffered message on {} after {} failed replays ({} bytes): {}",
+                        msg.subject, msg.attempts, msg.payload.len(), e
+                    );
+                    // Don't re-queue — let the messages behind it drain on
+                    // the next replay instead of starving forever.
+                } else {
+                    eprintln!(
+                        "[nats] buffered replay failed on {} (attempt {}) — re-queueing: {}",
+                        msg.subject, msg.attempts, e
+                    );
+                    self.publish_buffer
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .push_front(msg);
+                }
                 return Err(e);
             }
         }
@@ -1075,12 +1134,13 @@ impl SwarmTransport {
         let sid = self.alloc_sid();
         let inbox = new_inbox("js");
 
-        write!(conn.writer, "SUB {} {}\r\n", inbox, sid)?;
-        write!(conn.writer, "UNSUB {} 1\r\n", sid)?;
-        write!(conn.writer, "PUB {} {} {}\r\n", api_subject, inbox, request.len())?;
-        conn.writer.write_all(request)?;
-        conn.writer.write_all(b"\r\n")?;
-        conn.writer.flush()?;
+        let mut frame = Vec::with_capacity(request.len() + 128);
+        let _ = write!(frame, "SUB {} {}\r\n", inbox, sid);
+        let _ = write!(frame, "UNSUB {} 1\r\n", sid);
+        let _ = write!(frame, "PUB {} {} {}\r\n", api_subject, inbox, request.len());
+        frame.extend_from_slice(request);
+        frame.extend_from_slice(b"\r\n");
+        conn.write_frames(&frame)?;
 
         let prev = conn.read_timeout();
         conn.set_read_timeout(Some(timeout))?;
@@ -1132,8 +1192,7 @@ impl SwarmTransport {
         // If no reply was delivered, the auto-unsub never fired — remove the
         // subscription explicitly so it can't leak server-side.
         if !matches!(result, Ok(Some(_))) {
-            let _ = write!(conn.writer, "UNSUB {}\r\n", sid);
-            let _ = conn.writer.flush();
+            let _ = conn.write_frames(format!("UNSUB {}\r\n", sid).as_bytes());
         }
         let _ = conn.set_read_timeout(prev);
         if fatal {
@@ -1304,29 +1363,64 @@ impl SwarmTransport {
         let mut conn = self.lock_conn()?;
         // A dead Conn's outbound stream is desynced mid-frame — writing
         // anything more (this message OR the buffered replay) would be parsed
-        // by the server as the tail of the truncated frame. Fail fast and
-        // keep buffering until reconnect() swaps in a fresh socket. This also
-        // spares every post-failure publish the 5s write-timeout it used to
-        // burn re-failing on the same dead socket.
-        if conn.dead {
+        // by the server as the tail of the truncated frame. Try an in-place
+        // revival (rate-limited); if that fails, fail fast to the buffer.
+        // The revival is what lets long-lived daemons that hold an IMMUTABLE
+        // transport (swarm serve, attention, substrate, inbox watch) recover
+        // from one transient write timeout — only `swarm join` has a `mut`
+        // transport and the full reconnect() path.
+        if conn.dead && !self.try_revive_locked(&mut conn) {
             drop(conn);
             self.mark_disconnected();
             self.buffer_message(subject, payload);
             return Err(NatsError::Disconnected(
-                "connection desynced by an earlier mid-frame write failure — reconnect required"
+                "connection desynced by an earlier mid-frame write failure — awaiting revival"
                     .to_string(),
             ));
         }
         let result = self
             .flush_buffer_locked(&mut conn)
-            .and_then(|()| write_pub(&mut conn.writer, subject, payload));
+            .and_then(|()| write_pub(&mut conn, subject, payload));
         if result.is_err() {
-            conn.dead = true;
+            // The choke point already marked the Conn dead on a write error.
             drop(conn);
             self.mark_disconnected();
             self.buffer_message(subject, payload);
         }
         result
+    }
+
+    /// Replace a dead `Conn` with a freshly-handshaked one, in place and
+    /// through interior mutability — the counterpart to `reconnect()` for
+    /// callers that hold `&self`. Rate-limited to one dial per
+    /// REVIVE_INTERVAL so a busy publisher against a downed server pays one
+    /// connect timeout per window, not per publish. Does NOT re-ensure
+    /// JetStream streams (stream config is durable server-side) and does not
+    /// touch subscriptions — a subscription's reader owns clones of the OLD
+    /// socket and either keeps working (server still serves that
+    /// connection) or sees EOF and takes its own Closed path.
+    fn try_revive_locked(&self, conn: &mut Conn) -> bool {
+        {
+            let mut last = self.last_revive.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(t) = *last {
+                if t.elapsed() < REVIVE_INTERVAL {
+                    return false;
+                }
+            }
+            *last = Some(Instant::now());
+        }
+        match handshake(&self.url) {
+            Ok(fresh) => {
+                *conn = fresh;
+                *self.connected.lock().unwrap_or_else(|p| p.into_inner()) = true;
+                eprintln!("[nats] revived connection to {}", self.url);
+                true
+            }
+            Err(e) => {
+                eprintln!("[nats] revive failed ({}): retry in {}s", e, REVIVE_INTERVAL.as_secs());
+                false
+            }
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1722,9 +1816,7 @@ impl SwarmTransport {
         let sid = self.alloc_sid();
         let sid_str = sid.to_string();
 
-        write!(conn.writer, "SUB QUEEN.phase.* {}\r\n", sid)?;
-        write!(conn.writer, "PING\r\n")?;
-        conn.writer.flush()?;
+        conn.write_frames(format!("SUB QUEEN.phase.* {}\r\nPING\r\n", sid).as_bytes())?;
 
         let prev = conn.read_timeout();
         conn.set_read_timeout(Some(Duration::from_millis(1500)))?;
@@ -1763,8 +1855,7 @@ impl SwarmTransport {
             }
         }
 
-        let _ = write!(conn.writer, "UNSUB {}\r\n", sid);
-        let _ = conn.writer.flush();
+        let _ = conn.write_frames(format!("UNSUB {}\r\n", sid).as_bytes());
         let _ = conn.set_read_timeout(prev);
 
         if let Some(e) = fatal {
@@ -1977,13 +2068,14 @@ impl SwarmTransport {
     pub fn subscribe_phases_and_memories(&self, include_memories: bool) -> Result<NatsSubscription, NatsError> {
         let mut conn = self.lock_conn()?;
         let first_sid = self.alloc_sid();
-        write!(conn.writer, "SUB QUEEN.phase.* {}\r\n", first_sid)?;
-        write!(conn.writer, "SUB QUEEN.announce {}\r\n", self.alloc_sid())?;
+        let mut frame = Vec::new();
+        let _ = write!(frame, "SUB QUEEN.phase.* {}\r\n", first_sid);
+        let _ = write!(frame, "SUB QUEEN.announce {}\r\n", self.alloc_sid());
         if include_memories {
-            write!(conn.writer, "SUB KANNAKA.memory.new {}\r\n", self.alloc_sid())?;
-            write!(conn.writer, "SUB KANNAKA.dreams {}\r\n", self.alloc_sid())?;
+            let _ = write!(frame, "SUB KANNAKA.memory.new {}\r\n", self.alloc_sid());
+            let _ = write!(frame, "SUB KANNAKA.dreams {}\r\n", self.alloc_sid());
         }
-        conn.writer.flush()?;
+        conn.write_frames(&frame)?;
         let stream_clone = conn.writer.try_clone()?;
 
         Ok(NatsSubscription {
@@ -2013,8 +2105,7 @@ impl SwarmTransport {
         let deadline = Instant::now() + Duration::from_secs(2);
 
         let result = (|conn: &mut Conn| -> Result<(), NatsError> {
-            write!(conn.writer, "PING\r\n")?;
-            conn.writer.flush()?;
+            conn.write_frames(b"PING\r\n")?;
             loop {
                 if Instant::now() > deadline {
                     return Err(NatsError::Protocol("no PONG within 2s".to_string()));
@@ -2078,12 +2169,13 @@ impl SwarmTransport {
 
         // SUB inbox first so we don't race the reply; UNSUB <sid> 1 lets the
         // server clean up automatically after the first delivery.
-        write!(conn.writer, "SUB {} {}\r\n", inbox, sid)?;
-        write!(conn.writer, "PUB {} {} {}\r\n", subject, inbox, payload.len())?;
-        conn.writer.write_all(payload)?;
-        conn.writer.write_all(b"\r\n")?;
-        write!(conn.writer, "UNSUB {} 1\r\n", sid)?;
-        conn.writer.flush()?;
+        let mut frame = Vec::with_capacity(payload.len() + 128);
+        let _ = write!(frame, "SUB {} {}\r\n", inbox, sid);
+        let _ = write!(frame, "PUB {} {} {}\r\n", subject, inbox, payload.len());
+        frame.extend_from_slice(payload);
+        frame.extend_from_slice(b"\r\n");
+        let _ = write!(frame, "UNSUB {} 1\r\n", sid);
+        conn.write_frames(&frame)?;
 
         let prev = conn.read_timeout();
         conn.set_read_timeout(Some(timeout))?;
@@ -2131,8 +2223,7 @@ impl SwarmTransport {
         if result.is_err() {
             // No reply was delivered, so the auto-unsub never fired —
             // remove the subscription explicitly.
-            let _ = write!(conn.writer, "UNSUB {}\r\n", sid);
-            let _ = conn.writer.flush();
+            let _ = conn.write_frames(format!("UNSUB {}\r\n", sid).as_bytes());
         }
         let _ = conn.set_read_timeout(prev);
         if fatal {
@@ -2156,11 +2247,12 @@ impl SwarmTransport {
         let sid = self.alloc_sid();
         let mut conn = self.lock_conn()?;
 
-        write!(conn.writer, "SUB {} {}\r\n", inbox, sid)?;
-        write!(conn.writer, "PUB {} {} {}\r\n", subject, inbox, payload.len())?;
-        conn.writer.write_all(payload)?;
-        conn.writer.write_all(b"\r\n")?;
-        conn.writer.flush()?;
+        let mut frame = Vec::with_capacity(payload.len() + 128);
+        let _ = write!(frame, "SUB {} {}\r\n", inbox, sid);
+        let _ = write!(frame, "PUB {} {} {}\r\n", subject, inbox, payload.len());
+        frame.extend_from_slice(payload);
+        frame.extend_from_slice(b"\r\n");
+        conn.write_frames(&frame)?;
 
         let prev = conn.read_timeout();
         conn.set_read_timeout(Some(Duration::from_millis(500)))?;
@@ -2203,8 +2295,7 @@ impl SwarmTransport {
         }
 
         // UNSUB so the server stops delivering on this inbox.
-        let _ = write!(conn.writer, "UNSUB {}\r\n", sid);
-        let _ = conn.writer.flush();
+        let _ = conn.write_frames(format!("UNSUB {}\r\n", sid).as_bytes());
         let _ = conn.set_read_timeout(prev);
         if fatal {
             drop(conn);
@@ -2241,10 +2332,9 @@ impl SwarmTransport {
         let mut conn = self.lock_conn()?;
         let sid = self.alloc_sid();
         match queue_group {
-            Some(g) => write!(conn.writer, "SUB {} {} {}\r\n", subject, g, sid)?,
-            None => write!(conn.writer, "SUB {} {}\r\n", subject, sid)?,
+            Some(g) => conn.write_frames(format!("SUB {} {} {}\r\n", subject, g, sid).as_bytes())?,
+            None => conn.write_frames(format!("SUB {} {}\r\n", subject, sid).as_bytes())?,
         }
-        conn.writer.flush()?;
         let stream_clone = conn.writer.try_clone().map_err(NatsError::Io)?;
         // NOTE: the read timeout is a property of the underlying socket,
         // which is shared with the transport — this also clears the
@@ -2499,6 +2589,7 @@ mod tests {
         let msg = BufferedMessage {
             subject: "QUEEN.event.join".to_string(),
             payload: b"test".to_vec(),
+            attempts: 0,
         };
         let cloned = msg.clone();
         assert_eq!(cloned.subject, msg.subject);
@@ -2518,6 +2609,7 @@ mod tests {
                 guard.push_back(BufferedMessage {
                     subject: format!("test.{}", i),
                     payload: vec![],
+                    attempts: 0,
                 });
             }
             assert_eq!(guard.len(), PUBLISH_BUFFER_LIMIT);

--- a/src/spiral.rs
+++ b/src/spiral.rs
@@ -36,9 +36,13 @@ pub struct SpiralReport {
     pub net_charge: i32,
 }
 
-/// Wrap a phase difference into [−π, π).
+/// Wrap a phase difference into [−π, π). `pub(crate)` — the canonical wrap
+/// for the whole crate; consolidation's `wrapped_phase_delta` routes through
+/// it so there is exactly one wrapping convention and one implementation
+/// (rem_euclid stays exact for large drifted inputs where sin/atan2 loses
+/// precision).
 #[inline]
-fn wrap(d: f32) -> f32 {
+pub(crate) fn wrap(d: f32) -> f32 {
     (d + PI).rem_euclid(TAU) - PI
 }
 


### PR DESCRIPTION
Autonomous bug-hunt session (2026-07-04): a knowledge-graph pass over the whole repo, then targeted deep reviews of the three highest-risk subsystems (dream consolidation, hand-rolled NATS transport, self-update pipeline). Every fix here is verified by the full release suite: **18 suites, 731 tests, 0 failures**.

## Commits

- **docs(adr)** — two pairs of ADRs shipped with duplicate numbers; the later ones (2026-03-12) move to the free slots: skip-link-persistence → ADR-0032, kannaka-voice → ADR-0033. All external references meant the older pair, except one `kannaka.rs` comment (updated). Also: ADR-0006's H1 said ADR-0005, the index listed 9 of 38 ADRs (now complete), `Cargo.lock` still pinned 0.10.3 post-release, `.understand-anything/` gitignored.
- **perf(dream)** — the single-writer lock check moves BEFORE the ~60s HRM load; a skipped dream now exits in milliseconds (known follow-up from the 2026-06-18 double-writer fix).
- **fix(update)** — eight defects, highlights: fresh installs downloaded the TUI from kannaka-memory releases which stopped shipping it at v0.5.12 (silent 404 forever); `run_update_from_download` still used the fixed `.exe.old` rename-over pattern that `windows_swap_binary` was written to kill; `update_sibling_tui` (the path that actually writes TUI bytes on every update) never verified SHA-256; verification was fail-open on transient sidecar fetch errors (now retry once → fail closed); `version_is_newer` dropped unparsable components so a hotfix-suffixed tag compared OLDER than its base.
- **fix(consolidation)** — stored phases drift unbounded, but four sites did plain-number phase arithmetic: strengthen's arithmetic mean snapped wrap-straddling constructive pairs to anti-phase (next dream then dampened them); xi-repulsion ATTRACTED instead of repelled whenever φa < φb (direction picked by iteration order) and used unwrapped gaps; two alignment passes kicked drifted memories by a fraction of accumulated drift; `dream_lite` ghosted without the ADR-0037 recovery stamp. Phase math centralized in `circular_mean2`/`wrapped_phase_delta`/`repulsion_phase_correction` with regression tests.
- **fix(nats)** — `reconnect()` had zero production call sites: after a NATS restart the swarm-join daemon (sole HRM writer) buffered into the void until a human restarted it. The heartbeat loop now detects death within one tick (flag-first, PING otherwise), reconnects with heartbeat-interval backoff, replays the buffer, and re-announces presence. Plus: a mid-frame write failure now marks the `Conn` dead so the buffered replay can never be parsed as the tail of a truncated frame (silent corrupt publishes / `-ERR Unknown Protocol Operation`).

## Deferred (issues filed)

Architectural findings too invasive for one autonomous pass: #496 (chiral persistence asymmetry — the particle dream's constructive work reverts, its deletes persist), #497 (`rebuild_cache` resets `updated_at` → ghost recovery window destroyed across restarts), #498 (stale flat-view search), #499 (`swarm serve` dies on one WAN retransmission), #500 (no subscription liveness), #501 (unbounded wire-controlled allocations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
