### PR TITLE
[auto-maintainer] refactor(cli): inline format args (clippy::uninlined_format_args)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -522,12 +522,12 @@ fn resolve_plugin(verb: &str, args: Vec<String>) -> Dispatch {
         .iter()
         .find(|(alias, _)| *alias == verb)
         .map(|(_, real)| (*real).to_string())
-        .unwrap_or_else(|| format!("kannaka-{}", verb));
+        .unwrap_or_else(|| format!("kannaka-{verb}"));
 
     match which::which(OsStr::new(&target_name)) {
         Ok(path) => Dispatch::Plugin { binary: path, args },
         Err(_) => {
-            eprintln!("error: '{}' is not a kannaka subcommand and no plugin '{}' was found on PATH", verb, target_name);
+            eprintln!("error: '{verb}' is not a kannaka subcommand and no plugin '{target_name}' was found on PATH");
             eprintln!();
             eprintln!("Try:");
             eprintln!("  kannaka --help          # built-in subcommands");
@@ -550,7 +550,7 @@ fn print_plugins() {
     for (verb, target) in KNOWN_ALIASES {
         if let Ok(p) = which::which(OsStr::new(target)) {
             if seen.insert(target.to_string()) {
-                rows.push((format!("kannaka {}", verb), p.display().to_string()));
+                rows.push((format!("kannaka {verb}"), p.display().to_string()));
             }
         }
     }
@@ -586,7 +586,7 @@ fn print_plugins() {
                 let Some(suffix) = stem.strip_prefix("kannaka-") else { continue };
                 if suffix.is_empty() { continue; }
                 if seen.insert(stem.clone()) {
-                    rows.push((format!("kannaka {}", suffix), ent.path().display().to_string()));
+                    rows.push((format!("kannaka {suffix}"), ent.path().display().to_string()));
                 }
             }
         }
@@ -596,14 +596,14 @@ fn print_plugins() {
         println!("  (none — install a kannaka-* binary or one of the aliased targets)");
         println!();
         for (verb, target) in KNOWN_ALIASES {
-            println!("  alias 'kannaka {}' would exec '{}' (not on PATH)", verb, target);
+            println!("  alias 'kannaka {verb}' would exec '{target}' (not on PATH)");
         }
         return;
     }
 
     rows.sort();
     for (verb, path) in rows {
-        println!("  {:<28} {}", verb, path);
+        println!("  {verb:<28} {path}");
     }
 }
 
@@ -801,7 +801,7 @@ pub fn print_envelope(command: &str, data: serde_json::Value) {
         "data": data,
         "errors": [],
     });
-    println!("{}", env);
+    println!("{env}");
 }
 
 /// Same as `print_envelope` but with a single error attached.
@@ -817,7 +817,7 @@ pub fn print_envelope_error(command: &str, error_message: impl Into<String>) {
         "data": serde_json::Value::Null,
         "errors": [error_message.into()],
     });
-    println!("{}", env);
+    println!("{env}");
 }
 
 /// Exec the plugin binary, inheriting stdio so the operator sees the


### PR DESCRIPTION
## What changed

8 `format!("{}", x)` / `println!("{}", x)` / `eprintln!("{}", x)` call sites in `src/cli.rs` replaced with the idiomatic inline-capture form required by `clippy::uninlined_format_args`.

| Location | Before | After |
|----------|--------|-------|
| `resolve_plugin` L525 | `format!("kannaka-{}", verb)` | `format!("kannaka-{verb}")` |
| `resolve_plugin` L530 | `eprintln!("error: '{}' … '{}'", verb, target_name)` | `eprintln!("error: '{verb}' … '{target_name}'")` |
| `print_plugins` L553 (alias loop) | `format!("kannaka {}", verb)` | `format!("kannaka {verb}")` |
| `print_plugins` L589 (PATH loop) | `format!("kannaka {}", suffix)` | `format!("kannaka {suffix}")` |
| `print_plugins` L599 (empty case) | `println!("  alias … '{}' … '{}'", verb, target)` | `println!("  alias … '{verb}' … '{target}'")` |
| `print_plugins` L606 (rows loop) | `println!("  {:<28} {}", verb, path)` | `println!("  {verb:<28} {path}")` |
| `print_envelope` L804 | `println!("{}", env)` | `println!("{env}")` |
| `print_envelope_error` L820 | `println!("{}", env)` | `println!("{env}")` |

**Skipped (not inlinable — Clippy does not flag these):**

| Location | Reason |
|----------|--------|
| `exec_plugin` L833, L845 | `binary.display()` — method call |
| `handle_update` L624, L631 | `crate::config::VERSION` — const path expression |

## Why it's safe

The Rust Reference §[Format String Syntax](https://doc.rust-lang.org/std/fmt/index.html) guarantees `format!("{x}")` and `format!("{}", x)` are syntactically equivalent and expand to identical machine code. All 8 capture targets are simple local variables or function parameters — none are expressions. The width specifier `{verb:<28}` is preserved exactly.

This continues the series already open against this repo:
- PR #510 (open): `src/queen.rs` — 18 fixes
- PR #511 (open): `src/nats.rs` — 47 fixes

## Verification

`cargo check` and `cargo clippy --no-deps` cannot be run locally because the path dependencies `consciousness-core` and `kannaka-attention` (declared as `{ path = "../consciousness-core" }` in `Cargo.toml`) are absent from this workspace — same constraint as PRs #510 and #511.

The changes are provably safe by the Rust specification: purely syntactic with no logic paths touched. All format string literals are preserved character-for-character; only the argument position syntax changes.

Diff: 1 file, +8 −8 lines.

---
_Auto-maintainer run · 2026-07-07T22:14 UTC · kannaka-memory_

---
_Generated by [Claude Code](https://claude.ai/code/session_013qXEh6ytEKQ4MZr6FjiV77)_