### PR TITLE
Increment 0: read-side injection gate (open swarm stays open)

### DIFF
--- a/src/bin/handlers/ask.rs
+++ b/src/bin/handlers/ask.rs
@@ -244,10 +244,17 @@ pub(crate) fn handle_ask_remote(
                     let from = parsed.get("from").and_then(|v| v.as_str()).unwrap_or("?");
                     let text = parsed.get("text").and_then(|v| v.as_str())
                         .unwrap_or("(no text)");
+                    // SECURITY (increment-0): reply came from a peer over the
+                    // open swarm — sanitize the id + body before printing and
+                    // flag replies from ids not on the trusted allowlist.
+                    let from_s = kannaka_memory::sanitize_display(from);
+                    let trusted = from == cfg.agent.id
+                        || kannaka_memory::agent_matches_allowlist(from, &cfg.swarm_trust.trusted_agents);
+                    let mark = if trusted { "" } else { " (unverified)" };
                     if !quiet_tools {
-                        eprintln!("─── reply {} from {} ───", i + 1, from);
+                        eprintln!("─── reply {} from {}{} ───", i + 1, from_s, mark);
                     }
-                    println!("{}", text);
+                    println!("{}", kannaka_memory::sanitize_display(text));
                     if !quiet_tools && i + 1 < replies.len() { println!(); }
                 }
             }
@@ -261,7 +268,8 @@ pub(crate) fn handle_ask_remote(
                     .unwrap_or_else(|_| serde_json::json!({"raw": String::from_utf8_lossy(&reply)}));
                 let text = parsed.get("text").and_then(|v| v.as_str())
                     .unwrap_or("(no text)");
-                println!("{}", text);
+                // SECURITY (increment-0): wire-sourced reply body — never print raw.
+                println!("{}", kannaka_memory::sanitize_display(text));
             }
             Err(e) => { eprintln!("request_one: {e}"); process::exit(1); }
         }

--- a/src/bin/handlers/swarm.rs
+++ b/src/bin/handlers/swarm.rs
@@ -422,8 +422,17 @@ pub(crate) fn handle_swarm_exemplars(
                 let cid = e.get("cluster_id").and_then(|v| v.as_u64()).unwrap_or(0);
                 let amp = e.get("amplitude").and_then(|v| v.as_f64()).unwrap_or(0.0);
                 let content = e.get("content").and_then(|v| v.as_str()).unwrap_or("(no content)");
-                let preview: String = content.chars().take(120).collect();
-                println!("[{:3}] {} c{:<3} amp={:.3}", i + 1, agent, cid, amp);
+                // SECURITY (increment-0): agent_id + content are attacker-
+                // controllable wire strings — sanitize before printing (strip
+                // ANSI/control bytes) and flag sources not on the trusted
+                // allowlist as observe-only. Never print wire content raw.
+                let agent_s = kannaka_memory::sanitize_display(agent);
+                let trusted = agent == agent_id
+                    || kannaka_memory::agent_matches_allowlist(agent, &cfg.swarm_trust.trusted_agents);
+                let mark = if trusted { "" } else { " (unverified)" };
+                let preview: String =
+                    kannaka_memory::sanitize_display(content).chars().take(120).collect();
+                println!("[{:3}] {}{} c{:<3} amp={:.3}", i + 1, agent_s, mark, cid, amp);
                 println!("       {}", preview);
             }
             println!();
