### PR TITLE
Reconcile NATS config with deployed anon ACL + drift check

### DIFF
--- a/config/nats-server.conf
+++ b/config/nats-server.conf
@@ -1,101 +1,105 @@
-# NATS Server Configuration for QueenSync (QS-8, #59)
-# Deploy to: swarm.ninja-portal.com
+# NATS Server Configuration — Kannaka constellation swarm
+# Deploy target: swarm.ninja-portal.com  (:4222 native, :4223 websocket via nginx wss)
 #
-# TLS Setup (MANUAL):
-#   1. Obtain certificates (Let's Encrypt recommended):
-#      certbot certonly --standalone -d swarm.ninja-portal.com
-#   2. Copy certs to /etc/nats/certs/
-#   3. Uncomment the tls block below
-#   4. Restart: sudo systemctl restart nats-server
+# RECONCILED 2026-07-06 to match the DEPLOYED /etc/nats/nats.conf. The prior
+# committed baseline had drifted NARROWER than production: `anon` was
+# deliberately widened on the live server (a while back) to allow open
+# memory-sharing — KANNAKA.events.>, KANNAKA.memory.new, KANNAKA.consciousness,
+# KANNAKA.substrate.absorb.>. Deploying the old baseline would have REVERTED
+# that widening and broken the open swarm + legitimate anon memory-sharing.
+# This file now reflects deployed reality so a deploy is a no-op.
+#
+# SECRETS ARE PLACEHOLDERS. Real passwords are injected at deploy time
+# (NATS_USER + NATS_PASSWORD in the systemd unit / env). NEVER commit real
+# credentials to this file.
+#
+# SECURITY POSTURE: publish is intentionally OPEN — any anon peer may publish
+# phase/presence/memory/consciousness events. Protection is ABSORB-SIDE in the
+# kannaka client (branch feat/absorb-gate-increment0: nodes gate what they
+# internalize and how they weight wire metrics). A future SERVER-side tightening
+# (a separate `KANNAKA.events.untrusted.>` publish lane with a deny on the
+# trusted lane) is tracked as the L3 increment. Do NOT narrow `anon` here
+# without that lane — it would cut off legitimate anon nodes.
 
-# Server identity
+listen: 0.0.0.0:4222
 server_name: "kannaka-queen"
 
-# Listen on standard port
-port: 4222
+# Max payload — shared wavefronts can be large (matches deployed 64MB).
+max_payload: 64MB
 
-# HTTP monitoring endpoint (private — bind to localhost)
-http_port: 8222
+# HTTP monitoring is OFF in production today. Uncomment — BOUND TO LOCALHOST —
+# to restore /connz and /varz for connection tracing (never expose publicly;
+# `http_port: 8222` alone binds all interfaces, so use the host:port form):
+# http: "127.0.0.1:8222"
 
-# Max connections per client
-max_connections: 256
+# Optional server log (deployed server currently logs to journald/none):
+# logfile: "/var/log/nats/nats-server.log"
+# logfile_size_limit: 104857600
 
-# Max payload (1MB — shared wavefronts can be large)
-max_payload: 1048576
-
-# Client connection idle timeout
-ping_interval: "2m"
-ping_max: 2
-
-# Authorization — public anon user with swarm-join perms + privileged
-# internal user with full access. The "anon" user is what the public
-# `kannaka swarm join` CLI lands as (no_auth_user: anon below). It can
-# publish phase/presence/join events so visiting nodes show up in the
-# /player swarm visualization, and subscribe to QUEEN.> so it can read
-# the constellation back. The "kannaka_internal" user is used by the
-# kannaka-radio service and other server-side processes that need
-# full pub/sub (set NATS_USER + NATS_PASSWORD in their systemd unit).
 no_auth_user: anon
 