@@ -716,17 +725,26 @@ pub(crate) fn handle_swarm_peers(cfg: &KannakaConfig, args: &[String]) {
     println!("{:<24} {:<8} {:<8} {}", "AGENT", "MEMS", "VERSION", "CAPABILITIES");
     println!("{}", "─".repeat(78));
     for p in &peers {
-        let agent = p.get("agent_id").and_then(|v| v.as_str()).unwrap_or("?");
-        let display = p.get("display_name").and_then(|v| v.as_str()).unwrap_or("");
+        let agent_raw = p.get("agent_id").and_then(|v| v.as_str()).unwrap_or("?");
+        let display_raw = p.get("display_name").and_then(|v| v.as_str()).unwrap_or("");
         let mem = p.get("memory_count").and_then(|v| v.as_u64()).unwrap_or(0);
-        let ver = p.get("kannaka_version").and_then(|v| v.as_str()).unwrap_or("?");
+        let ver_raw = p.get("kannaka_version").and_then(|v| v.as_str()).unwrap_or("?");
         let caps_obj = p.get("capabilities").and_then(|v| v.as_object());
-        let caps = caps_obj
+        let caps_raw = caps_obj
             .map(|o| o.iter().filter_map(|(k, v)| if v.as_bool() == Some(true) { Some(k.as_str()) } else { None })
                 .collect::<Vec<_>>().join(","))
             .unwrap_or_default();
+        // SECURITY (increment-0): every field here is attacker-controllable
+        // wire data on the open swarm — sanitize before printing (strip
+        // ANSI/control bytes) and flag any peer whose id is not on the
+        // trusted allowlist as observe-only (` (unverified)`). Matching is on
+        // the raw id; our own id is always trusted.
+        let agent = kannaka_memory::sanitize_display(agent_raw);
+        let display = kannaka_memory::sanitize_display(display_raw);
+        let ver = kannaka_memory::sanitize_display(ver_raw);
+        let caps = kannaka_memory::sanitize_display(&caps_raw);
         let mut label = if display.is_empty() || display == agent {
-            agent.to_string()
+            agent.clone()
         } else {
             format!("{} ({})", display, agent)
         };
@@ -734,7 +752,12 @@ pub(crate) fn handle_swarm_peers(cfg: &KannakaConfig, args: &[String]) {
         // that joined while logged in via `kannaka identity` carry
         // {user_id, email} in their presence record — show the email.
         if let Some(email) = kannaka_memory::nats::AnnounceIdentity::email_from(p) {
-            label = format!("{} <{}>", label, email);
+            label = format!("{} <{}>", label, kannaka_memory::sanitize_display(email));
+        }
+        let trusted = agent_raw == cfg.agent.id
+            || kannaka_memory::agent_matches_allowlist(agent_raw, &cfg.swarm_trust.trusted_agents);
+        if !trusted {
+            label.push_str(" (unverified)");
         }
         println!("{:<24} {:<8} {:<8} {}", label, mem, ver, caps);
     }
@@ -1260,11 +1283,18 @@ pub(crate) fn handle_swarm_tail(cfg: &KannakaConfig, args: &[String]) {
                 match sub.next_event() {
                     SubEvent::Msg(msg) => {
                         let payload_str = std::str::from_utf8(&msg.payload).unwrap_or("<binary>");
+                        // SECURITY (increment-0): subject + payload are wire
+                        // data on the open swarm. A valid-JSON payload is
+                        // re-escaped by serde on output (so control bytes can't
+                        // reach the terminal raw), but the subject and the
+                        // non-JSON fallback are embedded as bare strings —
+                        // sanitize those to strip ANSI/control sequences.
                         let payload_json: serde_json::Value = serde_json::from_str(payload_str)
-                            .unwrap_or_else(|_| serde_json::Value::String(payload_str.to_string()));
+                            .unwrap_or_else(|_| serde_json::Value::String(
+                                kannaka_memory::sanitize_display(payload_str)));
                         let line = serde_json::json!({
                             "ts": chrono::Utc::now().timestamp_millis(),
-                            "subject": msg.subject,
+                            "subject": kannaka_memory::sanitize_display(&msg.subject),
                             "payload": payload_json,
                         });
                         let _guard = mu.lock();

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -4257,6 +4257,13 @@ fn main() {
                         &agent_id,
                     );
 
+                    // SECURITY (increment-0 interim; increment-1 replaces this
+                    // allowlist gate with signature+trust verification). Load the
+                    // swarm-trust config ONCE up front — the listen loop consults
+                    // it on every wire message but the config never changes for
+                    // the lifetime of the listener.
+                    let trust = cfg.swarm_trust.clone();
+
                     loop {
                         let msg = match sub.next_event() {
                             kannaka_memory::nats::SubEvent::Msg(m) => m,
@@ -4269,10 +4276,22 @@ fn main() {
                         if msg.subject.starts_with("QUEEN.phase.") {
                             if let Some(phase) = msg.as_phase() {
                                 println!("[{}] \u{03b8}={:.3} \u{03c9}={:.3} coherence={:.3} phi={:.3} memories={}",
-                                    phase.agent_id, phase.phase, phase.frequency,
+                                    kannaka_memory::sanitize_display(&phase.agent_id), phase.phase, phase.frequency,
                                     phase.coherence, phase.phi, phase.memory_count);
 
-                                if auto_sync && phase.agent_id != agent_id {
+                                // SECURITY (increment-0 interim; increment-1 replaces this
+                                // allowlist gate with signature+trust verification). Only let a
+                                // TRUSTED wire phase drive a pairwise Kuramoto sync step — self is
+                                // already excluded by `!= agent_id`; the gate is a no-op when the
+                                // escape hatch KANNAKA_METRICS_TRUSTED_ONLY=0 is set.
+                                if auto_sync
+                                    && phase.agent_id != agent_id
+                                    && kannaka_memory::wire_source_trusted(
+                                        &phase.agent_id,
+                                        &trust.trusted_agents,
+                                        trust.metrics_trusted_only,
+                                    )
+                                {
                                     let my_phase =
                                         queen.to_agent_phase(0, sys.engine.store.count(), 0);
                                     let swarm = vec![my_phase, phase];
@@ -4289,7 +4308,10 @@ fn main() {
                             if let Some(json) = msg.as_json() {
                                 let event = json["event"].as_str().unwrap_or("unknown");
                                 let agent = json["agent_id"].as_str().unwrap_or("?");
-                                println!("[announce] {} {}", agent, event);
+                                // Both fields are wire-sourced — sanitize before printing.
+                                println!("[announce] {} {}",
+                                    kannaka_memory::sanitize_display(agent),
+                                    kannaka_memory::sanitize_display(event));
                             }
                         } else if msg.subject == "KANNAKA.memory.new" && auto_sync {
                             if let Some(json) = msg.as_json() {
@@ -4308,19 +4330,24 @@ fn main() {
                                                         eprintln!("[sync] Memory {} already exists, skipping", mem_id);
                                                     }
                                                     _ => {
-                                                        match sys.engine.store.insert(mem) {
-                                                            Ok(_) => {
-                                                                println!("[sync] Imported memory {} from {}", mem_id, source_agent);
+                                                        // SECURITY (increment-0 interim; increment-1 replaces this allowlist gate with signature+trust verification)
+                                                        if kannaka_memory::wire_source_trusted(source_agent, &trust.trusted_agents, trust.metrics_trusted_only) {
+                                                            match sys.engine.store.insert(mem) {
+                                                                Ok(_) => {
+                                                                    println!("[sync] Imported memory {} from {}", mem_id, kannaka_memory::sanitize_display(source_agent));
+                                                                }
+                                                                Err(e) => {
+                                                                    eprintln!("[sync] Failed to import memory {} from {}: {}", mem_id, kannaka_memory::sanitize_display(source_agent), e);
+                                                                }
                                                             }
-                                                            Err(e) => {
-                                                                eprintln!("[sync] Failed to import memory {} from {}: {}", mem_id, source_agent, e);
-                                                            }
+                                                        } else {
+                                                            eprintln!("[sync] skip untrusted source {} (increment-0 gate)", kannaka_memory::sanitize_display(source_agent));
                                                         }
                                                     }
                                                 }
                                             }
                                             Err(e) => {
-                                                eprintln!("[sync] Failed to deserialize memory from {}: {}", source_agent, e);
+                                                eprintln!("[sync] Failed to deserialize memory from {}: {}", kannaka_memory::sanitize_display(source_agent), e);
                                             }
                                         }
                                     }
@@ -4334,8 +4361,10 @@ fn main() {
                                     let strengthened =
                                         json["memories_strengthened"].as_u64().unwrap_or(0);
                                     let pruned = json["memories_pruned"].as_u64().unwrap_or(0);
+                                    // KANNAKA.dreams is print-only (no store insert), so the wire
+                                    // source just needs sanitizing before it reaches the terminal.
                                     println!("[dream] {} completed dream: {} cycles, {} strengthened, {} pruned",
-                                        source_agent, cycles, strengthened, pruned);
+                                        kannaka_memory::sanitize_display(source_agent), cycles, strengthened, pruned);
                                 }
                             }
                         }
@@ -4358,11 +4387,37 @@ fn main() {
                     match try_nats_connect(&nats_url) {
                         Some(transport) => {
                             let nats_phases = transport.get_all_phases().unwrap_or_default();
+                            // SECURITY (increment-0): the open NATS swarm lets
+                            // anyone publish an AgentPhase. Report BOTH counts
+                            // truthfully — `peer_count` is every phase observed
+                            // on the wire (raw, unfiltered), `trusted_peer_count`
+                            // is the allowlisted (+ our own) subset that actually
+                            // feeds the sync/queen metrics — so a forged
+                            // `agent-<hex>` flood shows up as the gap between the
+                            // two instead of silently inflating one number.
+                            // Escape hatch KANNAKA_METRICS_TRUSTED_ONLY=0 makes
+                            // trusted_peer_count == peer_count.
                             peer_count = nats_phases.len();
+                            let trusted_peer_count = if cfg.swarm_trust.metrics_trusted_only {
+                                kannaka_memory::filter_wire_phases(
+                                    nats_phases,
+                                    &agent_id,
+                                    &cfg.swarm_trust.trusted_agents,
+                                    cfg.swarm_trust.wire_trust_cap,
+                                )
+                                .len()
+                            } else {
+                                peer_count
+                            };
                             nats_status = serde_json::json!({
                                 "connected": true,
                                 "url": nats_url,
+                                // `peers` kept as a back-compat alias (== raw observed)
+                                // for existing consumers; `peer_count`/`trusted_peer_count`
+                                // are the increment-0 pair.
                                 "peers": peer_count,
+                                "peer_count": peer_count,
+                                "trusted_peer_count": trusted_peer_count,
                             });
                         }
                         None => {
@@ -4404,6 +4459,20 @@ fn main() {
                     };
 
                     let nats_phases = transport.get_all_phases().unwrap_or_default();
+                    // SECURITY (increment-0): gate wire phases before they
+                    // weight the Kuramoto sync/metric — only allowlisted
+                    // (+ our own) ids count, wire trust_score capped. Escape
+                    // hatch: KANNAKA_METRICS_TRUSTED_ONLY=0.
+                    let nats_phases = if cfg.swarm_trust.metrics_trusted_only {
+                        kannaka_memory::filter_wire_phases(
+                            nats_phases,
+                            &agent_id,
+                            &cfg.swarm_trust.trusted_agents,
+                            cfg.swarm_trust.wire_trust_cap,
+                        )
+                    } else {
+                        nats_phases
+                    };
                     if nats_phases.is_empty() {
                         eprintln!(
                             "No swarm phases found via NATS. Publish first with 'swarm publish'."
@@ -4438,6 +4507,20 @@ fn main() {
                     };
 
                     let nats_phases = transport.get_all_phases().unwrap_or_default();
+                    // SECURITY (increment-0): gate wire phases before they
+                    // weight the queen metric — only allowlisted (+ our own)
+                    // ids count, wire trust_score capped. Escape hatch:
+                    // KANNAKA_METRICS_TRUSTED_ONLY=0.
+                    let nats_phases = if cfg.swarm_trust.metrics_trusted_only {
+                        kannaka_memory::filter_wire_phases(
+                            nats_phases,
+                            &agent_id,
+                            &cfg.swarm_trust.trusted_agents,
+                            cfg.swarm_trust.wire_trust_cap,
+                        )
+                    } else {
+                        nats_phases
+                    };
                     if nats_phases.is_empty() {
                         eprintln!(
                             "No swarm phases found. Run 'swarm publish' and 'swarm sync' first."
@@ -4465,6 +4548,20 @@ fn main() {
                     };
 
                     let nats_phases = transport.get_all_phases().unwrap_or_default();
+                    // SECURITY (increment-0): gate wire phases before hive
+                    // detection weights them — only allowlisted (+ our own)
+                    // ids count, wire trust_score capped. Escape hatch:
+                    // KANNAKA_METRICS_TRUSTED_ONLY=0.
+                    let nats_phases = if cfg.swarm_trust.metrics_trusted_only {
+                        kannaka_memory::filter_wire_phases(
+                            nats_phases,
+                            &agent_id,
+                            &cfg.swarm_trust.trusted_agents,
+                            cfg.swarm_trust.wire_trust_cap,
+                        )
+                    } else {
+                        nats_phases
+                    };
                     if nats_phases.is_empty() {
                         eprintln!(
                             "No swarm phases found. Run 'swarm publish' and 'swarm sync' first."

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,8 @@ pub struct KannakaConfig {
     pub coupling: CouplingConfig,
     #[serde(default = "EntropyConfig::default")]
     pub entropy: EntropyConfig,
+    #[serde(default = "SwarmTrustConfig::default")]
+    pub swarm_trust: SwarmTrustConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,6 +199,54 @@ fn default_entropy_source() -> String {
     "prng".to_string()
 }
 
+/// SECURITY (increment-0): read-side trust gate for the OPEN NATS swarm.
+/// Anonymous publish stays allowed, so the read side must not trust
+/// attacker-controlled wire fields. `trusted_agents` is an allowlist of
+/// agent-ids — each entry is either an exact id or a `prefix*` wildcard
+/// (e.g. `"qos-*"`). When `metrics_trusted_only` is set (default), only
+/// allowlisted (plus this node's own) phases feed the swarm metrics, and
+/// every kept phase has its wire `trust_score` clamped to `wire_trust_cap`.
+/// env: `KANNAKA_TRUSTED_AGENTS` (comma-separated, REPLACES the list) and
+/// `KANNAKA_METRICS_TRUSTED_ONLY=0` (disable the metrics filter — escape hatch).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmTrustConfig {
+    #[serde(default = "default_trusted_agents")]
+    pub trusted_agents: Vec<String>,
+    #[serde(default = "default_true")]
+    pub metrics_trusted_only: bool,
+    #[serde(default = "default_wire_trust_cap")]
+    pub wire_trust_cap: f32,
+}
+
+impl Default for SwarmTrustConfig {
+    fn default() -> Self {
+        Self {
+            trusted_agents: default_trusted_agents(),
+            metrics_trusted_only: true,
+            wire_trust_cap: default_wire_trust_cap(),
+        }
+    }
+}
+
+fn default_trusted_agents() -> Vec<String> {
+    [
+        "Kannaka",
+        "kannaka-prime",
+        "0xSCADA-QE",
+        "kannaka-witness-01",
+        "kannaktopus-01",
+        "Flaukowski",
+        "qos-*",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+fn default_wire_trust_cap() -> f32 {
+    0.5
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -334,6 +384,7 @@ impl Default for KannakaConfig {
             cluster: ClusterConfig::default(),
             coupling: CouplingConfig::default(),
             entropy: EntropyConfig::default(),
+            swarm_trust: SwarmTrustConfig::default(),
         }
     }
 }
@@ -439,6 +490,24 @@ impl KannakaConfig {
         if let Ok(v) = std::env::var("KANNAKA_OBSERVATORY_URL") { self.constellation.observatory_url = v; }
         if let Ok(v) = std::env::var("KANNAKA_GHOSTSIGNALS_HUB_URL") { self.ghostsignals.hub_url = v; }
         if let Ok(v) = std::env::var("KANNAKA_GHOSTSIGNALS_TOKEN") { self.ghostsignals.token = v; }
+        // SECURITY (increment-0): swarm-trust overrides. KANNAKA_TRUSTED_AGENTS
+        // is a comma-separated allowlist that REPLACES the default list (empty
+        // entries dropped, whitespace trimmed; an all-empty value trusts only
+        // this node's own id). KANNAKA_METRICS_TRUSTED_ONLY=0 (or false/no/off)
+        // disables the metrics filter — the escape hatch.
+        if let Ok(v) = std::env::var("KANNAKA_TRUSTED_AGENTS") {
+            self.swarm_trust.trusted_agents = v
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+        }
+        if let Ok(v) = std::env::var("KANNAKA_METRICS_TRUSTED_ONLY") {
+            let v = v.trim().to_ascii_lowercase();
+            self.swarm_trust.metrics_trusted_only =
+                !matches!(v.as_str(), "0" | "false" | "no" | "off");
+        }
     }
 
     /// Load the on-disk config WITHOUT applying environment overrides.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub use paradox::{
 };
 
 pub use queen::{QueenSync, QueenConfig, QueenState, AgentPhase, Hive, HiveInfo, Handedness, SwarmAgent, PartitionPhiResult};
+pub use queen::{filter_wire_phases, sanitize_display, agent_matches_allowlist, wire_source_trusted};
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 
     compute_irrationality, compute_invariant_metrics, cluster_by_delta, delta_distance

--- a/src/queen.rs
+++ b/src/queen.rs
@@ -1020,6 +1020,126 @@ impl QueenSync {
 }
 
 // ---------------------------------------------------------------------------
+// Wire-trust gate (increment-0)
+// ---------------------------------------------------------------------------
+//
+// The swarm runs on an OPEN NATS bus: anyone may publish an `AgentPhase`.
+// A confirmed attacker forges phases with `trust_score: 1.0`, fake
+// `coherence`, and throwaway `agent-<hex>` ids to steer the READ side —
+// the Kuramoto metrics weight `trust_score * coherence` straight off the
+// wire, and the display prints wire strings verbatim. These helpers are the
+// read-side gate: they DO NOT change the write/absorb path and add no crypto.
+
+/// Return true if `agent_id` matches the trusted allowlist. Each entry is
+/// either an exact agent-id or a `prefix*` wildcard (an entry ending in
+/// `*` matches any id starting with the text before it, e.g. `"qos-*"`).
+pub fn agent_matches_allowlist(agent_id: &str, trusted: &[String]) -> bool {
+    trusted.iter().any(|t| match t.strip_suffix('*') {
+        Some(prefix) => agent_id.starts_with(prefix),
+        None => agent_id == t,
+    })
+}
+
+/// Decide whether a wire-sourced peer may cross the trust boundary — i.e.
+/// drive a pairwise sync step or have its memory absorbed into the store.
+///
+/// SECURITY (increment-0 interim; increment-1 replaces this allowlist gate
+/// with signature+trust verification). Returns `true` iff the metrics-trust
+/// filter is disabled (`metrics_trusted_only == false`, the escape hatch
+/// `KANNAKA_METRICS_TRUSTED_ONLY=0`) OR `source_id` is on the allowlist.
+/// Callers must exclude their own id first — self-trust is a separate concern.
+pub fn wire_source_trusted(source_id: &str, trusted: &[String], metrics_trusted_only: bool) -> bool {
+    !metrics_trusted_only || agent_matches_allowlist(source_id, trusted)
+}
+
+/// Gate a set of wire-sourced phases before they feed the swarm metrics.
+///
+/// A phase is kept iff its `agent_id` is this node's own id (`self_id`,
+/// always trusted) OR it matches the allowlist. Every kept phase then has
+/// its attacker-controllable fields clamped: `trust_score` to
+/// `[0, trust_cap]` and `coherence` to `[0, 1]`. This neutralizes a forged
+/// `trust_score: 1.0` / `coherence: 1.0` flood — the throwaway ids are
+/// dropped entirely and any surviving allowlisted phase cannot exceed the
+/// trust cap on the wire.
+pub fn filter_wire_phases(
+    phases: Vec<AgentPhase>,
+    self_id: &str,
+    trusted: &[String],
+    trust_cap: f32,
+) -> Vec<AgentPhase> {
+    phases
+        .into_iter()
+        .filter(|p| p.agent_id == self_id || agent_matches_allowlist(&p.agent_id, trusted))
+        .map(|mut p| {
+            p.trust_score = p.trust_score.clamp(0.0, trust_cap);
+            p.coherence = p.coherence.clamp(0.0, 1.0);
+            p
+        })
+        .collect()
+}
+
+/// Make a wire-sourced string safe to print to a terminal.
+///
+/// Strips ANSI/OSC escape sequences (CSI `\x1b[…`, OSC `\x1b]…`) and all
+/// C0/C1 control characters (including `\n`, `\t`, `\r`, DEL and the C1
+/// range) — mapping them to nothing — so a forged `agent_id`, email, or
+/// memory body cannot move the cursor, recolor the terminal, or inject
+/// control codes. The result is truncated to 2000 characters with an
+/// ellipsis. Content from the wire must never be printed raw.
+pub fn sanitize_display(s: &str) -> String {
+    const MAX_CHARS: usize = 2000;
+    let mut out = String::with_capacity(s.len().min(MAX_CHARS + 4));
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\x1b' => match chars.peek() {
+                // CSI: ESC '[' params… final-byte in 0x40..=0x7E
+                Some('[') => {
+                    chars.next();
+                    while let Some(&p) = chars.peek() {
+                        chars.next();
+                        if ('\x40'..='\x7e').contains(&p) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ']' … terminated by BEL (0x07) or ST (ESC '\')
+                Some(']') => {
+                    chars.next();
+                    while let Some(&p) = chars.peek() {
+                        if p == '\x07' {
+                            chars.next();
+                            break;
+                        }
+                        if p == '\x1b' {
+                            chars.next();
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                        chars.next();
+                    }
+                }
+                // Lone ESC or other escape form: drop the ESC introducer only.
+                _ => {}
+            },
+            // Drop C0 controls (0x00-0x1F) and DEL/C1 (0x7F-0x9F).
+            c if (c as u32) < 0x20 => {}
+            c if (0x7f..=0x9f).contains(&(c as u32)) => {}
+            c => out.push(c),
+        }
+    }
+    if out.chars().count() > MAX_CHARS {
+        let mut truncated: String = out.chars().take(MAX_CHARS).collect();
+        truncated.push('\u{2026}');
+        truncated
+    } else {
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
 // NATS-augmented sync
 // ---------------------------------------------------------------------------
 
@@ -1047,6 +1167,25 @@ impl QueenSync {
                 warning = Some(format!("NATS read failed, using persistent phases only: {}", e));
                 vec![]
             }
+        };
+
+        // SECURITY (increment-0): gate wire phases before they are merged for
+        // the metric. Open NATS lets anyone publish an AgentPhase, so only
+        // allowlisted (+ our own) ids may weight the Kuramoto order parameter /
+        // Phi, and their wire trust_score is capped. `self.agent_id` is always
+        // trusted. Escape hatch: KANNAKA_METRICS_TRUSTED_ONLY=0. The trusted
+        // config is read here (rather than threaded through the signature) to
+        // keep this method's public API unchanged.
+        let trust_cfg = crate::config::KannakaConfig::load().swarm_trust;
+        let nats_phases = if trust_cfg.metrics_trusted_only {
+            filter_wire_phases(
+                nats_phases,
+                &self.agent_id,
+                &trust_cfg.trusted_agents,
+                trust_cfg.wire_trust_cap,
+            )
+        } else {
+            nats_phases
         };
 
         // 2. Merge: NATS phases override persistent phases (more recent)
@@ -1682,5 +1821,112 @@ mod tests {
     fn format_hive_topology_empty() {
         let output = QueenSync::format_hive_topology(&[]);
         assert!(output.contains("No hives detected"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Wire-trust gate tests (increment-0)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn agent_matches_allowlist_exact_and_prefix() {
+        let trusted = vec!["Kannaka".to_string(), "qos-*".to_string()];
+        assert!(agent_matches_allowlist("Kannaka", &trusted)); // exact
+        assert!(agent_matches_allowlist("qos-alpha", &trusted)); // prefix
+        assert!(agent_matches_allowlist("qos-", &trusted)); // prefix boundary
+        assert!(!agent_matches_allowlist("kannaka", &trusted)); // case-sensitive
+        assert!(!agent_matches_allowlist("agent-deadbeef", &trusted)); // forged
+        assert!(!agent_matches_allowlist("qo", &trusted)); // not long enough for prefix
+    }
+
+    #[test]
+    fn wire_source_trusted_gate_decision() {
+        let trusted = vec!["Kannaka".to_string(), "qos-*".to_string()];
+        // metrics_trusted_only = true (default): only allowlisted sources pass
+        // the gate (pairwise sync + absorb both use this decision).
+        assert!(wire_source_trusted("Kannaka", &trusted, true)); // exact
+        assert!(wire_source_trusted("qos-beta", &trusted, true)); // prefix
+        assert!(!wire_source_trusted("agent-deadbeef", &trusted, true)); // forged
+        assert!(!wire_source_trusted("attacker-1", &trusted, true)); // forged
+        // metrics_trusted_only = false (escape hatch): every source passes.
+        assert!(wire_source_trusted("agent-deadbeef", &trusted, false));
+        assert!(wire_source_trusted("Kannaka", &trusted, false));
+    }
+
+    #[test]
+    fn filter_wire_phases_drops_untrusted_keeps_self_and_caps() {
+        let trusted = crate::config::SwarmTrustConfig::default().trusted_agents;
+        let self_id = "my-node-xyz"; // deliberately NOT on the allowlist
+        let phases = vec![
+            make_agent_phase("Kannaka", 0.1, 1.0, 1.0),        // allowlisted (exact)
+            make_agent_phase("qos-alpha", 0.2, 1.0, 1.0),      // allowlisted (prefix qos-*)
+            make_agent_phase("my-node-xyz", 0.3, 0.8, 0.4),    // self
+            make_agent_phase("agent-deadbeef", 0.4, 1.0, 1.0), // forged -> dropped
+            make_agent_phase("attacker-1", 0.5, 1.0, 1.0),     // forged -> dropped
+        ];
+        let kept = filter_wire_phases(phases, self_id, &trusted, 0.5);
+        let ids: Vec<&str> = kept.iter().map(|p| p.agent_id.as_str()).collect();
+        assert!(ids.contains(&"Kannaka"));
+        assert!(ids.contains(&"qos-alpha"), "prefix match qos-* must keep qos-alpha");
+        assert!(ids.contains(&"my-node-xyz"), "self must always be kept");
+        assert!(!ids.contains(&"agent-deadbeef"), "forged id must be dropped");
+        assert!(!ids.contains(&"attacker-1"), "forged id must be dropped");
+        assert_eq!(kept.len(), 3);
+        // Wire trust_score is capped at the trust_cap for every kept phase.
+        for p in &kept {
+            assert!(p.trust_score <= 0.5 + 1e-6, "trust not capped: {} {}", p.agent_id, p.trust_score);
+            assert!(p.coherence <= 1.0 + 1e-6);
+        }
+        // "Kannaka" published trust_score=1.0 on the wire -> must be clamped to 0.5.
+        let kannaka = kept.iter().find(|p| p.agent_id == "Kannaka").unwrap();
+        assert!((kannaka.trust_score - 0.5).abs() < 1e-6, "cap not applied: {}", kannaka.trust_score);
+    }
+
+    #[test]
+    fn filter_wire_phases_metrics_invariant_under_forged_flood() {
+        let trusted = crate::config::SwarmTrustConfig::default().trusted_agents;
+        let self_id = "legit-self-node"; // not on allowlist -> kept only via self_id
+        let self_phase = make_agent_phase(self_id, 0.7, 0.9, 0.5);
+
+        // 48 forged phases: throwaway ids, maxed-out wire trust/coherence.
+        let mut forged: Vec<AgentPhase> = (0..48u32)
+            .map(|i| make_agent_phase(&format!("agent-{:08x}", 0xdead_0000u32 + i), i as f32 * 0.13, 1.0, 1.0))
+            .collect();
+        // The swarm as read off the wire: forged flood + our own legit phase.
+        forged.push(self_phase.clone());
+
+        let filtered = filter_wire_phases(forged, self_id, &trusted, 0.5);
+        assert_eq!(filtered.len(), 1, "only the self phase should survive the flood");
+
+        // Metrics over the filtered set must equal metrics over just [self].
+        let baseline = vec![self_phase.clone()];
+        let (r_f, psi_f) = QueenSync::compute_order_parameter(&filtered);
+        let (r_b, psi_b) = QueenSync::compute_order_parameter(&baseline);
+        assert!((r_f - r_b).abs() < 1e-6, "order parameter moved: {} vs {}", r_f, r_b);
+        assert!((psi_f - psi_b).abs() < 1e-6, "mean phase moved: {} vs {}", psi_f, psi_b);
+
+        let phi_f = QueenSync::compute_swarm_phi(&filtered, r_f);
+        let phi_b = QueenSync::compute_swarm_phi(&baseline, r_b);
+        assert!((phi_f - phi_b).abs() < 1e-6, "phi moved: {} vs {}", phi_f, phi_b);
+    }
+
+    #[test]
+    fn sanitize_display_strips_ansi_and_controls_and_truncates() {
+        // ANSI color, BEL, embedded newline + tab, ANSI reset.
+        let dirty = "\x1b[31mRED\x07\nnext\tline\x1b[0m done";
+        let clean = sanitize_display(dirty);
+        assert!(!clean.contains('\x1b'), "ESC survived: {:?}", clean);
+        assert!(!clean.contains('\x07'), "BEL survived: {:?}", clean);
+        assert!(!clean.contains('\n'), "newline survived: {:?}", clean);
+        assert!(!clean.contains('\t'), "tab survived: {:?}", clean);
+        assert_eq!(clean, "REDnextline done");
+
+        // OSC (window-title injection) is stripped whole.
+        assert_eq!(sanitize_display("\x1b]0;pwned\x07visible"), "visible");
+
+        // Over-long input is capped to 2000 chars + a single ellipsis.
+        let long = "a".repeat(5000);
+        let truncated = sanitize_display(&long);
+        assert_eq!(truncated.chars().count(), 2001);
+        assert!(truncated.ends_with('\u{2026}'));
     }
 }


### PR DESCRIPTION
Part of a sequenced defense for the **open** swarm (anonymous publish stays open by design — this hardens the absorb/read side). Prompted by a confirmed third-party injector (a cloud VM spoofing dozens of agent identities to inject content + forged `trust_score`/`consciousness`).

**What**
- `SwarmTrustConfig` allowlist (exact / `prefix*`), `metrics_trusted_only` (default on), `wire_trust_cap`; env `KANNAKA_TRUSTED_AGENTS`, `KANNAKA_METRICS_TRUSTED_ONLY=0`.
- `filter_wire_phases` (keep self ∨ allowlisted; clamp wire `trust_score`/`coherence`) gates order-parameter / Φ / hive metrics — a forged 48-id flood can no longer move Φ/order (unit-tested).
- `sanitize_display` (strip CSI/OSC/C0/C1 + truncate) on peers / exemplars / tail / ask; non-allowlisted tagged `(unverified)`.
- `swarm status` reports `peer_count` (observed) + `trusted_peer_count`; `peers` kept as a back-compat alias.
- `swarm listen --auto-sync`: interim allowlist gate on the pairwise sync **and** the previously-ungated `KANNAKA.memory.new` `store.insert` (a third absorb path).

**Not in scope (Increment 1):** ed25519 signatures, Sybil-resistant enrollment, persisted provenance, a single fail-closed absorb chokepoint over all three absorb paths. This PR is allowlist-based interim hardening (no crypto).

710 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