+# Authorization — open anon mirror + privileged internal user.
+#   anon             : what the public `kannaka swarm join` CLI lands as
+#                      (no_auth_user maps unauthenticated clients here). OPEN
+#                      publish for swarm participation + memory-sharing.
+#   kannaka_internal : server-side services (kannaka-radio, etc.); full pub/sub.
+#                      Set NATS_USER + NATS_PASSWORD in the systemd unit.
 authorization {
   users = [
     {
       user: anon
-      password: anon
+      password: "SET_VIA_DEPLOY"   # placeholder; no_auth_user makes the value moot for unauth clients
       permissions: {
         publish: {
           allow: [
-            "KANNAKA.ask.>",
-            "_INBOX.>", "_INBOX.req.>", "_INBOX.reqm.>",
-            "$JS.API.STREAM.MSG.GET.>",
-            # Swarm join — anyone can declare presence and publish phase.
-            "QUEEN.phase.>", "QUEEN.announce", "QUEEN.event.>",
-            "KANNAKA.presence.>",
-            "queen.event.>"
+            "KANNAKA.events.>", "KANNAKA.activity.>", "KANNAKA.snapshots.>",
+            "KANNAKA.memory.new", "KANNAKA.consciousness",
+            "KANNAKA.substrate.phi", "KANNAKA.substrate.absorb.>", "KANNAKA.substrate.recall",
+            "KANNAKA.ask.>", "KANNAKA.presence.>", "KANNAKA.cores.>",
+            "QUEEN.phase.>", "QUEEN.announce", "QUEEN.event.>", "queen.event.>",
+            "$JS.API.STREAM.CREATE.>", "$JS.API.STREAM.UPDATE.>", "$JS.API.STREAM.MSG.GET.>",
+            "_INBOX.>", "_INBOX.req.>", "_INBOX.reqm.>"
           ]
         }
         subscribe: {
           allow: [
-            "QUEEN.>",
-            "KANNAKA.consciousness", "KANNAKA.dreams",
-            "KANNAKA.exemplar.>", "KANNAKA.presence.>",
-            "_INBOX.>"
+            "KANNAKA.events.>", "KANNAKA.activity.>", "KANNAKA.snapshots.>",
+            "KANNAKA.substrate.>", "KANNAKA.consciousness", "KANNAKA.dreams",
+            "KANNAKA.exemplar.>", "KANNAKA.cores.>", "KANNAKA.presence.>",
+            "QUEEN.>", "_INBOX.>"
           ]
         }
       }
     }
     {
       user: kannaka_internal
-      password: "CHANGE_ME_TO_A_STRONG_PASSWORD"
+      password: "CHANGE_ME_TO_A_STRONG_PASSWORD"   # placeholder — inject the real value at deploy
       permissions: {
-        publish: { allow: [">"] }
+        publish: { allow: ["KANNAKA.substrate.absorb.>", "KANNAKA.substrate.recall", ">"] }
         subscribe: { allow: [">"] }
       }
     }
   ]
 }
 
-# TLS Configuration (uncomment after obtaining certs)
+# WebSocket listener — nginx terminates TLS at wss://swarm.ninja-portal.com/nats
+# and proxies here for browser/JS clients (matches deployed).
+websocket {
+  port: 4223
+  no_tls: true
+  no_auth_user: anon
+}
+
+# JetStream — persistent storage for phases/events/wavefronts (matches deployed).
+jetstream {
+  store_dir: "/var/lib/nats/jetstream"
+  max_mem: 1G
+  max_file: 10G
+}
+
+# TLS on native :4222 is handled by nginx for wss; uncomment for direct TLS:
 # tls {
 #   cert_file: "/etc/nats/certs/fullchain.pem"
 #   key_file: "/etc/nats/certs/privkey.pem"
 #   timeout: 2
-#   # Require TLS for all client connections
-#   verify: false
 # }
-
-# JetStream — persistent storage for phases, events, shared wavefronts
-jetstream {
-  store_dir: "/var/lib/nats/jetstream"
-  max_mem: 128MB
-  max_file: 1GB
-}
-
-# Rate limiting per client
-max_pending: 67108864
-
-# Logging
-logfile: "/var/log/nats/nats-server.log"
-logfile_size_limit: 104857600
-debug: false
-trace: false

--- a/scripts/check-nats-drift.sh
+++ b/scripts/check-nats-drift.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check-nats-drift.sh — detect drift between the committed NATS config and the
+# DEPLOYED /etc/nats/nats.conf on the swarm host.
+#
+# It compares only the authorization ACL (the publish/subscribe subject
+# allow-lists) with all secrets REDACTED — it never prints or diffs passwords.
+# Exit 0 = no ACL drift, exit 1 = drift (printed), exit 2 = usage/connection error.
+#
+# Why: `anon` on the live server was deliberately widened for the open swarm
+# (KANNAKA.events.>, memory.new, consciousness, substrate.absorb). If the
+# committed baseline ever drifts narrower again, deploying it would silently
+# revert that widening and break the swarm. Run this in cron/CI to catch it.
+#
+# Usage:
+#   SWARM_SSH="opc@170.9.238.136" \
+#   SWARM_KEY="$HOME/.ssh/ninja-portal-ed25519" \
+#   scripts/check-nats-drift.sh
+#
+# CI note: requires SSH reach to the swarm host (SWARM_SSH/SWARM_KEY as secrets).
+# If the runner cannot reach it, run this as a scheduled job on a host that can.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+COMMITTED="$HERE/config/nats-server.conf"
+SSH_TGT="${SWARM_SSH:-}"
+SSH_KEY="${SWARM_KEY:-$HOME/.ssh/ninja-portal-ed25519}"
+REMOTE_CONF="${REMOTE_CONF:-/etc/nats/nats.conf}"
+
+[ -f "$COMMITTED" ] || { echo "error: committed config not found: $COMMITTED" >&2; exit 2; }
+[ -n "$SSH_TGT" ] || { echo "error: set SWARM_SSH=user@host" >&2; exit 2; }
+
+# Redact any secret-bearing value before anything is printed or compared.
+redact() { sed -E 's/(password|token|seed|nkey)([[:space:]]*[:=][[:space:]]*)("?)[^"[:space:]]+/\1\2\3REDACTED/Ig'; }
+# Extract the set of quoted subject tokens (the ACL surface), sorted + unique.
+acl() { grep -oE '"(KANNAKA|QUEEN|queen|_INBOX|\$JS)[^"]*"' | sort -u; }
+
+LIVE="$(ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=12 -o StrictHostKeyChecking=accept-new \
+          "$SSH_TGT" "sudo -n cat '$REMOTE_CONF' 2>/dev/null || cat '$REMOTE_CONF'")" \
+  || { echo "error: could not read $REMOTE_CONF on $SSH_TGT" >&2; exit 2; }
+
+if diff -u \
+     <(redact < "$COMMITTED" | acl) \
+     <(printf '%s\n' "$LIVE" | redact | acl) ; then
+  echo "OK: committed config/nats-server.conf ACL matches deployed $REMOTE_CONF."
+  exit 0
+else
+  echo "" >&2
+  echo "DRIFT: committed nats-server.conf ACL differs from deployed (diff above:" >&2
+  echo "  '-' = committed only, '+' = live only). Reconcile before any deploy." >&2
+  exit 1
+fi


### PR DESCRIPTION
The committed `config/nats-server.conf` had drifted **narrower** than the deployed server: `anon` was intentionally widened in production for open memory-sharing (`KANNAKA.events.>`, `KANNAKA.memory.new`, `KANNAKA.consciousness`, `KANNAKA.substrate.absorb.>`) but never committed back. Deploying the stale baseline would have **reverted** that widening and broken the open swarm.

- Config now reflects deployed reality (widened anon ACL, `:4223` websocket, 64MB payload, 1G/10G jetstream). **Secrets remain placeholders** — injected at deploy.
- `scripts/check-nats-drift.sh`: redacted ACL drift-check (subject allow-lists only, never secrets) for cron/CI.
- Validated with `nats-server -t`.

Publish stays open by design; protection is absorb-side. A server-side untrusted-lane split (L3) is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
