### PR TITLE
Increment 1: behavior-based (corroboration) absorb-side trust — dormant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +487,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +575,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -640,6 +714,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1017,6 +1097,7 @@ dependencies = [
  "consciousness-core",
  "ctrlc",
  "dirs",
+ "ed25519-dalek",
  "flate2",
  "image",
  "kannaka-attention",
@@ -1025,6 +1106,7 @@ dependencies = [
  "ndarray",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rayon",
  "rubato",
  "rustfft",
@@ -1317,6 +1399,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "png"
@@ -1620,6 +1712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1892,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,15 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 bincode = "1"
 ndarray = { version = "0.15", optional = true }
-blake3 = { version = "1.5", optional = true }
+# blake3 is UNCONDITIONAL (was `optional`, gated under the `hrm` feature):
+# content hashing runs on the non-hrm-gated provenance path (canonical_mem /
+# canonical_phase bind blake3(content)). Keep it always available.
+blake3 = "1.5"
+# ed25519 provenance substrate (inc-1a): sign/verify swarm memory + phase
+# provenance, node key at rest. std for Error impls, rand_core for keygen,
+# zeroize to scrub the signing key on drop.
+ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core", "zeroize"] }
+rand_core = "0.6"
 rayon = "1"
 clap = { version = "4.0", features = ["derive"] }
 # `clap_complete` generates bash / zsh / fish / PowerShell / elvish
@@ -86,7 +94,7 @@ audio = []
 video = ["image"]
 glyph = []
 collective = []  # rayon is now unconditional
-hrm = ["ndarray", "blake3"]
+hrm = ["ndarray"]  # blake3 promoted to an unconditional dependency (inc-1a)
 # tui feature removed in v0.5.13 — see NickFlach/kannaka-tui
 # sqlite-migrate feature removed
 

--- a/src/absorb_gate.rs
+++ b/src/absorb_gate.rs
@@ -43,6 +43,14 @@
 //!   its own `memory.new`/exemplar emits, gated behind nothing. Signing is
 //!   additive and harmless when the gate is off, and it is the ONLY way
 //!   corroboration can accrue before an operator flips the gate on.
+//! - **Beacon freshness rides in [`QuarantineStaging`].** The anti-eclipse
+//!   [`BeaconTracker`] (PART A) lives inside the staging store that `admit`
+//!   already threads, so the chokepoint signature is unchanged. When the gate is
+//!   ACTIVE, a `Live` promotion additionally requires a FRESH seed beacon; if
+//!   beacons are stale/absent (eclipse or partition) the promotion **freezes to
+//!   Quarantine** (never Drop — legit content is preserved and promotes once
+//!   beacons resume). Feeding the tracker is [`QuarantineStaging::ingest_beacon`]
+//!   (called from the swarm receive path / `kannaka identity beacon`).
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -50,6 +58,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::beacon::{Beacon, BeaconReject, BeaconTracker};
 use crate::config::KannakaConfig;
 use crate::memory::HyperMemory;
 use crate::provenance::{amp_to_q16, now_ms, verify_mem, ProvenanceSig, ReplayLru};
@@ -285,6 +294,16 @@ pub fn admit(
 
     match decision {
         Promotion::Live { .. } => {
+            // (f) PART A anti-eclipse fail-closed: a Live promotion additionally
+            // requires a FRESH seed heartbeat beacon. If beacons are stale/absent
+            // (eclipse or partition), FREEZE — return Quarantine so the content
+            // stays staged (never Drop legit content) and promotes once beacons
+            // resume. Corroboration is NOT recorded while frozen, so the same
+            // content re-decides Live the moment a fresh beacon arrives.
+            if !staging.beacons.fresh(epoch, cfg.swarm_trust.beacon_grace_epochs) {
+                let _ = staging.save();
+                return (AdmitDecision::Quarantine, clean);
+            }
             // Promote: accrue to the origin + mark Live in the DAG, then drop the
             // staged copy (the caller inserts the current memory into the medium).
             rep.record_promotion(h, origin, epoch, corroborators, &cfg.swarm_trust);
@@ -338,6 +357,10 @@ pub struct QuarantineStaging {
     entries: HashMap<[u8; 32], StagedMemory>,
     /// (memory_id, nonce) replay freshness for [`admit`].
     replay: ReplayLru,
+    /// PART A anti-eclipse: per-seed latest verified heartbeat epoch. A Live
+    /// promotion requires this to be fresh (see [`admit`]). Rides here so the
+    /// chokepoint signature stays unchanged.
+    beacons: BeaconTracker,
     cap: usize,
     ttl_ms: i64,
 }
@@ -349,6 +372,7 @@ impl QuarantineStaging {
             dir: None,
             entries: HashMap::new(),
             replay: ReplayLru::new(),
+            beacons: BeaconTracker::new(),
             cap: STAGING_CAP,
             ttl_ms: STAGING_TTL_MS,
         }
@@ -362,6 +386,7 @@ impl QuarantineStaging {
         let dir = data_dir.join("quarantine");
         let mut s = Self {
             replay: ReplayLru::load(&dir.join("replay.json"), now_ms()),
+            beacons: BeaconTracker::load(&dir.join("beacons.json")),
             dir: Some(dir.clone()),
             entries: HashMap::new(),
             cap: STAGING_CAP,
@@ -404,6 +429,26 @@ impl QuarantineStaging {
     /// Whether `h` is currently staged.
     pub fn contains(&self, h: &[u8; 32]) -> bool {
         self.entries.contains_key(h)
+    }
+
+    /// PART A: verify a heartbeat beacon and, if it is a fresh SEED beacon,
+    /// record its epoch in the anti-eclipse tracker. Non-seed / replayed /
+    /// future-dated beacons are rejected (see [`BeaconTracker::ingest`]). This is
+    /// the receive path a swarm serve/join loop (or `kannaka identity beacon`
+    /// out-of-band) calls; `seeds` is the pinned seed set (`RepStore::seeds`).
+    pub fn ingest_beacon(
+        &mut self,
+        beacon: &Beacon,
+        seeds: &HashSet<PubKey>,
+        now_epoch: u64,
+    ) -> Result<PubKey, BeaconReject> {
+        self.beacons.ingest(beacon, seeds, now_epoch)
+    }
+
+    /// PART A: whether at least one seed beacon is fresh within `grace` epochs of
+    /// `now_epoch` — the freshness predicate [`admit`] gates Live promotion on.
+    pub fn beacons_fresh(&self, now_epoch: u64, grace: u32) -> bool {
+        self.beacons.fresh(now_epoch, grace)
     }
 
     /// The accrual origin (first signer) of a staged content-hash.
@@ -500,6 +545,10 @@ impl QuarantineStaging {
         // Replay persistence is best-effort — a lost replay set only re-opens the
         // skew window, and the set fails closed on a corrupt reload.
         let _ = self.replay.persist(&dir.join("replay.json"));
+        // Beacon freshness is best-effort — a lost/corrupt file reloads empty,
+        // which freezes promotion (the fail-closed direction) until a fresh
+        // beacon is re-ingested.
+        let _ = self.beacons.save(&dir.join("beacons.json"));
         Ok(())
     }
 }
@@ -560,6 +609,7 @@ fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::beacon::Beacon;
     use crate::provenance::{sign_mem, verifying_key_bytes};
     use crate::reputation::RepStore;
 
@@ -715,6 +765,15 @@ mod tests {
         let mut rep = RepStore::in_memory(&cfg.swarm_trust);
         let mut staging = QuarantineStaging::in_memory();
 
+        // PART A: seed a fresh heartbeat so the Live promotion below isn't frozen
+        // by the anti-eclipse gate.
+        let seed_set: HashSet<PubKey> = (0..seeds.signing.len())
+            .map(|i| verifying_key_bytes(&seeds.seed(i)))
+            .collect();
+        let now_epoch = epoch_now(&cfg, now);
+        let beacon = Beacon::sign(&seeds.seed(0), now_epoch, [0u8; 32]);
+        staging.ingest_beacon(&beacon, &seed_set, now_epoch).unwrap();
+
         // author (non-seed) → Quarantine
         let id0 = Uuid::new_v4();
         let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
@@ -749,6 +808,51 @@ mod tests {
         let (rep, staging, _cfg, h, _origin) = promote_to_live(&seeds, content, now);
         assert!(rep.dag().is_promoted(&h), "promoted to live");
         assert!(!staging.contains(&h), "moved out of staging on promotion");
+    }
+
+    // --- PART A: stale/absent beacon freezes an otherwise-promotable memory --
+    #[test]
+    fn stale_beacon_freezes_then_fresh_beacon_thaws() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let now = 1_000_000;
+        let content = "an otherwise-promotable fact observed during an eclipse";
+        let now_epoch = epoch_now(&cfg, now);
+
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory(); // NO beacon ⇒ eclipsed
+
+        // author → Quarantine; seed0 → ProbationLive; seed1 → would be Live (C=2≥K=2).
+        let id0 = Uuid::new_v4();
+        let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
+            &mut staging, &mut rep, &cfg, now);
+        let id1 = Uuid::new_v4();
+        let s1 = signed(&seeds.seed(0), id1, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
+            &mut staging, &mut rep, &cfg, now);
+        let id2 = Uuid::new_v4();
+        let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (frozen, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
+            &mut staging, &mut rep, &cfg, now);
+
+        let h = content_hash(content);
+        assert_eq!(frozen, AdmitDecision::Quarantine, "stale/absent beacons freeze promotion");
+        assert!(!rep.dag().is_promoted(&h), "frozen: not promoted to live");
+        assert!(staging.contains(&h), "frozen content preserved in staging (never dropped)");
+
+        // Beacons resume ⇒ the next corroboration promotes the SAME content.
+        let seed_set: HashSet<PubKey> = (0..seeds.signing.len())
+            .map(|i| verifying_key_bytes(&seeds.seed(i)))
+            .collect();
+        let beacon = Beacon::sign(&seeds.seed(0), now_epoch, [0u8; 32]);
+        staging.ingest_beacon(&beacon, &seed_set, now_epoch).unwrap();
+        let id3 = Uuid::new_v4();
+        let s3 = signed(&seeds.seed(2), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (thawed, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
+            &mut staging, &mut rep, &cfg, now);
+        assert_eq!(thawed, AdmitDecision::Live, "a fresh seed beacon thaws promotion");
+        assert!(rep.dag().is_promoted(&h), "promoted once beacons resumed");
     }
 
     // --- (e) echo: already-Live content ⇒ no new memory, accrues nothing ---

--- a/src/absorb_gate.rs
+++ b/src/absorb_gate.rs
@@ -951,6 +951,64 @@ mod tests {
         assert!(rep.dag().is_promoted(&h), "promoted once beacons resumed");
     }
 
+    // --- PART A wired: a beacon that crossed the JSON wire un-freezes the gate -
+    // Proves the receive→ingest path this increment adds: a seed beacon is signed,
+    // serialized to the NATS wire form, parsed back, and ingested into the SAME
+    // staging admit() reads — un-freezing an otherwise-frozen Live promotion. No
+    // real NATS (library-level).
+    #[test]
+    fn wire_beacon_ingest_unfreezes_gate() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let now = 1_000_000;
+        let content = "a fact observed while beacons crossed the wire";
+        let now_epoch = epoch_now(&cfg, now);
+
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory(); // NO beacon ⇒ eclipsed
+
+        // author (non-seed) + 2 seeds ⇒ would be Live, but FROZEN with no beacon.
+        let id0 = Uuid::new_v4();
+        let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
+            &mut staging, &mut rep, &cfg, now);
+        let id1 = Uuid::new_v4();
+        let s1 = signed(&seeds.seed(0), id1, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
+            &mut staging, &mut rep, &cfg, now);
+        let id2 = Uuid::new_v4();
+        let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (frozen, _, frozen_pending) = admit(content, 0.5, 0.0, 0.1, false,
+            SUBJECT_MEMORY_NEW, id2, Some(&s2), &mut staging, &mut rep, &cfg, now);
+        let h = content_hash(content);
+        assert_eq!(frozen, AdmitDecision::Quarantine, "no beacon ⇒ frozen");
+        assert!(frozen_pending.is_none());
+        assert!(!rep.dag().is_promoted(&h), "frozen: not promoted");
+
+        // A seed signs a beacon; it crosses the JSON wire (publish → receive); the
+        // receiver parses it and ingests it into the SAME staging.
+        let beacon = Beacon::sign(&seeds.seed(0), now_epoch, crate::beacon::EMPTY_REJECT_ROOT);
+        let wire = serde_json::to_vec(&beacon).expect("encode beacon to wire");
+        let received: Beacon = serde_json::from_slice(&wire).expect("decode beacon from wire");
+        assert_eq!(received, beacon, "beacon survives the wire intact");
+        let seed_set: HashSet<PubKey> = (0..seeds.signing.len())
+            .map(|i| verifying_key_bytes(&seeds.seed(i)))
+            .collect();
+        staging
+            .ingest_beacon(&received, &seed_set, now_epoch)
+            .expect("a fresh seed beacon ingests");
+
+        // The next corroboration of the SAME content now promotes ⇒ receive→ingest
+        // un-froze the gate.
+        let id3 = Uuid::new_v4();
+        let s3 = signed(&seeds.seed(2), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (thawed, _, pending) = admit(content, 0.5, 0.0, 0.1, false,
+            SUBJECT_MEMORY_NEW, id3, Some(&s3), &mut staging, &mut rep, &cfg, now);
+        assert_eq!(thawed, AdmitDecision::Live, "wire beacon un-freezes Live promotion");
+        commit_promotion(pending, &mut rep, &mut staging, &cfg);
+        assert!(rep.dag().is_promoted(&h), "promoted after wire beacon ingest");
+    }
+
     // --- (e) echo: already-Live content ⇒ no new memory, accrues nothing ---
     #[test]
     fn echo_earns_nothing() {

--- a/src/absorb_gate.rs
+++ b/src/absorb_gate.rs
@@ -682,6 +682,34 @@ mod tests {
 
     const NON_SEED: [u8; 32] = [200u8; 32];
 
+    // --- (a0) seeds pinned but gate OFF is still dormant --------------------
+    // Guards the AND in `gate_active` (enabled && !seeds.empty). This is the
+    // rollout state — an operator has pinned seeds but not yet flipped the gate
+    // on — and it MUST stay exact inc-0 behavior. A `&&`->`||` mutant would make
+    // this active, reject the unsigned memory, and fail the Live assertion.
+    #[test]
+    fn seeds_pinned_gate_off_is_dormant() {
+        let seed = [7u8; 32];
+        let cfg = test_cfg(vec![b64(&seed)], false); // seeds present, gate OFF
+        assert!(!gate_active(&cfg), "seeds pinned + gate off => NOT active");
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let (dec, clean) = admit(
+            "rollout-state content",
+            5.0, 100.0, 9e9, true, // absurd + wire immune flag set
+            SUBJECT_MEMORY_NEW,
+            Uuid::new_v4(),
+            None, // unsigned — dormant accepts it (inc-0 preserved)
+            &mut staging,
+            &mut rep,
+            &cfg,
+            1_000_000,
+        );
+        assert_eq!(dec, AdmitDecision::Live, "seeds pinned + gate off => dormant Live");
+        assert!(clean.amplitude <= MAX_WIRE_AMPLITUDE, "amplitude still clamped");
+        assert!(!clean.hallucinated, "hallucinated still forced to local default");
+    }
+
     // --- (a) dormant passthrough sanitizes ---------------------------------
     #[test]
     fn dormant_passthrough_sanitizes() {

--- a/src/absorb_gate.rs
+++ b/src/absorb_gate.rs
@@ -1,0 +1,822 @@
+//! Absorb gate — the inc-1b corroboration `admit()` chokepoint.
+//!
+//! This is the single write-side chokepoint every wire→store absorb path routes
+//! through. It composes the committed inc-1a/1b substrate ([`crate::provenance`]
+//! sign/verify + replay, [`crate::reputation`] pubkey-keyed trust core) into one
+//! decision + one field-sanitization step.
+//!
+//! ## Two responsibilities
+//!
+//! 1. **UNCONDITIONAL sanitization ([`CleanFields`]).** Runs even when the gate
+//!    is dormant. Clamps `amplitude`/`phase`/`frequency` to sane finite ranges
+//!    and — critically — **forces `hallucinated` to the local default, NEVER the
+//!    wire value** (an attacker must not be able to set/clear the immune flag
+//!    over the wire). This is the inc-1b fix for the raw-insert gap.
+//! 2. **CONDITIONAL promotion gate.** Only when
+//!    `cfg.swarm_trust.corroboration_gate_enabled` is true AND seeds are pinned
+//!    does [`admit`] require a valid signature and run the corroboration
+//!    predicate. Otherwise it returns [`AdmitDecision::Live`] with the sanitized
+//!    fields — i.e. **inc-0 behaviour is preserved** and the swarm keeps working
+//!    until an operator pins seeds. **DORMANT BY DEFAULT.**
+//!
+//! ## Corroboration model (join key = `blake3(normalize(content))`)
+//!
+//! A "corroboration" is simply **another distinct trusted node independently
+//! signing-and-remembering the SAME content** — there is no separate endorsement
+//! message. The gate accumulates, per content-hash, the set of DISTINCT signer
+//! pubkeys that have signed-remembered it, and promotes when
+//! [`RepStore::decide`](crate::reputation::RepStore::decide) says `Live`.
+//!
+//! ## Judgment calls (documented for the reviewer)
+//!
+//! - **Fixed signed agent-id.** The pubkey is the real identity; the wire
+//!   agent-id string is forgeable and untrusted. So both sign and verify bind a
+//!   fixed [`SIGN_AGENT_ID`] into the canonical bytes, which keeps `admit()` free
+//!   of an agent-id parameter while still reusing the committed `canonical_mem`.
+//! - **`high_impact` = amplitude proxy.** There is no category taxonomy yet, so a
+//!   wire memory whose (clamped) amplitude ≥ [`HIGH_IMPACT_AMPLITUDE`] must clear
+//!   `K_high` distinct lineages. Deferred to the seed-ceremony pass.
+//! - **"already Live" = `RepStore::dag().is_promoted(h)`.** The reputation DAG is
+//!   the authoritative record of gate promotions; an echo re-records the edge and
+//!   accrues nothing.
+//! - **Always-sign on publish** (see the publish call sites): every node signs
+//!   its own `memory.new`/exemplar emits, gated behind nothing. Signing is
+//!   additive and harmless when the gate is off, and it is the ONLY way
+//!   corroboration can accrue before an operator flips the gate on.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::config::KannakaConfig;
+use crate::memory::HyperMemory;
+use crate::provenance::{amp_to_q16, now_ms, verify_mem, ProvenanceSig, ReplayLru};
+use crate::reputation::{Promotion, PubKey, RepStore};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Fixed agent-id bound into the signed canonical bytes on BOTH sign and verify.
+/// The pubkey ([`ProvenanceSig::pubkey`]) is the real identity; the wire agent-id
+/// string is forgeable, so it is deliberately not bound. Using a constant keeps
+/// [`admit`] free of an agent-id parameter while reusing `canonical_mem`.
+pub const SIGN_AGENT_ID: &str = "kannaka-swarm";
+
+/// Fixed tier discriminant bound into the signed canonical bytes.
+pub const PROV_TIER: u8 = 0;
+
+/// Subject bound into a `KANNAKA.memory.new` provenance signature (sign + verify).
+pub const SUBJECT_MEMORY_NEW: &str = "KANNAKA.memory.new";
+
+/// Subject bound into a `KANNAKA.exemplar.*` provenance signature (sign + verify).
+pub const SUBJECT_EXEMPLAR: &str = "KANNAKA.exemplar";
+
+/// Hard ceiling on a wire memory's amplitude (inc-1b sanitization).
+pub const MAX_WIRE_AMPLITUDE: f32 = 0.95;
+
+/// Frequency clamp ceiling for a wire memory.
+pub const MAX_WIRE_FREQUENCY: f32 = 1000.0;
+
+/// Fallback frequency for a non-finite wire value (mirrors `WaveParams::default`).
+const DEFAULT_FREQUENCY: f32 = 0.1;
+
+/// (Clamped) amplitude at/above which a wire memory is treated as high-impact and
+/// must clear `K_high` distinct lineages. Judgment call — amplitude proxy until a
+/// category taxonomy lands.
+pub const HIGH_IMPACT_AMPLITUDE: f32 = 0.9;
+
+/// Max staged content-hashes retained (disk-full defense).
+pub const STAGING_CAP: usize = 10_000;
+
+/// TTL after which a staged (uncorroborated) entry is evicted, in ms (7 days).
+pub const STAGING_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Decision + cleaned fields
+// ---------------------------------------------------------------------------
+
+/// The fate of a candidate wire memory at the absorb chokepoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmitDecision {
+    /// Reject: invalid/absent signature, replay, or an echo of already-Live
+    /// content. The caller inserts NO memory.
+    Drop,
+    /// Signed but under-corroborated: goes to the staging tier (persisted,
+    /// excluded from recall/metrics/dream), NOT the live medium.
+    Quarantine,
+    /// Seed-endorsed cold-start without full quorum: probation tier (same
+    /// staging treatment as Quarantine for this pass — not live).
+    ProbationLive,
+    /// Promote into the live medium — the caller inserts the memory with the
+    /// sanitized [`CleanFields`].
+    Live,
+}
+
+/// Sanitized wave fields the caller MUST apply before inserting a wire memory.
+/// Produced on EVERY [`admit`] call, dormant or active.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CleanFields {
+    /// `wire_amp` clamped to `[0, MAX_WIRE_AMPLITUDE]` (non-finite → 0).
+    pub amplitude: f32,
+    /// `wire_phase` reduced to `[0, 2π)` (non-finite → 0).
+    pub phase: f32,
+    /// `wire_freq` clamped to `[0, MAX_WIRE_FREQUENCY]` (non-finite → default).
+    pub frequency: f32,
+    /// ALWAYS the local default (`false`) — the wire immune flag is never trusted.
+    pub hallucinated: bool,
+}
+
+impl CleanFields {
+    /// Overwrite a memory's wire-controlled fields with the sanitized values.
+    pub fn apply(&self, mem: &mut HyperMemory) {
+        mem.amplitude = self.amplitude;
+        mem.phase = self.phase;
+        mem.frequency = self.frequency;
+        mem.hallucinated = self.hallucinated;
+    }
+}
+
+fn sanitize(wire_amp: f32, wire_phase: f32, wire_freq: f32) -> CleanFields {
+    let amplitude = if wire_amp.is_finite() {
+        wire_amp.clamp(0.0, MAX_WIRE_AMPLITUDE)
+    } else {
+        0.0
+    };
+    let phase = if wire_phase.is_finite() {
+        wire_phase.rem_euclid(std::f32::consts::TAU)
+    } else {
+        0.0
+    };
+    let frequency = if wire_freq.is_finite() {
+        wire_freq.clamp(0.0, MAX_WIRE_FREQUENCY)
+    } else {
+        DEFAULT_FREQUENCY
+    };
+    // SECURITY (inc-1b): `hallucinated` is FORCED to the local default; the wire
+    // immune flag is never trusted (an attacker must not pre-set/clear it).
+    CleanFields { amplitude, phase, frequency, hallucinated: false }
+}
+
+// ---------------------------------------------------------------------------
+// Small pure helpers
+// ---------------------------------------------------------------------------
+
+/// True when the corroboration promotion gate is armed: master switch on AND at
+/// least one seed pinned. Everything else is dormant (inc-0 fallback).
+pub fn gate_active(cfg: &KannakaConfig) -> bool {
+    cfg.swarm_trust.corroboration_gate_enabled && !cfg.swarm_trust.seed_pubkeys.is_empty()
+}
+
+/// Corroboration epoch for `now_ms` (`now / epoch_length_ms`, guarded).
+pub fn epoch_now(cfg: &KannakaConfig, now_ms: i64) -> u64 {
+    let len = cfg.swarm_trust.epoch_length_ms.max(1);
+    (now_ms.max(0) / len) as u64
+}
+
+/// The corroboration join key: `blake3(normalize(content))`. Whitespace is
+/// collapsed so cosmetic differences don't split a corroboration set.
+pub fn content_hash(content: &str) -> [u8; 32] {
+    let normalized = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    *blake3::hash(normalized.as_bytes()).as_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// admit() — the chokepoint
+// ---------------------------------------------------------------------------
+
+/// The absorb chokepoint. Returns the promotion decision plus the sanitized
+/// fields the caller must apply before any insert.
+///
+/// - **Dormant** (`!gate_active` or no live seeds): returns `(Live, cleaned)` —
+///   inc-0 behaviour preserved. The caller still applies `cleaned` (the
+///   unconditional field bug-fix) and keeps whatever inc-0 source gating it had.
+/// - **Active**: a valid, fresh signature is required (`Drop` otherwise). An echo
+///   of already-Live content records the corroboration edge and returns `Drop`
+///   (no new memory, no accrual). Otherwise the signer is accumulated into the
+///   per-content staging set and [`RepStore::decide`] governs.
+#[allow(clippy::too_many_arguments)]
+pub fn admit(
+    content: &str,
+    wire_amp: f32,
+    wire_phase: f32,
+    wire_freq: f32,
+    _wire_hallucinated: bool, // deliberately ignored — never trust the wire immune flag
+    subject: &str,
+    memory_id: Uuid,
+    sig: Option<&ProvenanceSig>,
+    staging: &mut QuarantineStaging,
+    rep: &mut RepStore,
+    cfg: &KannakaConfig,
+    now_ms: i64,
+) -> (AdmitDecision, CleanFields) {
+    // (a) ALWAYS sanitize — unconditional inc-1b bug fix.
+    let clean = sanitize(wire_amp, wire_phase, wire_freq);
+
+    // (b) Dormant: no promotion logic, no signature requirement.
+    if !gate_active(cfg) || rep.live_seed_count() == 0 {
+        return (AdmitDecision::Live, clean);
+    }
+
+    // (c) Active: a valid + fresh signature is a hard precondition.
+    let amp_q16 = amp_to_q16(wire_amp);
+    let pk: PubKey = match sig {
+        Some(s) => match verify_mem(
+            s,
+            SIGN_AGENT_ID,
+            memory_id,
+            content,
+            subject,
+            amp_q16,
+            PROV_TIER,
+            now_ms,
+        ) {
+            Ok(pk) => {
+                // Freshness: single-use (memory_id, nonce); fail-closed if poisoned.
+                if staging.replay.refuses_live(now_ms)
+                    || staging
+                        .replay
+                        .check_and_insert(memory_id, &s.nonce, now_ms)
+                        .is_err()
+                {
+                    return (AdmitDecision::Drop, clean);
+                }
+                pk
+            }
+            Err(_) => return (AdmitDecision::Drop, clean),
+        },
+        None => return (AdmitDecision::Drop, clean),
+    };
+
+    let epoch = epoch_now(cfg, now_ms);
+    let h = content_hash(content);
+    let high_impact = clean.amplitude >= HIGH_IMPACT_AMPLITUDE;
+
+    // (d) Echo: content already Live ⇒ record the corroboration edge, insert NO
+    // new memory, accrue nothing.
+    if rep.dag().is_promoted(&h) {
+        let root = rep.seed_root_of(&pk);
+        rep.record_promotion(h, pk, epoch, vec![(pk, root)], &cfg.swarm_trust);
+        let _ = staging.save();
+        return (AdmitDecision::Drop, clean);
+    }
+
+    // (e) Accumulate this distinct signer, then decide.
+    staging.add_corroborator(h, content, &clean, pk, now_ms);
+    let origin = staging.origin(&h).unwrap_or(pk);
+    let corroborators: Vec<(PubKey, Option<PubKey>)> = staging
+        .corroborators(&h)
+        .into_iter()
+        .map(|c| (c, rep.seed_root_of(&c)))
+        .collect();
+
+    let decision = rep.decide(
+        h,
+        origin,
+        &corroborators,
+        epoch,
+        rep.live_seed_count(),
+        high_impact,
+        /* resonance_ok = */ false,
+        &cfg.swarm_trust,
+    );
+
+    match decision {
+        Promotion::Live { .. } => {
+            // Promote: accrue to the origin + mark Live in the DAG, then drop the
+            // staged copy (the caller inserts the current memory into the medium).
+            rep.record_promotion(h, origin, epoch, corroborators, &cfg.swarm_trust);
+            let _ = staging.promote(&h);
+            let _ = staging.save();
+            (AdmitDecision::Live, clean)
+        }
+        Promotion::ProbationLive => {
+            let _ = staging.save();
+            (AdmitDecision::ProbationLive, clean)
+        }
+        Promotion::Quarantine => {
+            let _ = staging.save();
+            (AdmitDecision::Quarantine, clean)
+        }
+        // decide() never emits Drop, but map it for completeness.
+        Promotion::Drop => {
+            let _ = staging.promote(&h);
+            (AdmitDecision::Drop, clean)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QuarantineStaging — persisted, recall/metrics/dream-excluded staging tier
+// ---------------------------------------------------------------------------
+
+/// A staged (signed-but-under-corroborated) memory. Lives on disk under
+/// `<data_dir>/quarantine/`, NEVER in the live `.hrm`, so it is excluded from
+/// recall / metrics / dream by construction.
+#[derive(Debug, Clone)]
+pub struct StagedMemory {
+    /// Raw content of the (first) staging message.
+    pub content: String,
+    /// Sanitized fields to apply on eventual promotion.
+    pub cleaned: CleanFields,
+    /// First time this content-hash was seen locally (ms) — TTL anchor + origin.
+    pub first_seen: i64,
+    /// The first signer of this content — the promotion-accrual origin.
+    pub origin: PubKey,
+    /// Distinct signer pubkeys accumulated for this content-hash.
+    pub corroborators: HashSet<PubKey>,
+}
+
+/// Persisted content-hash-keyed staging store with a replay-freshness set.
+/// Bounded by [`STAGING_CAP`] entries + [`STAGING_TTL_MS`] TTL.
+#[derive(Debug)]
+pub struct QuarantineStaging {
+    /// `<data_dir>/quarantine/`; `None` for in-memory test stores.
+    dir: Option<PathBuf>,
+    entries: HashMap<[u8; 32], StagedMemory>,
+    /// (memory_id, nonce) replay freshness for [`admit`].
+    replay: ReplayLru,
+    cap: usize,
+    ttl_ms: i64,
+}
+
+impl QuarantineStaging {
+    /// An in-memory (no-persistence) staging store for tests.
+    pub fn in_memory() -> Self {
+        Self {
+            dir: None,
+            entries: HashMap::new(),
+            replay: ReplayLru::new(),
+            cap: STAGING_CAP,
+            ttl_ms: STAGING_TTL_MS,
+        }
+    }
+
+    /// Load the staging tier from `<data_dir>/quarantine/` (staging.json +
+    /// replay.json). Missing files ⇒ empty store; a corrupt staging.json is
+    /// treated as empty (the corroboration record is reconstructable from the
+    /// append-only reputation log). The replay set fails closed on corruption.
+    pub fn load(data_dir: &Path) -> Self {
+        let dir = data_dir.join("quarantine");
+        let mut s = Self {
+            replay: ReplayLru::load(&dir.join("replay.json"), now_ms()),
+            dir: Some(dir.clone()),
+            entries: HashMap::new(),
+            cap: STAGING_CAP,
+            ttl_ms: STAGING_TTL_MS,
+        };
+        if let Ok(bytes) = std::fs::read(dir.join("staging.json")) {
+            if let Ok(wire) = serde_json::from_slice::<StagingWire>(&bytes) {
+                for e in wire.entries {
+                    s.entries.insert(
+                        e.hash,
+                        StagedMemory {
+                            content: e.content,
+                            cleaned: CleanFields {
+                                amplitude: e.amplitude,
+                                phase: e.phase,
+                                frequency: e.frequency,
+                                hallucinated: e.hallucinated,
+                            },
+                            first_seen: e.first_seen,
+                            origin: e.origin,
+                            corroborators: e.corroborators.into_iter().collect(),
+                        },
+                    );
+                }
+            }
+        }
+        s
+    }
+
+    /// Number of staged content-hashes.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when nothing is staged.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Whether `h` is currently staged.
+    pub fn contains(&self, h: &[u8; 32]) -> bool {
+        self.entries.contains_key(h)
+    }
+
+    /// The accrual origin (first signer) of a staged content-hash.
+    pub fn origin(&self, h: &[u8; 32]) -> Option<PubKey> {
+        self.entries.get(h).map(|e| e.origin)
+    }
+
+    /// The distinct signer set accumulated for a staged content-hash.
+    pub fn corroborators(&self, h: &[u8; 32]) -> Vec<PubKey> {
+        self.entries
+            .get(h)
+            .map(|e| e.corroborators.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Record a distinct signer of `content` under its hash, creating the entry
+    /// on first sight (the first signer is the origin). Enforces TTL + cap.
+    fn add_corroborator(
+        &mut self,
+        h: [u8; 32],
+        content: &str,
+        cleaned: &CleanFields,
+        pk: PubKey,
+        now_ms: i64,
+    ) {
+        self.evict_expired(now_ms);
+        if !self.entries.contains_key(&h) && self.entries.len() >= self.cap {
+            self.evict_oldest();
+        }
+        let entry = self.entries.entry(h).or_insert_with(|| StagedMemory {
+            content: content.to_string(),
+            cleaned: *cleaned,
+            first_seen: now_ms,
+            origin: pk,
+            corroborators: HashSet::new(),
+        });
+        entry.corroborators.insert(pk);
+    }
+
+    /// Remove and return the staged memory for `h` (used on promotion).
+    pub fn promote(&mut self, h: &[u8; 32]) -> Option<StagedMemory> {
+        self.entries.remove(h)
+    }
+
+    /// Drop a staged entry without returning it.
+    pub fn remove(&mut self, h: &[u8; 32]) {
+        self.entries.remove(h);
+    }
+
+    fn evict_expired(&mut self, now_ms: i64) {
+        let ttl = self.ttl_ms;
+        self.entries
+            .retain(|_, e| now_ms.saturating_sub(e.first_seen) <= ttl);
+    }
+
+    fn evict_oldest(&mut self) {
+        if let Some(oldest) = self
+            .entries
+            .iter()
+            .min_by_key(|(_, e)| e.first_seen)
+            .map(|(h, _)| *h)
+        {
+            self.entries.remove(&oldest);
+        }
+    }
+
+    /// Persist the staging tier + replay set (atomic). No-op for in-memory stores.
+    pub fn save(&self) -> Result<(), String> {
+        let Some(dir) = &self.dir else {
+            return Ok(());
+        };
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("quarantine: mkdir {}: {e}", dir.display()))?;
+        let wire = StagingWire {
+            entries: self
+                .entries
+                .iter()
+                .map(|(h, m)| StagedWire {
+                    hash: *h,
+                    content: m.content.clone(),
+                    amplitude: m.cleaned.amplitude,
+                    phase: m.cleaned.phase,
+                    frequency: m.cleaned.frequency,
+                    hallucinated: m.cleaned.hallucinated,
+                    first_seen: m.first_seen,
+                    origin: m.origin,
+                    corroborators: m.corroborators.iter().copied().collect(),
+                })
+                .collect(),
+        };
+        let bytes = serde_json::to_vec(&wire)
+            .map_err(|e| format!("quarantine: encode: {e}"))?;
+        atomic_write_bytes(&dir.join("staging.json"), &bytes)?;
+        // Replay persistence is best-effort — a lost replay set only re-opens the
+        // skew window, and the set fails closed on a corrupt reload.
+        let _ = self.replay.persist(&dir.join("replay.json"));
+        Ok(())
+    }
+}
+
+// --- persistence wire types -------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct StagedWire {
+    hash: [u8; 32],
+    content: String,
+    amplitude: f32,
+    phase: f32,
+    frequency: f32,
+    hallucinated: bool,
+    first_seen: i64,
+    origin: [u8; 32],
+    corroborators: Vec<[u8; 32]>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct StagingWire {
+    entries: Vec<StagedWire>,
+}
+
+/// Atomic write: temp sibling → `write_all` → `sync_all` → rename over target.
+/// Mirrors the sidecar writers elsewhere in the crate.
+fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("quarantine: mkdir {}: {e}", dir.display()))?;
+    let tmp = dir.join(format!(".kannaka-staging-tmp-{}", Uuid::new_v4()));
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::File::create(&tmp).map_err(|e| format!("quarantine: tmp: {e}"))?;
+        if let Err(e) = f.write_all(bytes) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("quarantine: write: {e}"));
+        }
+        if let Err(e) = f.sync_all() {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("quarantine: sync: {e}"));
+        }
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("quarantine: rename: {e}"));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::{sign_mem, verifying_key_bytes};
+    use crate::reputation::RepStore;
+
+    // --- fixtures -----------------------------------------------------------
+
+    /// A small set of pinned-seed SIGNING keys + their base64 pubkeys.
+    struct Seeds {
+        signing: Vec<[u8; 32]>,
+    }
+    impl Seeds {
+        fn new(n: u8) -> Self {
+            Seeds { signing: (1..=n).map(|i| [i; 32]).collect() }
+        }
+        fn seed(&self, i: usize) -> [u8; 32] {
+            self.signing[i]
+        }
+        fn pubkeys_b64(&self) -> Vec<String> {
+            self.signing.iter().map(|s| b64(&verifying_key_bytes(s))).collect()
+        }
+    }
+
+    fn test_cfg(seed_pubkeys: Vec<String>, gate: bool) -> KannakaConfig {
+        let mut cfg = KannakaConfig::default();
+        cfg.swarm_trust.corroboration_gate_enabled = gate;
+        cfg.swarm_trust.seed_pubkeys = seed_pubkeys;
+        cfg.swarm_trust.epoch_length_ms = 60_000;
+        cfg
+    }
+
+    /// Sign `content` with a signing seed, matching what `admit` will verify.
+    fn signed(
+        signing: &[u8; 32],
+        mem_id: Uuid,
+        content: &str,
+        subject: &str,
+        amp: f32,
+        now: i64,
+    ) -> ProvenanceSig {
+        let nonce = *Uuid::new_v4().as_bytes();
+        sign_mem(
+            signing,
+            SIGN_AGENT_ID,
+            mem_id,
+            &nonce,
+            now,
+            content,
+            subject,
+            amp_to_q16(amp),
+            PROV_TIER,
+        )
+    }
+
+    /// Standard-alphabet base64 (matches `reputation::b64_decode_32`).
+    fn b64(data: &[u8]) -> String {
+        const A: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::new();
+        for chunk in data.chunks(3) {
+            let b0 = chunk[0];
+            let b1 = *chunk.get(1).unwrap_or(&0);
+            let b2 = *chunk.get(2).unwrap_or(&0);
+            let n = ((b0 as u32) << 16) | ((b1 as u32) << 8) | (b2 as u32);
+            out.push(A[((n >> 18) & 63) as usize] as char);
+            out.push(A[((n >> 12) & 63) as usize] as char);
+            out.push(if chunk.len() > 1 { A[((n >> 6) & 63) as usize] as char } else { '=' });
+            out.push(if chunk.len() > 2 { A[(n & 63) as usize] as char } else { '=' });
+        }
+        out
+    }
+
+    const NON_SEED: [u8; 32] = [200u8; 32];
+
+    // --- (a) dormant passthrough sanitizes ---------------------------------
+    #[test]
+    fn dormant_passthrough_sanitizes() {
+        let cfg = test_cfg(vec![], false); // gate off, no seeds
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let (dec, clean) = admit(
+            "hello world",
+            5.0,   // absurd amplitude
+            100.0, // absurd phase
+            9e9,   // absurd frequency
+            true,  // wire immune flag set — must be ignored
+            SUBJECT_MEMORY_NEW,
+            Uuid::new_v4(),
+            None, // unsigned — but dormant, so accepted
+            &mut staging,
+            &mut rep,
+            &cfg,
+            1_000_000,
+        );
+        assert_eq!(dec, AdmitDecision::Live, "dormant unsigned ⇒ Live (inc-0 preserved)");
+        assert!(clean.amplitude <= MAX_WIRE_AMPLITUDE, "amplitude clamped");
+        assert!(!clean.hallucinated, "hallucinated forced to local default");
+        assert!(clean.phase >= 0.0 && clean.phase < std::f32::consts::TAU, "phase reduced");
+        assert!(clean.frequency <= MAX_WIRE_FREQUENCY, "frequency clamped");
+    }
+
+    // --- (b) active + unsigned ⇒ Drop --------------------------------------
+    #[test]
+    fn active_unsigned_drops() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let (dec, _clean) = admit(
+            "novel content here that is long enough",
+            0.5,
+            0.0,
+            0.1,
+            false,
+            SUBJECT_MEMORY_NEW,
+            Uuid::new_v4(),
+            None,
+            &mut staging,
+            &mut rep,
+            &cfg,
+            1_000_000,
+        );
+        assert_eq!(dec, AdmitDecision::Drop, "active + unsigned ⇒ Drop");
+    }
+
+    // --- (c) active + signed non-seed, C<K ⇒ Quarantine --------------------
+    #[test]
+    fn active_signed_nonseed_quarantines() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let now = 1_000_000;
+        let content = "an uncorroborated claim from an unknown handle";
+        let mem_id = Uuid::new_v4();
+        let sig = signed(&NON_SEED, mem_id, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (dec, _c) = admit(
+            content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, mem_id, Some(&sig),
+            &mut staging, &mut rep, &cfg, now,
+        );
+        assert_eq!(dec, AdmitDecision::Quarantine, "signed non-seed, C<K ⇒ Quarantine");
+        let h = content_hash(content);
+        assert!(staging.contains(&h), "stays in staging");
+        assert!(!rep.dag().is_promoted(&h), "not promoted to live");
+    }
+
+    /// Drive `content` to Live: non-seed author, then K seed-disjoint lineages.
+    /// K=2 for a 3-seed roster. Returns (rep, staging, cfg, h, origin_pk).
+    fn promote_to_live(
+        seeds: &Seeds,
+        content: &str,
+        now: i64,
+    ) -> (RepStore, QuarantineStaging, KannakaConfig, [u8; 32], PubKey) {
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+
+        // author (non-seed) → Quarantine
+        let id0 = Uuid::new_v4();
+        let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (d0, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
+            &mut staging, &mut rep, &cfg, now);
+        assert_eq!(d0, AdmitDecision::Quarantine);
+
+        // seed 0 corroborates → ProbationLive (C=1 < K=2, seed present)
+        let id1 = Uuid::new_v4();
+        let s1 = signed(&seeds.seed(0), id1, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (d1, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
+            &mut staging, &mut rep, &cfg, now);
+        assert_eq!(d1, AdmitDecision::ProbationLive);
+
+        // seed 1 corroborates → Live (C=2 ≥ K=2)
+        let id2 = Uuid::new_v4();
+        let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (d2, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
+            &mut staging, &mut rep, &cfg, now);
+        assert_eq!(d2, AdmitDecision::Live);
+
+        let h = content_hash(content);
+        (rep, staging, cfg, h, verifying_key_bytes(&NON_SEED))
+    }
+
+    // --- (d) active + K distinct seed lineages ⇒ Live ----------------------
+    #[test]
+    fn active_k_seed_lineages_promote() {
+        let seeds = Seeds::new(3);
+        let now = 1_000_000;
+        let content = "a fact corroborated by two independent operator seeds";
+        let (rep, staging, _cfg, h, _origin) = promote_to_live(&seeds, content, now);
+        assert!(rep.dag().is_promoted(&h), "promoted to live");
+        assert!(!staging.contains(&h), "moved out of staging on promotion");
+    }
+
+    // --- (e) echo: already-Live content ⇒ no new memory, accrues nothing ---
+    #[test]
+    fn echo_earns_nothing() {
+        let seeds = Seeds::new(3);
+        let now = 1_000_000;
+        let content = "a fact corroborated then echoed";
+        let (mut rep, mut staging, cfg, h, origin) = promote_to_live(&seeds, content, now);
+
+        let rep_before = rep.rep(&origin);
+        // A NEW seed (index 2) re-signs the already-Live content.
+        let id3 = Uuid::new_v4();
+        let s3 = signed(&seeds.seed(2), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (dec, _c) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
+            &mut staging, &mut rep, &cfg, now);
+
+        assert_eq!(dec, AdmitDecision::Drop, "echo ⇒ no new memory");
+        assert!(rep.dag().is_promoted(&h), "content stays Live");
+        assert_eq!(rep.rep(&origin), rep_before, "echo accrues nothing to the origin");
+        assert!(!staging.contains(&h), "echo creates no staging entry");
+    }
+
+    // --- (f) wire immune/amplitude injection is neutralized ----------------
+    #[test]
+    fn wire_injection_is_sanitized() {
+        let cfg = test_cfg(vec![], false); // dormant is sufficient for sanitization
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+
+        // Task (f): wire hallucinated=false, amplitude=1.0.
+        let (_d, clean) = admit("x", 1.0, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
+            None, &mut staging, &mut rep, &cfg, 1);
+        assert!(clean.amplitude <= MAX_WIRE_AMPLITUDE, "amplitude clamped ≤0.95");
+        assert!(!clean.hallucinated, "hallucinated is the local default");
+
+        // Stronger: attacker sets the wire immune flag TRUE — must NOT be taken.
+        let (_d2, clean2) = admit("y", 1.0, 0.0, 0.1, true, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
+            None, &mut staging, &mut rep, &cfg, 1);
+        assert!(!clean2.hallucinated, "the wire immune flag is never trusted");
+
+        // And it applies onto a real memory.
+        let mut mem = HyperMemory::new(vec![0.0; 4], "y".to_string());
+        mem.hallucinated = true;
+        mem.amplitude = 42.0;
+        clean2.apply(&mut mem);
+        assert!(!mem.hallucinated && mem.amplitude <= MAX_WIRE_AMPLITUDE);
+    }
+
+    // --- persistence round-trip (staging survives reload) ------------------
+    #[test]
+    fn staging_persist_reload() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let dir = tempfile::tempdir().unwrap();
+        let now = 1_000_000;
+        let content = "a claim awaiting corroboration";
+        let h = content_hash(content);
+        {
+            let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+            let mut staging = QuarantineStaging::load(dir.path());
+            let id = Uuid::new_v4();
+            let sig = signed(&NON_SEED, id, content, SUBJECT_MEMORY_NEW, 0.5, now);
+            let (dec, _c) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id, Some(&sig),
+                &mut staging, &mut rep, &cfg, now);
+            assert_eq!(dec, AdmitDecision::Quarantine);
+        }
+        let reloaded = QuarantineStaging::load(dir.path());
+        assert!(reloaded.contains(&h), "staged entry survived reload");
+    }
+}

--- a/src/absorb_gate.rs
+++ b/src/absorb_gate.rs
@@ -196,16 +196,23 @@ pub fn content_hash(content: &str) -> [u8; 32] {
 // admit() — the chokepoint
 // ---------------------------------------------------------------------------
 
-/// The absorb chokepoint. Returns the promotion decision plus the sanitized
-/// fields the caller must apply before any insert.
+/// The absorb chokepoint. Returns the promotion decision, the sanitized fields
+/// the caller must apply before any insert, and — for a `Live` decision — a
+/// [`PendingPromotion`] the caller commits AFTER a successful medium insert.
 ///
-/// - **Dormant** (`!gate_active` or no live seeds): returns `(Live, cleaned)` —
-///   inc-0 behaviour preserved. The caller still applies `cleaned` (the
+/// - **Dormant** (`!gate_active` or no live seeds): returns `(Live, cleaned,
+///   None)` — inc-0 behaviour preserved. The caller still applies `cleaned` (the
 ///   unconditional field bug-fix) and keeps whatever inc-0 source gating it had.
 /// - **Active**: a valid, fresh signature is required (`Drop` otherwise). An echo
 ///   of already-Live content records the corroboration edge and returns `Drop`
 ///   (no new memory, no accrual). Otherwise the signer is accumulated into the
 ///   per-content staging set and [`RepStore::decide`] governs.
+/// - **#8 commit ordering**: on a `Live` decision `admit` does NOT record the
+///   promotion inline. It returns `Some(PendingPromotion)`; the caller inserts
+///   into the live medium and calls [`commit_promotion`] ONLY on `Ok`. If the
+///   insert fails the caller drops the pending — the DAG stays un-promoted and
+///   the content re-decides `Live` on retry (no ledger/medium divergence). Every
+///   non-`Live` decision returns `None`.
 #[allow(clippy::too_many_arguments)]
 pub fn admit(
     content: &str,
@@ -220,13 +227,13 @@ pub fn admit(
     rep: &mut RepStore,
     cfg: &KannakaConfig,
     now_ms: i64,
-) -> (AdmitDecision, CleanFields) {
+) -> (AdmitDecision, CleanFields, Option<PendingPromotion>) {
     // (a) ALWAYS sanitize — unconditional inc-1b bug fix.
     let clean = sanitize(wire_amp, wire_phase, wire_freq);
 
     // (b) Dormant: no promotion logic, no signature requirement.
     if !gate_active(cfg) || rep.live_seed_count() == 0 {
-        return (AdmitDecision::Live, clean);
+        return (AdmitDecision::Live, clean, None);
     }
 
     // (c) Active: a valid + fresh signature is a hard precondition.
@@ -250,13 +257,13 @@ pub fn admit(
                         .check_and_insert(memory_id, &s.nonce, now_ms)
                         .is_err()
                 {
-                    return (AdmitDecision::Drop, clean);
+                    return (AdmitDecision::Drop, clean, None);
                 }
                 pk
             }
-            Err(_) => return (AdmitDecision::Drop, clean),
+            Err(_) => return (AdmitDecision::Drop, clean, None),
         },
-        None => return (AdmitDecision::Drop, clean),
+        None => return (AdmitDecision::Drop, clean, None),
     };
 
     let epoch = epoch_now(cfg, now_ms);
@@ -269,7 +276,7 @@ pub fn admit(
         let root = rep.seed_root_of(&pk);
         rep.record_promotion(h, pk, epoch, vec![(pk, root)], &cfg.swarm_trust);
         let _ = staging.save();
-        return (AdmitDecision::Drop, clean);
+        return (AdmitDecision::Drop, clean, None);
     }
 
     // (e) Accumulate this distinct signer, then decide.
@@ -302,29 +309,70 @@ pub fn admit(
             // content re-decides Live the moment a fresh beacon arrives.
             if !staging.beacons.fresh(epoch, cfg.swarm_trust.beacon_grace_epochs) {
                 let _ = staging.save();
-                return (AdmitDecision::Quarantine, clean);
+                return (AdmitDecision::Quarantine, clean, None);
             }
-            // Promote: accrue to the origin + mark Live in the DAG, then drop the
-            // staged copy (the caller inserts the current memory into the medium).
-            rep.record_promotion(h, origin, epoch, corroborators, &cfg.swarm_trust);
-            let _ = staging.promote(&h);
+            // (#8) DEFER the commit. The medium insert is the commit point: the
+            // caller inserts, then calls `commit_promotion` ONLY on Ok. We save
+            // the accumulated corroborator set (so a retry re-reaches quorum) but
+            // do NOT record the DAG promotion or drop the staged copy here — if
+            // the caller's insert fails it drops the pending and the content
+            // re-decides Live on the next attempt (no ledger/medium divergence).
             let _ = staging.save();
-            (AdmitDecision::Live, clean)
+            let pending = PendingPromotion { h, origin, epoch, corroborators };
+            (AdmitDecision::Live, clean, Some(pending))
         }
         Promotion::ProbationLive => {
             let _ = staging.save();
-            (AdmitDecision::ProbationLive, clean)
+            (AdmitDecision::ProbationLive, clean, None)
         }
         Promotion::Quarantine => {
             let _ = staging.save();
-            (AdmitDecision::Quarantine, clean)
+            (AdmitDecision::Quarantine, clean, None)
         }
         // decide() never emits Drop, but map it for completeness.
         Promotion::Drop => {
             let _ = staging.promote(&h);
-            (AdmitDecision::Drop, clean)
+            (AdmitDecision::Drop, clean, None)
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// PendingPromotion + commit_promotion — the #8 commit-ordering split
+// ---------------------------------------------------------------------------
+
+/// The deferred commit of a `Live` [`admit`] decision (finding #8). Returned by
+/// [`admit`] when a memory reaches quorum; the caller passes it to
+/// [`commit_promotion`] ONLY after the live-medium insert returns `Ok`, so the
+/// DAG ledger never records a promotion the medium is missing. Opaque to
+/// callers — construct it only via [`admit`].
+#[derive(Debug, Clone)]
+pub struct PendingPromotion {
+    h: [u8; 32],
+    origin: PubKey,
+    epoch: u64,
+    corroborators: Vec<(PubKey, Option<PubKey>)>,
+}
+
+/// Commit the deferred half of a `Live` [`admit`] decision AFTER a successful
+/// medium insert (finding #8): record the DAG promotion + rep accrual and drop
+/// the staged copy. Call this ONLY once `store.insert(...)` (or
+/// `remember_with_category`) has returned `Ok`. On an insert error the caller
+/// drops the pending WITHOUT calling this — the DAG stays un-promoted and the
+/// same content re-decides `Live` on retry, so the ledger and the live medium
+/// never diverge. A `None` (dormant / non-`Live` decision) is a no-op.
+pub fn commit_promotion(
+    pending: Option<PendingPromotion>,
+    rep: &mut RepStore,
+    staging: &mut QuarantineStaging,
+    cfg: &KannakaConfig,
+) {
+    let Some(p) = pending else {
+        return;
+    };
+    rep.record_promotion(p.h, p.origin, p.epoch, p.corroborators, &cfg.swarm_trust);
+    let _ = staging.promote(&p.h);
+    let _ = staging.save();
 }
 
 // ---------------------------------------------------------------------------
@@ -383,14 +431,21 @@ impl QuarantineStaging {
     /// treated as empty (the corroboration record is reconstructable from the
     /// append-only reputation log). The replay set fails closed on corruption.
     pub fn load(data_dir: &Path) -> Self {
+        Self::load_bounded(data_dir, STAGING_CAP, STAGING_TTL_MS, now_ms())
+    }
+
+    /// [`load`](QuarantineStaging::load) with explicit bounds + clock so the #12
+    /// re-eviction is testable deterministically. Production `load` passes the
+    /// [`STAGING_CAP`] / [`STAGING_TTL_MS`] constants and `now_ms()`.
+    fn load_bounded(data_dir: &Path, cap: usize, ttl_ms: i64, now: i64) -> Self {
         let dir = data_dir.join("quarantine");
         let mut s = Self {
-            replay: ReplayLru::load(&dir.join("replay.json"), now_ms()),
+            replay: ReplayLru::load(&dir.join("replay.json"), now),
             beacons: BeaconTracker::load(&dir.join("beacons.json")),
             dir: Some(dir.clone()),
             entries: HashMap::new(),
-            cap: STAGING_CAP,
-            ttl_ms: STAGING_TTL_MS,
+            cap,
+            ttl_ms,
         };
         if let Ok(bytes) = std::fs::read(dir.join("staging.json")) {
             if let Ok(wire) = serde_json::from_slice::<StagingWire>(&bytes) {
@@ -412,6 +467,14 @@ impl QuarantineStaging {
                     );
                 }
             }
+        }
+        // #12: a persisted staging.json is untrusted input. Re-apply the SAME
+        // eviction the write path (`add_corroborator`) enforces — drop entries
+        // past the TTL, then evict oldest until under the cap — so a stale or
+        // over-cap file can't smuggle entries past the disk-full defense.
+        s.evict_expired(now);
+        while s.entries.len() > s.cap {
+            s.evict_oldest();
         }
         s
     }
@@ -694,7 +757,7 @@ mod tests {
         assert!(!gate_active(&cfg), "seeds pinned + gate off => NOT active");
         let mut rep = RepStore::in_memory(&cfg.swarm_trust);
         let mut staging = QuarantineStaging::in_memory();
-        let (dec, clean) = admit(
+        let (dec, clean, _) = admit(
             "rollout-state content",
             5.0, 100.0, 9e9, true, // absurd + wire immune flag set
             SUBJECT_MEMORY_NEW,
@@ -716,7 +779,7 @@ mod tests {
         let cfg = test_cfg(vec![], false); // gate off, no seeds
         let mut rep = RepStore::in_memory(&cfg.swarm_trust);
         let mut staging = QuarantineStaging::in_memory();
-        let (dec, clean) = admit(
+        let (dec, clean, _) = admit(
             "hello world",
             5.0,   // absurd amplitude
             100.0, // absurd phase
@@ -744,7 +807,7 @@ mod tests {
         let cfg = test_cfg(seeds.pubkeys_b64(), true);
         let mut rep = RepStore::in_memory(&cfg.swarm_trust);
         let mut staging = QuarantineStaging::in_memory();
-        let (dec, _clean) = admit(
+        let (dec, _clean, _) = admit(
             "novel content here that is long enough",
             0.5,
             0.0,
@@ -772,7 +835,7 @@ mod tests {
         let content = "an uncorroborated claim from an unknown handle";
         let mem_id = Uuid::new_v4();
         let sig = signed(&NON_SEED, mem_id, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (dec, _c) = admit(
+        let (dec, _c, _) = admit(
             content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, mem_id, Some(&sig),
             &mut staging, &mut rep, &cfg, now,
         );
@@ -805,23 +868,26 @@ mod tests {
         // author (non-seed) → Quarantine
         let id0 = Uuid::new_v4();
         let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (d0, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
+        let (d0, _, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
             &mut staging, &mut rep, &cfg, now);
         assert_eq!(d0, AdmitDecision::Quarantine);
 
         // seed 0 corroborates → ProbationLive (C=1 < K=2, seed present)
         let id1 = Uuid::new_v4();
         let s1 = signed(&seeds.seed(0), id1, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (d1, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
+        let (d1, _, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
             &mut staging, &mut rep, &cfg, now);
         assert_eq!(d1, AdmitDecision::ProbationLive);
 
-        // seed 1 corroborates → Live (C=2 ≥ K=2)
+        // seed 1 corroborates → Live (C=2 ≥ K=2). #8: admit returns a pending
+        // promotion; commit it (simulating a successful medium insert) so the
+        // DAG records the promotion the same way the wired callers do.
         let id2 = Uuid::new_v4();
         let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (d2, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
+        let (d2, _, pending) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
             &mut staging, &mut rep, &cfg, now);
         assert_eq!(d2, AdmitDecision::Live);
+        commit_promotion(pending, &mut rep, &mut staging, &cfg);
 
         let h = content_hash(content);
         (rep, staging, cfg, h, verifying_key_bytes(&NON_SEED))
@@ -861,11 +927,12 @@ mod tests {
             &mut staging, &mut rep, &cfg, now);
         let id2 = Uuid::new_v4();
         let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (frozen, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
+        let (frozen, _, frozen_pending) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
             &mut staging, &mut rep, &cfg, now);
 
         let h = content_hash(content);
         assert_eq!(frozen, AdmitDecision::Quarantine, "stale/absent beacons freeze promotion");
+        assert!(frozen_pending.is_none(), "a frozen promotion yields no pending commit");
         assert!(!rep.dag().is_promoted(&h), "frozen: not promoted to live");
         assert!(staging.contains(&h), "frozen content preserved in staging (never dropped)");
 
@@ -877,9 +944,10 @@ mod tests {
         staging.ingest_beacon(&beacon, &seed_set, now_epoch).unwrap();
         let id3 = Uuid::new_v4();
         let s3 = signed(&seeds.seed(2), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (thawed, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
+        let (thawed, _, thawed_pending) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
             &mut staging, &mut rep, &cfg, now);
         assert_eq!(thawed, AdmitDecision::Live, "a fresh seed beacon thaws promotion");
+        commit_promotion(thawed_pending, &mut rep, &mut staging, &cfg);
         assert!(rep.dag().is_promoted(&h), "promoted once beacons resumed");
     }
 
@@ -895,7 +963,7 @@ mod tests {
         // A NEW seed (index 2) re-signs the already-Live content.
         let id3 = Uuid::new_v4();
         let s3 = signed(&seeds.seed(2), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
-        let (dec, _c) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
+        let (dec, _c, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
             &mut staging, &mut rep, &cfg, now);
 
         assert_eq!(dec, AdmitDecision::Drop, "echo ⇒ no new memory");
@@ -912,13 +980,13 @@ mod tests {
         let mut staging = QuarantineStaging::in_memory();
 
         // Task (f): wire hallucinated=false, amplitude=1.0.
-        let (_d, clean) = admit("x", 1.0, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
+        let (_d, clean, _) = admit("x", 1.0, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
             None, &mut staging, &mut rep, &cfg, 1);
         assert!(clean.amplitude <= MAX_WIRE_AMPLITUDE, "amplitude clamped ≤0.95");
         assert!(!clean.hallucinated, "hallucinated is the local default");
 
         // Stronger: attacker sets the wire immune flag TRUE — must NOT be taken.
-        let (_d2, clean2) = admit("y", 1.0, 0.0, 0.1, true, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
+        let (_d2, clean2, _) = admit("y", 1.0, 0.0, 0.1, true, SUBJECT_MEMORY_NEW, Uuid::new_v4(),
             None, &mut staging, &mut rep, &cfg, 1);
         assert!(!clean2.hallucinated, "the wire immune flag is never trusted");
 
@@ -936,7 +1004,10 @@ mod tests {
         let seeds = Seeds::new(3);
         let cfg = test_cfg(seeds.pubkeys_b64(), true);
         let dir = tempfile::tempdir().unwrap();
-        let now = 1_000_000;
+        // Use a real wall-clock `now`: #12 now re-applies the staging TTL on load
+        // (against `now_ms()`), so a fixture must stamp `first_seen` at real time
+        // or the entry is (correctly) aged out on reload.
+        let now = now_ms();
         let content = "a claim awaiting corroboration";
         let h = content_hash(content);
         {
@@ -944,11 +1015,191 @@ mod tests {
             let mut staging = QuarantineStaging::load(dir.path());
             let id = Uuid::new_v4();
             let sig = signed(&NON_SEED, id, content, SUBJECT_MEMORY_NEW, 0.5, now);
-            let (dec, _c) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id, Some(&sig),
+            let (dec, _c, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id, Some(&sig),
                 &mut staging, &mut rep, &cfg, now);
             assert_eq!(dec, AdmitDecision::Quarantine);
         }
         let reloaded = QuarantineStaging::load(dir.path());
         assert!(reloaded.contains(&h), "staged entry survived reload");
+    }
+
+    // --- (#6) invalid signature ⇒ Drop, not staged, not promoted -------------
+    #[test]
+    fn active_invalid_signature_drops() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let now = 1_000_000;
+        let mem_id = Uuid::new_v4();
+        // Sign over ONE content, then admit a DIFFERENT content with that sig —
+        // the signature verifies FALSE over the swapped bytes.
+        let sig = signed(&NON_SEED, mem_id, "the originally-signed content", SUBJECT_MEMORY_NEW, 0.5, now);
+        let forged = "attacker-swapped content the signature does NOT cover";
+        let (dec, _c, pending) = admit(
+            forged, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, mem_id, Some(&sig),
+            &mut staging, &mut rep, &cfg, now,
+        );
+        assert_eq!(dec, AdmitDecision::Drop, "sig verifies FALSE ⇒ Drop");
+        assert!(pending.is_none(), "a dropped memory yields no pending promotion");
+        let h = content_hash(forged);
+        assert!(!staging.contains(&h), "invalid-sig content is NOT staged");
+        assert!(!rep.dag().is_promoted(&h), "invalid-sig content is NOT promoted");
+    }
+
+    // --- (#7) SUBJECT_EXEMPLAR path round-trips (sign/verify amp from separate
+    // variables) ⇒ correct decision --------------------------------------------
+    #[test]
+    fn active_exemplar_path_round_trips() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let now = 1_000_000;
+        let content = "an exemplar observation awaiting corroboration";
+        let mem_id = Uuid::new_v4();
+        // SEPARATE variables for the signed vs verified amplitude; equal here, so
+        // verify passes. A sign/verify desync in the exemplar path would make the
+        // amp_q16 differ ⇒ BadSig ⇒ Drop, so asserting Quarantine proves the
+        // subject + amplitude are threaded consistently.
+        let sign_amp: f32 = 0.5;
+        let wire_amp: f32 = 0.5;
+        let sig = signed(&NON_SEED, mem_id, content, SUBJECT_EXEMPLAR, sign_amp, now);
+        let (dec, _c, pending) = admit(
+            content, wire_amp, 0.0, 0.1, false, SUBJECT_EXEMPLAR, mem_id, Some(&sig),
+            &mut staging, &mut rep, &cfg, now,
+        );
+        assert_eq!(dec, AdmitDecision::Quarantine, "exemplar verifies ⇒ single non-seed ⇒ Quarantine");
+        assert!(pending.is_none());
+        let h = content_hash(content);
+        assert!(staging.contains(&h), "exemplar sits in staging awaiting corroboration");
+    }
+
+    // --- (#14) replay: same (memory_id, nonce, sig) twice ⇒ 2nd is Drop ------
+    #[test]
+    fn active_replayed_sig_drops_second() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let now = 1_000_000;
+        let content = "a claim delivered twice with the identical signed envelope";
+        let mem_id = Uuid::new_v4();
+        let sig = signed(&NON_SEED, mem_id, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        // First delivery: verifies + fresh ⇒ Quarantine (single non-seed).
+        let (d1, _c1, _p1) = admit(
+            content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, mem_id, Some(&sig),
+            &mut staging, &mut rep, &cfg, now,
+        );
+        assert_eq!(d1, AdmitDecision::Quarantine, "first delivery ⇒ Quarantine");
+        // Second delivery: SAME (memory_id, nonce) ⇒ replay ⇒ Drop.
+        let (d2, _c2, p2) = admit(
+            content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, mem_id, Some(&sig),
+            &mut staging, &mut rep, &cfg, now,
+        );
+        assert_eq!(d2, AdmitDecision::Drop, "replayed (memory_id, nonce, sig) ⇒ Drop");
+        assert!(p2.is_none());
+    }
+
+    // --- (#8) insert-failure ordering: Live is pending until committed -------
+    #[test]
+    fn live_is_pending_until_committed_and_retryable() {
+        let seeds = Seeds::new(3);
+        let cfg = test_cfg(seeds.pubkeys_b64(), true);
+        let mut rep = RepStore::in_memory(&cfg.swarm_trust);
+        let mut staging = QuarantineStaging::in_memory();
+        let now = 1_000_000;
+        let content = "a fact whose live-medium insert fails on the first attempt";
+        let h = content_hash(content);
+
+        // Fresh beacon so the anti-eclipse gate doesn't freeze the promotion.
+        let seed_set: HashSet<PubKey> = (0..seeds.signing.len())
+            .map(|i| verifying_key_bytes(&seeds.seed(i)))
+            .collect();
+        let now_epoch = epoch_now(&cfg, now);
+        let beacon = Beacon::sign(&seeds.seed(0), now_epoch, [0u8; 32]);
+        staging.ingest_beacon(&beacon, &seed_set, now_epoch).unwrap();
+
+        // Drive to quorum: author (non-seed) + seed0 + seed1 ⇒ Live (K=2).
+        let id0 = Uuid::new_v4();
+        let s0 = signed(&NON_SEED, id0, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (_d0, _, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id0, Some(&s0),
+            &mut staging, &mut rep, &cfg, now);
+        let id1 = Uuid::new_v4();
+        let s1 = signed(&seeds.seed(0), id1, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (_d1, _, _) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id1, Some(&s1),
+            &mut staging, &mut rep, &cfg, now);
+        let id2 = Uuid::new_v4();
+        let s2 = signed(&seeds.seed(1), id2, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (d2, _c2, pending) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id2, Some(&s2),
+            &mut staging, &mut rep, &cfg, now);
+
+        assert_eq!(d2, AdmitDecision::Live, "quorum reached ⇒ Live");
+        assert!(pending.is_some(), "Live returns a pending promotion, not a committed one");
+        // The ledger is NOT yet mutated — commit is the caller's post-insert step.
+        assert!(!rep.dag().is_promoted(&h), "not committed until the medium insert succeeds");
+        assert!(staging.contains(&h), "content stays staged while the promotion is pending");
+
+        // SIMULATE INSERT FAILURE: the caller drops the pending WITHOUT committing.
+        drop(pending);
+        assert!(!rep.dag().is_promoted(&h), "insert failed ⇒ ledger still NOT promoted (re-decidable)");
+        assert!(staging.contains(&h), "content preserved for retry");
+
+        // RETRY: a fresh corroboration of the SAME content re-decides Live; this
+        // time the caller commits (insert Ok).
+        let id3 = Uuid::new_v4();
+        let s3 = signed(&seeds.seed(0), id3, content, SUBJECT_MEMORY_NEW, 0.5, now);
+        let (d3, _c3, pending3) = admit(content, 0.5, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id3, Some(&s3),
+            &mut staging, &mut rep, &cfg, now);
+        assert_eq!(d3, AdmitDecision::Live, "same content re-decides Live on retry");
+        commit_promotion(pending3, &mut rep, &mut staging, &cfg);
+        assert!(rep.dag().is_promoted(&h), "committed after a successful insert");
+        assert!(!staging.contains(&h), "promoted content leaves staging on commit");
+    }
+
+    // --- (#12) load re-applies TTL + cap to a persisted staging.json ---------
+    #[test]
+    fn load_reapplies_ttl_and_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let qdir = dir.path().join("quarantine");
+        std::fs::create_dir_all(&qdir).unwrap();
+        let now = 10 * STAGING_TTL_MS; // well past the TTL for the "old" entries
+
+        // 2 STALE (first_seen ancient) + 5 FRESH entries persisted to disk.
+        let mut entries = Vec::new();
+        for i in 0..2u8 {
+            entries.push(StagedWire {
+                hash: [i; 32],
+                content: format!("stale-{i}"),
+                amplitude: 0.1,
+                phase: 0.0,
+                frequency: 0.1,
+                hallucinated: false,
+                first_seen: 0, // ancient ⇒ TTL-evicted on load
+                origin: [i; 32],
+                corroborators: vec![[i; 32]],
+            });
+        }
+        for i in 10..15u8 {
+            entries.push(StagedWire {
+                hash: [i; 32],
+                content: format!("fresh-{i}"),
+                amplitude: 0.1,
+                phase: 0.0,
+                frequency: 0.1,
+                hallucinated: false,
+                first_seen: now, // fresh
+                origin: [i; 32],
+                corroborators: vec![[i; 32]],
+            });
+        }
+        let wire = StagingWire { entries };
+        std::fs::write(qdir.join("staging.json"), serde_json::to_vec(&wire).unwrap()).unwrap();
+
+        // Load with a small cap (2) + the real TTL: stale gone, fresh trimmed to cap.
+        let loaded = QuarantineStaging::load_bounded(dir.path(), 2, STAGING_TTL_MS, now);
+        assert_eq!(loaded.len(), 2, "trimmed to cap after TTL eviction");
+        assert!(!loaded.contains(&[0u8; 32]), "stale entry evicted by TTL");
+        assert!(!loaded.contains(&[1u8; 32]), "stale entry evicted by TTL");
     }
 }

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -1,0 +1,358 @@
+//! Heartbeat beacons — eclipse / partition fail-closed defense (inc-1b PART A).
+//!
+//! An eclipse or network partition can starve a node of the corroborations it
+//! needs and, worse, feed it a manufactured local "consensus" (synthesis §4.2).
+//! The corroboration gate ([`crate::absorb_gate`]) defends against this by
+//! requiring a FRESH signed heartbeat from at least one operator SEED before it
+//! will promote wire content to the live medium. If beacons go stale (the node
+//! stops hearing from the seed set), promotion **fails closed** — content is not
+//! dropped, it is frozen in the Quarantine staging tier until beacons resume.
+//!
+//! This module is the substrate:
+//!
+//! - [`Beacon`] — a `{ epoch, prev_reject_root, pubkey, sig }` statement signed
+//!   over [`crate::provenance::canonical_beacon`] (`DOMAIN_BEACON ‖ epoch ‖
+//!   prev_reject_root`). Only a SEED's beacon counts.
+//! - [`roll_reject_root`] — the lightweight blake3 rolling hash that stands in
+//!   for a full Merkle root of recently operator-rejected mem-hashes. Documented
+//!   simplification (synthesis §3.4): good enough to *bind* a reject summary into
+//!   the signed beacon so it can't be replayed with a swapped payload; a real
+//!   Merkle tree with membership proofs is a later drop-in.
+//! - [`BeaconTracker`] — records, per seed pubkey, the latest VERIFIED beacon
+//!   epoch seen; [`BeaconTracker::fresh`] answers the gate's freshness question.
+//!
+//! **Dormant by default:** nothing here runs unless the corroboration gate is
+//! armed (seeds pinned + `corroboration_gate_enabled`). With no seeds there are
+//! no beacons and no behavior change.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+
+use crate::provenance::{canonical_beacon, VerifyErr};
+use crate::reputation::PubKey;
+
+/// The rolling reject-root before any reject has been folded in.
+pub const EMPTY_REJECT_ROOT: [u8; 32] = [0u8; 32];
+
+/// Fold one operator-rejected mem-hash into the rolling reject-root:
+/// `root' = blake3(root ‖ rejected)`. A lightweight, order-sensitive stand-in
+/// for a full Merkle root of recent rejects (synthesis §3.4) — enough to bind a
+/// reject summary into a signed [`Beacon`]; not yet a proof-carrying tree.
+pub fn roll_reject_root(prev: &[u8; 32], rejected_mem_hash: &[u8; 32]) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(prev);
+    h.update(rejected_mem_hash);
+    *h.finalize().as_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Beacon
+// ---------------------------------------------------------------------------
+
+/// A signed heartbeat: proof that a seed was live at `epoch`, plus a summary of
+/// the rejects it has seen. `epoch ‖ prev_reject_root` is signed under
+/// `DOMAIN_BEACON`, so a signature minted for any other statement type (mem,
+/// phase, …) fails [`Beacon::verify`] by domain separation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Beacon {
+    /// Corroboration epoch this beacon attests liveness for.
+    pub epoch: u64,
+    /// Rolling blake3 summary of recently operator-rejected mem-hashes.
+    pub prev_reject_root: [u8; 32],
+    /// The signer's ed25519 verifying (public) key — must be a pinned SEED to count.
+    pub pubkey: [u8; 32],
+    /// The 64-byte ed25519 signature over the canonical beacon bytes.
+    pub sig: [u8; 64],
+}
+
+impl Beacon {
+    /// Sign a beacon for `epoch` with a raw 32-byte ed25519 seed.
+    pub fn sign(signing_seed: &[u8; 32], epoch: u64, prev_reject_root: [u8; 32]) -> Beacon {
+        let sk = SigningKey::from_bytes(signing_seed);
+        let msg = canonical_beacon(epoch, &prev_reject_root);
+        let sig = sk.sign(&msg);
+        Beacon {
+            epoch,
+            prev_reject_root,
+            pubkey: sk.verifying_key().to_bytes(),
+            sig: sig.to_bytes(),
+        }
+    }
+
+    /// Verify the beacon's signature over its canonical bytes. PURE — reads no
+    /// clock and no seed set (the caller decides trust). Returns the verified
+    /// signer pubkey on success, [`VerifyErr::BadSig`] otherwise.
+    pub fn verify(&self) -> Result<PubKey, VerifyErr> {
+        let vk = VerifyingKey::from_bytes(&self.pubkey).map_err(|_| VerifyErr::BadSig)?;
+        let signature = Signature::from_bytes(&self.sig);
+        let msg = canonical_beacon(self.epoch, &self.prev_reject_root);
+        vk.verify_strict(&msg, &signature).map_err(|_| VerifyErr::BadSig)?;
+        Ok(self.pubkey)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BeaconTracker
+// ---------------------------------------------------------------------------
+
+/// Why a beacon was not counted by [`BeaconTracker::ingest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeaconReject {
+    /// The ed25519 signature did not verify over the canonical beacon bytes.
+    BadSig,
+    /// The signer is not an operator-pinned seed — a non-seed beacon never counts.
+    NotSeed,
+    /// `epoch` is implausibly far in the future (> `now_epoch + 1`) — refusing
+    /// this stops an attacker from future-dating a beacon to stay "fresh" forever.
+    FutureEpoch,
+    /// Not newer than the latest epoch already recorded for this seed — a
+    /// replayed or stale beacon can never re-arm freshness.
+    Stale,
+}
+
+impl std::fmt::Display for BeaconReject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::BadSig => "beacon signature verification failed",
+            Self::NotSeed => "beacon signer is not a pinned seed",
+            Self::FutureEpoch => "beacon epoch is implausibly far in the future",
+            Self::Stale => "beacon epoch is not newer than the last seen (replay/stale)",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for BeaconReject {}
+
+/// Per-seed latest-verified-beacon-epoch tracker. Every recorded entry is a
+/// SEED (non-seed beacons are rejected at [`ingest`](BeaconTracker::ingest)), so
+/// [`fresh`](BeaconTracker::fresh) can answer "did any seed beacon recently?"
+/// without re-checking the seed set.
+#[derive(Debug, Default, Clone)]
+pub struct BeaconTracker {
+    /// `seed pubkey -> latest VERIFIED beacon epoch` (monotone per seed).
+    latest: HashMap<PubKey, u64>,
+}
+
+impl BeaconTracker {
+    /// An empty tracker (no beacons seen ⇒ NOT fresh ⇒ promotion fails closed).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Verify a beacon and, if it is a fresh SEED beacon, record its epoch.
+    ///
+    /// Rejects, in order: a bad signature ([`BeaconReject::BadSig`]); a non-seed
+    /// signer ([`BeaconReject::NotSeed`]); an epoch more than one ahead of
+    /// `now_epoch` ([`BeaconReject::FutureEpoch`]); and an epoch not strictly
+    /// newer than the last one recorded for this seed ([`BeaconReject::Stale`] —
+    /// this is what defeats a replayed old-epoch beacon). On success returns the
+    /// seed pubkey and advances its latest epoch.
+    pub fn ingest(
+        &mut self,
+        beacon: &Beacon,
+        seeds: &HashSet<PubKey>,
+        now_epoch: u64,
+    ) -> Result<PubKey, BeaconReject> {
+        let pk = beacon.verify().map_err(|_| BeaconReject::BadSig)?;
+        if !seeds.contains(&pk) {
+            return Err(BeaconReject::NotSeed);
+        }
+        if beacon.epoch > now_epoch.saturating_add(1) {
+            return Err(BeaconReject::FutureEpoch);
+        }
+        if let Some(&prev) = self.latest.get(&pk) {
+            if beacon.epoch <= prev {
+                return Err(BeaconReject::Stale);
+            }
+        }
+        self.latest.insert(pk, beacon.epoch);
+        Ok(pk)
+    }
+
+    /// Fail-closed freshness: true iff at least one recorded SEED beacon is
+    /// within `grace` epochs of `now_epoch` (i.e. `now_epoch <= epoch + grace`).
+    /// An empty tracker is NOT fresh — with no live beacon the gate freezes
+    /// promotion, which is the safe direction under eclipse/partition.
+    pub fn fresh(&self, now_epoch: u64, grace: u32) -> bool {
+        let g = grace as u64;
+        self.latest
+            .values()
+            .any(|&epoch| now_epoch <= epoch.saturating_add(g))
+    }
+
+    /// The latest verified beacon epoch for a seed, if any (inspection/tests).
+    pub fn latest_epoch(&self, pk: &PubKey) -> Option<u64> {
+        self.latest.get(pk).copied()
+    }
+
+    /// Number of seeds with a recorded beacon.
+    pub fn len(&self) -> usize {
+        self.latest.len()
+    }
+
+    /// True when no beacons have been recorded.
+    pub fn is_empty(&self) -> bool {
+        self.latest.is_empty()
+    }
+
+    /// Persist the tracker to `path` (best-effort JSON). A lost or corrupt file
+    /// simply reloads empty — which is the fail-closed direction (freeze until a
+    /// fresh beacon is re-ingested), so no atomic/fsync ceremony is needed.
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        let wire = BeaconTrackerWire {
+            entries: self.latest.iter().map(|(pk, e)| (*pk, *e)).collect(),
+        };
+        let bytes =
+            serde_json::to_vec(&wire).map_err(|e| format!("beacon: encode: {e}"))?;
+        std::fs::write(path, bytes).map_err(|e| format!("beacon: write {}: {e}", path.display()))
+    }
+
+    /// Load the tracker from `path`. Missing or corrupt ⇒ empty (fail-closed).
+    pub fn load(path: &Path) -> Self {
+        let parsed = std::fs::read(path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<BeaconTrackerWire>(&b).ok());
+        match parsed {
+            Some(w) => BeaconTracker {
+                latest: w.entries.into_iter().collect(),
+            },
+            None => BeaconTracker::new(),
+        }
+    }
+}
+
+/// On-disk shape of [`BeaconTracker`]. `[u8; 32]` is serde-native (serde ships
+/// array impls up to length 32), so no base64 wire is needed here.
+#[derive(Serialize, Deserialize, Default)]
+struct BeaconTrackerWire {
+    entries: Vec<([u8; 32], u64)>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A seed's raw signing seed and its derived verifying pubkey.
+    fn seed_key(n: u8) -> ([u8; 32], PubKey) {
+        let signing = [n; 32];
+        let pk = crate::provenance::verifying_key_bytes(&signing);
+        (signing, pk)
+    }
+
+    fn seed_set(pks: &[PubKey]) -> HashSet<PubKey> {
+        pks.iter().copied().collect()
+    }
+
+    // sign -> verify round-trip returns the signer pubkey.
+    #[test]
+    fn sign_verify_round_trip() {
+        let (signing, pk) = seed_key(1);
+        let b = Beacon::sign(&signing, 42, EMPTY_REJECT_ROOT);
+        assert_eq!(b.verify(), Ok(pk));
+        assert_eq!(b.pubkey, pk);
+    }
+
+    // Tampering the reject-root breaks the signature.
+    #[test]
+    fn tampered_reject_root_is_bad_sig() {
+        let (signing, _pk) = seed_key(1);
+        let mut b = Beacon::sign(&signing, 42, EMPTY_REJECT_ROOT);
+        b.prev_reject_root[0] ^= 0xFF;
+        assert_eq!(b.verify(), Err(VerifyErr::BadSig));
+    }
+
+    // roll_reject_root is deterministic and order-sensitive.
+    #[test]
+    fn roll_reject_root_is_order_sensitive() {
+        let a = [1u8; 32];
+        let bb = [2u8; 32];
+        let r_ab = roll_reject_root(&roll_reject_root(&EMPTY_REJECT_ROOT, &a), &bb);
+        let r_ba = roll_reject_root(&roll_reject_root(&EMPTY_REJECT_ROOT, &bb), &a);
+        assert_eq!(
+            r_ab,
+            roll_reject_root(&roll_reject_root(&EMPTY_REJECT_ROOT, &a), &bb),
+            "deterministic"
+        );
+        assert_ne!(r_ab, r_ba, "reject order changes the root");
+    }
+
+    // A fresh seed beacon makes the tracker fresh within grace.
+    #[test]
+    fn fresh_seed_beacon_is_fresh() {
+        let (signing, pk) = seed_key(1);
+        let seeds = seed_set(&[pk]);
+        let mut t = BeaconTracker::new();
+        assert!(!t.fresh(10, 3), "empty tracker is never fresh");
+        let b = Beacon::sign(&signing, 10, EMPTY_REJECT_ROOT);
+        assert_eq!(t.ingest(&b, &seeds, 10), Ok(pk));
+        assert!(t.fresh(10, 3), "same epoch is fresh");
+        assert!(t.fresh(13, 3), "within grace (10..=13) is fresh");
+        assert!(!t.fresh(14, 3), "beyond grace freezes");
+    }
+
+    // A NON-seed beacon does not count toward freshness.
+    #[test]
+    fn non_seed_beacon_rejected() {
+        let (_s1, pk1) = seed_key(1); // the only pinned seed
+        let (signing2, _pk2) = seed_key(2); // a non-seed signer
+        let seeds = seed_set(&[pk1]);
+        let mut t = BeaconTracker::new();
+        let b = Beacon::sign(&signing2, 10, EMPTY_REJECT_ROOT);
+        assert_eq!(t.ingest(&b, &seeds, 10), Err(BeaconReject::NotSeed));
+        assert!(!t.fresh(10, 3), "a non-seed beacon leaves the tracker stale");
+    }
+
+    // A replayed old-epoch beacon is rejected (monotone per seed).
+    #[test]
+    fn replayed_old_epoch_rejected() {
+        let (signing, pk) = seed_key(1);
+        let seeds = seed_set(&[pk]);
+        let mut t = BeaconTracker::new();
+        let fresh = Beacon::sign(&signing, 10, EMPTY_REJECT_ROOT);
+        assert_eq!(t.ingest(&fresh, &seeds, 10), Ok(pk));
+        // Replay the same beacon: epoch 10 is not newer than the recorded 10.
+        assert_eq!(t.ingest(&fresh, &seeds, 12), Err(BeaconReject::Stale));
+        // An even older beacon is stale too.
+        let old = Beacon::sign(&signing, 5, EMPTY_REJECT_ROOT);
+        assert_eq!(t.ingest(&old, &seeds, 12), Err(BeaconReject::Stale));
+        assert_eq!(t.latest_epoch(&pk), Some(10), "latest epoch unchanged by replays");
+    }
+
+    // A future-dated beacon is refused (can't buy permanent freshness).
+    #[test]
+    fn future_dated_beacon_rejected() {
+        let (signing, pk) = seed_key(1);
+        let seeds = seed_set(&[pk]);
+        let mut t = BeaconTracker::new();
+        let future = Beacon::sign(&signing, 100, EMPTY_REJECT_ROOT);
+        assert_eq!(t.ingest(&future, &seeds, 10), Err(BeaconReject::FutureEpoch));
+        assert!(t.is_empty());
+    }
+
+    // Persistence round-trips the latest-epoch map.
+    #[test]
+    fn tracker_persist_reload() {
+        let (signing, pk) = seed_key(1);
+        let seeds = seed_set(&[pk]);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("beacons.json");
+        let mut t = BeaconTracker::new();
+        t.ingest(&Beacon::sign(&signing, 7, EMPTY_REJECT_ROOT), &seeds, 7).unwrap();
+        t.save(&path).unwrap();
+        let loaded = BeaconTracker::load(&path);
+        assert_eq!(loaded.latest_epoch(&pk), Some(7));
+        assert!(loaded.fresh(9, 3));
+        // A missing file loads empty (fail-closed).
+        let empty = BeaconTracker::load(&dir.path().join("nope.json"));
+        assert!(empty.is_empty());
+    }
+}

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -38,6 +38,13 @@ use crate::reputation::PubKey;
 /// The rolling reject-root before any reject has been folded in.
 pub const EMPTY_REJECT_ROOT: [u8; 32] = [0u8; 32];
 
+/// NATS subject a signed heartbeat [`Beacon`] is published on (PART A
+/// anti-eclipse). Deliberately under `KANNAKA.events.>` so it rides the swarm's
+/// existing anon publish/subscribe ACL — no server ACL change is needed for
+/// seeds to emit or peers to receive. Seeds publish here (`publish_beacon`) and
+/// the `swarm listen --auto-sync` loop subscribes + ingests.
+pub const BEACON_SUBJECT: &str = "KANNAKA.events.beacon";
+
 /// Fold one operator-rejected mem-hash into the rolling reject-root:
 /// `root' = blake3(root ‖ rejected)`. A lightweight, order-sensitive stand-in
 /// for a full Merkle root of recent rejects (synthesis §3.4) — enough to bind a
@@ -92,6 +99,49 @@ impl Beacon {
         let msg = canonical_beacon(self.epoch, &self.prev_reject_root);
         vk.verify_strict(&msg, &signature).map_err(|_| VerifyErr::BadSig)?;
         Ok(self.pubkey)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Beacon JSON wire form
+// ---------------------------------------------------------------------------
+
+/// On-wire JSON shape of a [`Beacon`] — the fixed-width byte fields base64
+/// encoded (standard alphabet), exactly mirroring how
+/// [`crate::provenance::ProvenanceSig`] is put on the NATS wire. `epoch` is a
+/// plain integer. Unknown extra keys (e.g. the `schema_version`/`ts` envelope a
+/// publisher may add) are ignored on decode — no `deny_unknown_fields`.
+#[derive(Serialize, Deserialize)]
+struct BeaconWire {
+    epoch: u64,
+    prev_reject_root: String,
+    pubkey: String,
+    sig: String,
+}
+
+impl Serialize for Beacon {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        BeaconWire {
+            epoch: self.epoch,
+            prev_reject_root: crate::provenance::b64_encode(&self.prev_reject_root),
+            pubkey: crate::provenance::b64_encode(&self.pubkey),
+            sig: crate::provenance::b64_encode(&self.sig),
+        }
+        .serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Beacon {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use crate::provenance::b64_decode_arr;
+        let w = BeaconWire::deserialize(d)?;
+        Ok(Beacon {
+            epoch: w.epoch,
+            prev_reject_root: b64_decode_arr::<32>(&w.prev_reject_root)
+                .map_err(serde::de::Error::custom)?,
+            pubkey: b64_decode_arr::<32>(&w.pubkey).map_err(serde::de::Error::custom)?,
+            sig: b64_decode_arr::<64>(&w.sig).map_err(serde::de::Error::custom)?,
+        })
     }
 }
 
@@ -268,6 +318,31 @@ mod tests {
         let mut b = Beacon::sign(&signing, 42, EMPTY_REJECT_ROOT);
         b.prev_reject_root[0] ^= 0xFF;
         assert_eq!(b.verify(), Err(VerifyErr::BadSig));
+    }
+
+    // The JSON wire form round-trips exactly, and a tampered wire byte (a
+    // flipped signature byte carried across the wire) fails verify.
+    #[test]
+    fn wire_round_trip_and_tampered_byte_fails_verify() {
+        let (signing, pk) = seed_key(1);
+        let b = Beacon::sign(&signing, 77, EMPTY_REJECT_ROOT);
+
+        // to_wire -> from_wire equal, and the round-tripped beacon still verifies.
+        let json = serde_json::to_string(&b).expect("encode");
+        let back: Beacon = serde_json::from_str(&json).expect("decode");
+        assert_eq!(b, back, "wire round-trip is the identity");
+        assert_eq!(back.verify(), Ok(pk), "round-tripped beacon still verifies");
+
+        // Tamper ONE signature byte, carry it across the wire, and verify fails.
+        let mut tampered = back.clone();
+        tampered.sig[0] ^= 0xFF;
+        let j2 = serde_json::to_string(&tampered).expect("encode tampered");
+        let back2: Beacon = serde_json::from_str(&j2).expect("decode tampered");
+        assert_eq!(
+            back2.verify(),
+            Err(VerifyErr::BadSig),
+            "a tampered wire byte fails verify"
+        );
     }
 
     // roll_reject_root is deterministic and order-sensitive.

--- a/src/bin/handlers/identity.rs
+++ b/src/bin/handlers/identity.rs
@@ -13,11 +13,15 @@
 use std::io::Write;
 use std::process;
 
+use kannaka_memory::config::KannakaConfig;
 use kannaka_memory::identity::{
     self, AuthClient, IdentityError, IdentityStore, UserInfo,
 };
+use kannaka_memory::provenance::{node_signing_key, verifying_key_bytes};
+use kannaka_memory::reputation::{RepStore, SeedStatus};
 
-const USAGE: &str = "Usage: kannaka identity <register|login|whoami|logout> [--email ADDR]";
+const USAGE: &str = "Usage: kannaka identity \
+    <register|login|whoami|logout|keygen|pubkey|enroll-seed|vouch|revoke> [args]";
 
 pub(crate) fn handle_identity(args: &[String]) {
     let sub = match args.get(1) {
@@ -29,10 +33,17 @@ pub(crate) fn handle_identity(args: &[String]) {
     };
 
     match sub {
+        // SpaceChild SSO session.
         "register" => handle_register(args),
         "login" => handle_login(args),
         "whoami" => handle_whoami(),
         "logout" => handle_logout(),
+        // inc-1 cryptographic swarm identity + corroboration trust root.
+        "keygen" => handle_keygen(),
+        "pubkey" => handle_pubkey(),
+        "enroll-seed" => handle_enroll_seed(args),
+        "vouch" => handle_vouch(args),
+        "revoke" => handle_revoke(args),
         _ => {
             eprintln!("{USAGE}");
             process::exit(1);
@@ -161,8 +172,220 @@ fn handle_logout() {
 }
 
 // ---------------------------------------------------------------------------
+// inc-1 corroboration trust model — node key + seed/vouch/revoke
+// ---------------------------------------------------------------------------
+//
+// These verbs manage the node's CRYPTOGRAPHIC swarm identity (ed25519 node key)
+// and the operator trust root (pinned seeds + vouch lineage). They are
+// independent of the SpaceChild SSO session above. They change NO automatic
+// runtime behaviour: the corroboration gate stays dormant until an operator
+// pins a seed AND sets `swarm_trust.corroboration_gate_enabled`.
+//
+// config-vs-store split (judgment call):
+//   • seeds live in CONFIG (`swarm_trust.seed_pubkeys`) — operator-pinned,
+//     persisted to config.toml, the root `RepStore::seeds_from_cfg` reads.
+//   • vouch edges / poison live in the STORE (reputation.{log,snapshot.gz}) —
+//     derived trust state the DAG walks to a seed_root.
+
+/// `kannaka identity keygen` — ensure `<data_dir>/node_key.ed25519` exists and
+/// print this node's base64 verifying pubkey. Idempotent: a re-run prints the
+/// same key. The pubkey goes to STDOUT (scriptable); the note to stderr, so
+/// `keygen` and `pubkey` produce byte-identical stdout.
+fn handle_keygen() {
+    let (pk_b64, path) = ensure_node_pubkey();
+    println!("{pk_b64}");
+    eprintln!("  \u{2713} node key ensured at {}", path.display());
+    eprintln!(
+        "  This base64 pubkey is this node's swarm identity — share it to be \
+         enrolled as a seed or vouched into the web of trust."
+    );
+}
+
+/// `kannaka identity pubkey` — print this node's base64 verifying pubkey. Like
+/// keygen it ensures the key exists first (no additional side effect), but is
+/// framed as a plain read (stdout only).
+fn handle_pubkey() {
+    let (pk_b64, _path) = ensure_node_pubkey();
+    println!("{pk_b64}");
+}
+
+/// Ensure the node key exists; return `(base64_pubkey, key_path)`.
+fn ensure_node_pubkey() -> (String, std::path::PathBuf) {
+    let dir = KannakaConfig::data_dir();
+    let seed = match node_signing_key(&dir) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("  identity: could not load/create node key: {e}");
+            process::exit(1);
+        }
+    };
+    let pk = verifying_key_bytes(&seed);
+    (crate::b64_encode_std(&pk), dir.join("node_key.ed25519"))
+}
+
+/// Add a base64 seed pubkey to `cfg.swarm_trust.seed_pubkeys`, deduping by the
+/// decoded 32-byte key (so re-enrolling the same key, even with different
+/// padding/whitespace, is a no-op). Returns `(new_seed_count, added)` or an
+/// error if the key is malformed. Pure — mutates only the passed cfg — so it
+/// is unit-testable without touching disk.
+pub(crate) fn enroll_seed(cfg: &mut KannakaConfig, b64: &str) -> Result<(usize, bool), String> {
+    let pk = crate::b64_decode_32(b64)?;
+    let canon = crate::b64_encode_std(&pk);
+    let already = cfg
+        .swarm_trust
+        .seed_pubkeys
+        .iter()
+        .any(|s| crate::b64_decode_32(s).map(|d| d == pk).unwrap_or(false));
+    if !already {
+        cfg.swarm_trust.seed_pubkeys.push(canon);
+    }
+    Ok((cfg.swarm_trust.seed_pubkeys.len(), !already))
+}
+
+/// `kannaka identity enroll-seed <b64-pubkey>` — operator: pin a base64 pubkey
+/// as a trust-root seed. Validates 32-byte decode, dedups, persists to config.
+fn handle_enroll_seed(args: &[String]) {
+    let usage = "Usage: kannaka identity enroll-seed <base64-pubkey>";
+    let b64 = require_arg(args, 2, usage);
+    // load_unmodified so persisting the seed set doesn't bake unrelated
+    // env-only values (KANNAKA_AGENT_ID, KANNAKA_NATS_URL, …) into the file.
+    let mut cfg = KannakaConfig::load_unmodified();
+    match enroll_seed(&mut cfg, &b64) {
+        Ok((count, added)) => {
+            if !added {
+                println!("  seed already enrolled — {count} seed(s) pinned");
+                return;
+            }
+            if let Err(e) = cfg.save() {
+                eprintln!("  enroll-seed: failed to save config: {e}");
+                process::exit(1);
+            }
+            println!("  \u{2713} enrolled seed — {count} seed(s) now pinned");
+            println!(
+                "  Seeds are the trust root: every promotion lineage must resolve to a \
+                 pinned seed. The gate stays dormant until swarm_trust.corroboration_gate_enabled."
+            );
+        }
+        Err(e) => {
+            eprintln!("  enroll-seed: malformed pubkey — {e}");
+            process::exit(1);
+        }
+    }
+}
+
+/// `kannaka identity vouch <b64-pubkey>` — if THIS node is itself a pinned
+/// seed, record a vouch edge `this_node -> target` in the reputation DAG
+/// (persisted), building `seed_root` lineage for a non-seed peer. Non-seeds
+/// are refused.
+fn handle_vouch(args: &[String]) {
+    let usage = "Usage: kannaka identity vouch <base64-pubkey>";
+    let target_b64 = require_arg(args, 2, usage);
+    let target = match crate::b64_decode_32(&target_b64) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("  vouch: malformed pubkey — {e}");
+            process::exit(1);
+        }
+    };
+    let dir = KannakaConfig::data_dir();
+    let cfg = KannakaConfig::load();
+    let me = match node_signing_key(&dir) {
+        Ok(seed) => verifying_key_bytes(&seed),
+        Err(e) => {
+            eprintln!("  vouch: node key error: {e}");
+            process::exit(1);
+        }
+    };
+    let mut store = RepStore::load(&dir, &cfg.swarm_trust);
+    if store.seed_status(&me) != SeedStatus::Seed {
+        eprintln!("  vouch refused: only pinned seeds may vouch, and this node is not a seed.");
+        eprintln!("  this node's pubkey: {}", crate::b64_encode_std(&me));
+        eprintln!(
+            "  an operator can pin it with: kannaka identity enroll-seed {}",
+            crate::b64_encode_std(&me)
+        );
+        process::exit(1);
+    }
+    if me == target {
+        println!("  a seed already roots to itself — nothing to vouch.");
+        return;
+    }
+    store.record_vouch(me, target);
+    let root = store
+        .seed_root_of(&target)
+        .map(|r| crate::b64_encode_std(&r))
+        .unwrap_or_else(|| "-".to_string());
+    println!("  \u{2713} vouched {} -> {}", crate::b64_encode_std(&me), target_b64);
+    println!("  target seed_root now: {root}");
+}
+
+/// `kannaka identity revoke <b64-pubkey>` — operator: remove the key from the
+/// pinned seed set (if present) and record a revocation in the store, flooring
+/// its reputation to 0. The store's only rep-lowering lever is the operator
+/// poison (`P_POISON`), so this applies it until rep hits 0 (rep ∈ [0,1] and
+/// P_POISON = 0.5 ⇒ at most 2 events for a former non-seed).
+fn handle_revoke(args: &[String]) {
+    let usage = "Usage: kannaka identity revoke <base64-pubkey>";
+    let b64 = require_arg(args, 2, usage);
+    let pk = match crate::b64_decode_32(&b64) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("  revoke: malformed pubkey — {e}");
+            process::exit(1);
+        }
+    };
+
+    // 1. Config: drop it from the pinned seed set (dedup-safe by decoded bytes).
+    let mut cfg = KannakaConfig::load_unmodified();
+    let before = cfg.swarm_trust.seed_pubkeys.len();
+    cfg.swarm_trust
+        .seed_pubkeys
+        .retain(|s| crate::b64_decode_32(s).map(|d| d != pk).unwrap_or(true));
+    let removed_seed = cfg.swarm_trust.seed_pubkeys.len() != before;
+    if removed_seed {
+        if let Err(e) = cfg.save() {
+            eprintln!("  revoke: failed to save config: {e}");
+            process::exit(1);
+        }
+    }
+
+    // 2. Store: record the revocation (operator poison) and floor rep to 0.
+    //    Load the store with the POST-removal seed set so a former seed is now
+    //    a plain handle whose record rep can actually be driven down.
+    let dir = KannakaConfig::data_dir();
+    let mut store = RepStore::load(&dir, &cfg.swarm_trust);
+    let mut events = 0;
+    while store.rep(&pk) > 0.0 && events < 8 {
+        store.record_poison(pk, &cfg.swarm_trust);
+        events += 1;
+    }
+
+    if removed_seed {
+        println!(
+            "  \u{2713} revoked — unpinned from seeds ({} remain), rep floored to 0 ({events} poison event(s))",
+            cfg.swarm_trust.seed_pubkeys.len()
+        );
+    } else {
+        println!(
+            "  \u{2713} revoked — was not a pinned seed; rep floored to 0 ({events} poison event(s))"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// A required positional at `idx` (rejects a missing value or a `--flag`).
+fn require_arg(args: &[String], idx: usize, usage: &str) -> String {
+    match args.get(idx) {
+        Some(s) if !s.is_empty() && !s.starts_with("--") => s.clone(),
+        _ => {
+            eprintln!("{usage}");
+            process::exit(1);
+        }
+    }
+}
 
 /// id/email/expiry only — tokens never reach stdout.
 fn print_whoami(user: &UserInfo, access_token: &str) {
@@ -239,4 +462,74 @@ fn read_password(email: &str) -> String {
         process::exit(1);
     }
     password
+}
+
+// ---------------------------------------------------------------------------
+// Tests — inc-1 corroboration trust model verbs
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // keygen is idempotent: node_signing_key generates once then reloads the
+    // SAME key, so the printed base64 pubkey is stable across re-runs.
+    #[test]
+    fn keygen_pubkey_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let k1 = node_signing_key(dir.path()).unwrap();
+        let k2 = node_signing_key(dir.path()).unwrap();
+        assert_eq!(
+            crate::b64_encode_std(&verifying_key_bytes(&k1)),
+            crate::b64_encode_std(&verifying_key_bytes(&k2)),
+            "re-run must print the same pubkey"
+        );
+    }
+
+    // enroll-seed adds to the config seed set and dedups a repeat by decoded key.
+    #[test]
+    fn enroll_seed_adds_then_dedups() {
+        let mut cfg = KannakaConfig::default();
+        assert!(cfg.swarm_trust.seed_pubkeys.is_empty());
+        let pk_b64 = crate::b64_encode_std(&[7u8; 32]);
+
+        let (count1, added1) = enroll_seed(&mut cfg, &pk_b64).unwrap();
+        assert_eq!(count1, 1);
+        assert!(added1, "first enroll adds");
+
+        let (count2, added2) = enroll_seed(&mut cfg, &pk_b64).unwrap();
+        assert_eq!(count2, 1, "same key must not grow the set");
+        assert!(!added2, "repeat is a dedup no-op");
+    }
+
+    // enroll-seed rejects a malformed key (wrong length + invalid chars) and
+    // leaves the config untouched.
+    #[test]
+    fn enroll_seed_rejects_bad_key() {
+        let mut cfg = KannakaConfig::default();
+        // 16 bytes decodes fine as base64 but is the wrong length for a key.
+        assert!(enroll_seed(&mut cfg, &crate::b64_encode_std(&[1u8; 16])).is_err());
+        // Non-alphabet characters.
+        assert!(enroll_seed(&mut cfg, "!!! not base64 !!!").is_err());
+        assert!(
+            cfg.swarm_trust.seed_pubkeys.is_empty(),
+            "bad keys leave config untouched"
+        );
+    }
+
+    // A node that is NOT a pinned seed may not vouch — the refusal predicate
+    // handle_vouch checks (seed_status != Seed) holds for a fresh node with an
+    // empty seed set.
+    #[test]
+    fn non_seed_may_not_vouch() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = KannakaConfig::default(); // no seeds pinned
+        let store = RepStore::load(dir.path(), &cfg.swarm_trust);
+        let me = verifying_key_bytes(&node_signing_key(dir.path()).unwrap());
+        assert_ne!(
+            store.seed_status(&me),
+            SeedStatus::Seed,
+            "fresh node with no pinned seed is not a seed ⇒ vouch refused"
+        );
+    }
 }

--- a/src/bin/handlers/identity.rs
+++ b/src/bin/handlers/identity.rs
@@ -17,11 +17,12 @@ use kannaka_memory::config::KannakaConfig;
 use kannaka_memory::identity::{
     self, AuthClient, IdentityError, IdentityStore, UserInfo,
 };
+use kannaka_memory::beacon::Beacon;
 use kannaka_memory::provenance::{node_signing_key, verifying_key_bytes};
 use kannaka_memory::reputation::{RepStore, SeedStatus};
 
 const USAGE: &str = "Usage: kannaka identity \
-    <register|login|whoami|logout|keygen|pubkey|enroll-seed|vouch|revoke> [args]";
+    <register|login|whoami|logout|keygen|pubkey|enroll-seed|vouch|revoke|beacon> [args]";
 
 pub(crate) fn handle_identity(args: &[String]) {
     let sub = match args.get(1) {
@@ -44,6 +45,7 @@ pub(crate) fn handle_identity(args: &[String]) {
         "enroll-seed" => handle_enroll_seed(args),
         "vouch" => handle_vouch(args),
         "revoke" => handle_revoke(args),
+        "beacon" => handle_beacon(),
         _ => {
             eprintln!("{USAGE}");
             process::exit(1);
@@ -370,6 +372,54 @@ fn handle_revoke(args: &[String]) {
             "  \u{2713} revoked — was not a pinned seed; rep floored to 0 ({events} poison event(s))"
         );
     }
+}
+
+/// `kannaka identity beacon` — if THIS node is a pinned seed, emit a signed
+/// heartbeat beacon for the current epoch (PART A anti-eclipse). Prints the
+/// beacon as JSON to stdout so an operator can publish it to the swarm; a
+/// receiver verifies it and feeds `QuarantineStaging::ingest_beacon`
+/// (`BeaconTracker::ingest`). A non-seed is refused — only seed beacons count
+/// toward freshness. Changes NO automatic runtime behaviour (the gate stays
+/// dormant until seeds are pinned AND `corroboration_gate_enabled`).
+fn handle_beacon() {
+    let dir = KannakaConfig::data_dir();
+    let cfg = KannakaConfig::load();
+    let seed = match node_signing_key(&dir) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("  beacon: node key error: {e}");
+            process::exit(1);
+        }
+    };
+    let me = verifying_key_bytes(&seed);
+    let store = RepStore::load(&dir, &cfg.swarm_trust);
+    if store.seed_status(&me) != SeedStatus::Seed {
+        eprintln!("  beacon refused: only pinned seeds emit heartbeat beacons; this node is not a seed.");
+        eprintln!("  this node's pubkey: {}", crate::b64_encode_std(&me));
+        process::exit(1);
+    }
+
+    let now = kannaka_memory::provenance::now_ms();
+    let epoch = kannaka_memory::absorb_gate::epoch_now(&cfg, now);
+    // prev_reject_root: lightweight stand-in — the empty root until a persisted
+    // operator-reject log is wired (then fold each reject via
+    // kannaka_memory::beacon::roll_reject_root before signing).
+    let beacon = Beacon::sign(&seed, epoch, kannaka_memory::beacon::EMPTY_REJECT_ROOT);
+    let v = serde_json::json!({
+        "epoch": beacon.epoch,
+        "prev_reject_root": crate::b64_encode_std(&beacon.prev_reject_root),
+        "pubkey": crate::b64_encode_std(&beacon.pubkey),
+        "sig": crate::b64_encode_std(&beacon.sig),
+    });
+    println!("{v}");
+    eprintln!("  \u{2713} signed heartbeat beacon for epoch {epoch}");
+    // TODO(inc-1): publish this over NATS from the swarm serve/join loop, and on
+    // the receive side verify + feed QuarantineStaging::ingest_beacon so peers'
+    // freshness advances automatically instead of via this manual emit.
+    eprintln!(
+        "  Publish this to the swarm; receivers verify it and feed the beacon tracker \
+         (a stale/absent seed beacon freezes promotion — anti-eclipse fail-closed)."
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bin/handlers/identity.rs
+++ b/src/bin/handlers/identity.rs
@@ -405,21 +405,39 @@ fn handle_beacon() {
     // operator-reject log is wired (then fold each reject via
     // kannaka_memory::beacon::roll_reject_root before signing).
     let beacon = Beacon::sign(&seed, epoch, kannaka_memory::beacon::EMPTY_REJECT_ROOT);
-    let v = serde_json::json!({
-        "epoch": beacon.epoch,
-        "prev_reject_root": crate::b64_encode_std(&beacon.prev_reject_root),
-        "pubkey": crate::b64_encode_std(&beacon.pubkey),
-        "sig": crate::b64_encode_std(&beacon.sig),
-    });
-    println!("{v}");
+    // Print the beacon's JSON wire form (the SAME serde shape published below,
+    // so a captured line can be replayed by an operator/cron by hand).
+    match serde_json::to_string(&beacon) {
+        Ok(j) => println!("{j}"),
+        Err(e) => {
+            eprintln!("  beacon: failed to encode JSON: {e}");
+            process::exit(1);
+        }
+    }
     eprintln!("  \u{2713} signed heartbeat beacon for epoch {epoch}");
-    // TODO(inc-1): publish this over NATS from the swarm serve/join loop, and on
-    // the receive side verify + feed QuarantineStaging::ingest_beacon so peers'
-    // freshness advances automatically instead of via this manual emit.
-    eprintln!(
-        "  Publish this to the swarm; receivers verify it and feed the beacon tracker \
-         (a stale/absent seed beacon freezes promotion — anti-eclipse fail-closed)."
-    );
+
+    // PART A: PUBLISH to the swarm so peers' freshness advances automatically.
+    // The `swarm listen --auto-sync` loop subscribes to BEACON_SUBJECT, verifies
+    // and feeds QuarantineStaging::ingest_beacon (a stale/absent seed beacon
+    // freezes promotion — anti-eclipse fail-closed). The beacon is already
+    // printed above, so a publish failure is a warning, not a hard error — an
+    // operator can still relay the printed line.
+    let nats_url = if cfg.swarm.nats_url.is_empty() {
+        kannaka_memory::nats::DEFAULT_NATS_URL.to_string()
+    } else {
+        cfg.swarm.nats_url.clone()
+    };
+    match kannaka_memory::nats::SwarmTransport::connect(&nats_url) {
+        Ok(transport) => match transport.publish_beacon(&beacon) {
+            Ok(()) => eprintln!(
+                "  \u{2713} published beacon to {} on {}",
+                nats_url,
+                kannaka_memory::BEACON_SUBJECT
+            ),
+            Err(e) => eprintln!("  warning: beacon signed but NATS publish failed: {e}"),
+        },
+        Err(e) => eprintln!("  warning: beacon signed but NATS connect failed ({nats_url}): {e}"),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bin/handlers/reputation.rs
+++ b/src/bin/handlers/reputation.rs
@@ -1,0 +1,297 @@
+//! `kannaka reputation` — operator inspection of the inc-1 corroboration trust
+//! ledger.
+//!
+//! Read the pubkey-keyed reputation store (`show`, `list`) plus the single
+//! operator hard-reject lever (`hard-reject`). These verbs change NO automatic
+//! runtime behaviour: the corroboration gate stays dormant until an operator
+//! pins a seed AND sets `swarm_trust.corroboration_gate_enabled`. Follows the
+//! handler-extraction pattern in `handlers/substrate.rs`; base64 (standard
+//! alphabet, matching the provenance wire codec) lives in `bin/kannaka.rs` as
+//! `crate::b64_{encode_std,decode_32}` and is shared with the identity handler.
+//!
+//! config-vs-store split: seeds are read from config (`swarm_trust.seed_pubkeys`
+//! → `RepStore` seed set); rep/promoted/poison/lineage come from the store at
+//! `<data_dir>/reputation.{log,snapshot.gz}`.
+
+use std::process;
+
+use kannaka_memory::config::KannakaConfig;
+use kannaka_memory::reputation::{RepStore, SeedStatus};
+
+const USAGE: &str = "Usage: kannaka reputation \
+    <show <b64-pubkey> [--json] | list [--json] | hard-reject <b64-mem-hash> --origin <b64-pubkey>>";
+
+pub(crate) fn handle_reputation(args: &[String]) {
+    match args.get(1).map(|s| s.as_str()) {
+        Some("show") => handle_show(args),
+        Some("list") => handle_list(args),
+        Some("hard-reject") => handle_hard_reject(args),
+        _ => {
+            eprintln!("{USAGE}");
+            process::exit(1);
+        }
+    }
+}
+
+/// Enrollment status → the stable label the CLI + JSON expose.
+fn status_str(s: SeedStatus) -> &'static str {
+    match s {
+        SeedStatus::Seed => "Seed",
+        SeedStatus::Enrolled => "Enrolled",
+        SeedStatus::Unknown => "Unknown",
+    }
+}
+
+/// `kannaka reputation show <b64-pubkey> [--json]` — rep, seed_status,
+/// seed_root, and the promoted/poison bookkeeping counters for one pubkey. An
+/// unknown key is rep 0 / Unknown / seed_root "-".
+fn handle_show(args: &[String]) {
+    let usage = "Usage: kannaka reputation show <base64-pubkey> [--json]";
+    let b64 = require_positional(args, 2, usage);
+    let pk = match crate::b64_decode_32(&b64) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("  reputation show: malformed pubkey — {e}");
+            process::exit(1);
+        }
+    };
+    let json = args.iter().any(|a| a == "--json");
+
+    let cfg = KannakaConfig::load();
+    let dir = KannakaConfig::data_dir();
+    let store = RepStore::load(&dir, &cfg.swarm_trust);
+
+    let rep = store.rep(&pk);
+    let status = store.seed_status(&pk);
+    let seed_root = store.seed_root_of(&pk).map(|r| crate::b64_encode_std(&r));
+    let (promoted, poison) = store
+        .record(&pk)
+        .map(|r| (r.promoted, r.poison))
+        .unwrap_or((0, 0));
+
+    if json {
+        let v = serde_json::json!({
+            "pubkey": b64,
+            "rep": rep,
+            "status": status_str(status),
+            "seed_root": seed_root,
+            "promoted": promoted,
+            "poison": poison,
+            "fail_closed": store.refuses_promotion(),
+        });
+        println!("{v}");
+    } else {
+        println!("  pubkey:    {b64}");
+        println!("  rep:       {rep:.4}");
+        println!("  status:    {}", status_str(status));
+        println!("  seed_root: {}", seed_root.as_deref().unwrap_or("-"));
+        println!("  promoted:  {promoted}");
+        println!("  poison:    {poison}");
+        if store.refuses_promotion() {
+            println!(
+                "  note:      store is fail-closed (corrupt/unverifiable log) — all promotion refused"
+            );
+        }
+    }
+}
+
+/// `kannaka reputation list [--json]` — every known pubkey (pinned seeds ∪
+/// pubkeys carrying a rep record) with its rep + status.
+fn handle_list(args: &[String]) {
+    let json = args.iter().any(|a| a == "--json");
+
+    let cfg = KannakaConfig::load();
+    let dir = KannakaConfig::data_dir();
+    let store = RepStore::load(&dir, &cfg.swarm_trust);
+
+    // Known pubkeys = pinned seeds ∪ pubkeys that carry a rep record.
+    // BTreeSet keeps the listing deterministic (byte order).
+    let mut keys: std::collections::BTreeSet<[u8; 32]> = std::collections::BTreeSet::new();
+    for s in store.seeds() {
+        keys.insert(*s);
+    }
+    for r in store.records() {
+        keys.insert(r.pubkey);
+    }
+
+    #[allow(clippy::type_complexity)]
+    let rows: Vec<(String, f32, SeedStatus, Option<String>, u32, u32)> = keys
+        .iter()
+        .map(|pk| {
+            let (promoted, poison) = store
+                .record(pk)
+                .map(|r| (r.promoted, r.poison))
+                .unwrap_or((0, 0));
+            (
+                crate::b64_encode_std(pk),
+                store.rep(pk),
+                store.seed_status(pk),
+                store.seed_root_of(pk).map(|r| crate::b64_encode_std(&r)),
+                promoted,
+                poison,
+            )
+        })
+        .collect();
+
+    if json {
+        let arr: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|(pk, rep, status, root, promoted, poison)| {
+                serde_json::json!({
+                    "pubkey": pk,
+                    "rep": rep,
+                    "status": status_str(*status),
+                    "seed_root": root,
+                    "promoted": promoted,
+                    "poison": poison,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::Value::Array(arr));
+        return;
+    }
+
+    if rows.is_empty() {
+        println!("  (no known pubkeys — no seeds pinned and no reputation records yet)");
+        println!("  Pin a seed with: kannaka identity enroll-seed <base64-pubkey>");
+        return;
+    }
+    println!(
+        "  {:<44}  {:>7}  {:<9}  {:>8}  {:>6}",
+        "PUBKEY(b64)", "REP", "STATUS", "PROMOTED", "POISON"
+    );
+    for (pk, rep, status, _root, promoted, poison) in &rows {
+        println!(
+            "  {:<44}  {:>7.4}  {:<9}  {:>8}  {:>6}",
+            pk,
+            rep,
+            status_str(*status),
+            promoted,
+            poison
+        );
+    }
+    println!(
+        "  {} known pubkey(s); {} pinned seed(s)",
+        rows.len(),
+        store.live_seed_count()
+    );
+}
+
+/// `kannaka reputation hard-reject <b64-mem-hash> --origin <b64-pubkey>` —
+/// operator: dock the origin's reputation (`record_poison`, rep -= P_POISON)
+/// for a rejected memory.
+///
+/// The committed store keys reputation on the origin PUBKEY; resolving an
+/// origin *from* a mem_hash is the (not-yet-wired) admit layer's job, so the
+/// operator supplies `--origin` explicitly for now. The mem_hash is validated
+/// and echoed for the audit trail.
+fn handle_hard_reject(args: &[String]) {
+    let usage =
+        "Usage: kannaka reputation hard-reject <base64-mem-hash> --origin <base64-pubkey>";
+    let mem_b64 = require_positional(args, 2, usage);
+    let _mem_hash = match crate::b64_decode_32(&mem_b64) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("  hard-reject: malformed mem_hash — {e}");
+            process::exit(1);
+        }
+    };
+    // TODO(inc-1): M-of-N operator quorum — a hard-reject should require M
+    // operator signatures before it docks rep; today it is single-operator.
+    let origin_b64 = match flag_value(args, "--origin") {
+        Some(v) => v,
+        None => {
+            eprintln!("{usage}");
+            eprintln!("  (need --origin <base64-pubkey>: the memory origin whose rep to dock)");
+            process::exit(1);
+        }
+    };
+    let origin = match crate::b64_decode_32(&origin_b64) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("  hard-reject: malformed --origin pubkey — {e}");
+            process::exit(1);
+        }
+    };
+
+    let cfg = KannakaConfig::load();
+    let dir = KannakaConfig::data_dir();
+    let mut store = RepStore::load(&dir, &cfg.swarm_trust);
+
+    let before = store.rep(&origin);
+    store.record_poison(origin, &cfg.swarm_trust);
+    let after = store.rep(&origin);
+
+    println!("  \u{2713} hard-reject recorded for mem {mem_b64}");
+    println!("  origin {origin_b64}: rep {before:.4} -> {after:.4}");
+    if store.seed_status(&origin) == SeedStatus::Seed {
+        println!(
+            "  note: origin is a pinned seed — rep() reports 1.0 for seeds regardless; the poison \
+             is logged, but a seed's authority comes from the pin. Use `kannaka identity revoke` to unpin."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A required positional at `idx` (rejects a missing value or a `--flag`).
+fn require_positional(args: &[String], idx: usize, usage: &str) -> String {
+    match args.get(idx) {
+        Some(s) if !s.is_empty() && !s.starts_with("--") => s.clone(),
+        _ => {
+            eprintln!("{usage}");
+            process::exit(1);
+        }
+    }
+}
+
+/// The value following `flag` anywhere in `args`, if present.
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `reputation show` on an unknown key resolves to rep 0 / Unknown — the
+    // read-side the handler formats.
+    #[test]
+    fn show_unknown_key_is_rep_zero_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = KannakaConfig::default(); // no seeds pinned
+        let store = RepStore::load(dir.path(), &cfg.swarm_trust);
+        let unknown = [42u8; 32];
+        assert_eq!(store.rep(&unknown), 0.0, "unknown handle is rep 0");
+        assert_eq!(store.seed_status(&unknown), SeedStatus::Unknown);
+        assert_eq!(status_str(store.seed_status(&unknown)), "Unknown");
+        assert!(store.seed_root_of(&unknown).is_none(), "unknown handle has ⊥ lineage");
+        assert!(store.record(&unknown).is_none(), "unknown handle has no record");
+    }
+
+    #[test]
+    fn status_str_maps_all_variants() {
+        assert_eq!(status_str(SeedStatus::Seed), "Seed");
+        assert_eq!(status_str(SeedStatus::Enrolled), "Enrolled");
+        assert_eq!(status_str(SeedStatus::Unknown), "Unknown");
+    }
+
+    #[test]
+    fn flag_value_finds_and_misses() {
+        let args: Vec<String> = ["hard-reject", "MEM", "--origin", "PK"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(flag_value(&args, "--origin").as_deref(), Some("PK"));
+        assert_eq!(flag_value(&args, "--missing"), None);
+    }
+}

--- a/src/bin/handlers/swarm.rs
+++ b/src/bin/handlers/swarm.rs
@@ -714,7 +714,7 @@ pub(crate) fn handle_swarm_absorb(
             let wire_phase = e.get("phase").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
             let wire_freq = e.get("frequency").and_then(|v| v.as_f64()).unwrap_or(0.1) as f32;
             let now = kannaka_memory::provenance::now_ms();
-            let (decision, clean) = kannaka_memory::admit(
+            let (decision, clean, pending) = kannaka_memory::admit(
                 content, amp as f32, wire_phase, wire_freq, false,
                 kannaka_memory::SUBJECT_EXEMPLAR, memory_id, prov_sig.as_ref(),
                 &mut staging, &mut rep_store, cfg, now,
@@ -725,7 +725,13 @@ pub(crate) fn handle_swarm_absorb(
                     // Tag with provenance so we can identify swarm-origin memories later.
                     let category = format!("swarm:{}", source);
                     match sys.remember_with_category(content, &category, clean.amplitude as f64) {
-                        Ok(id) => { eprintln!("      remembered as {}", id); absorbed += 1; }
+                        Ok(id) => {
+                            // #8: commit the pending promotion ONLY after the medium
+                            // write succeeds (no-op when dormant / non-Live).
+                            kannaka_memory::commit_promotion(pending, &mut rep_store, &mut staging, cfg);
+                            eprintln!("      remembered as {}", id); absorbed += 1;
+                        }
+                        // #8: write failed — drop the pending, do not commit.
                         Err(e) => { eprintln!("      remember failed: {e}"); }
                     }
                 }
@@ -961,7 +967,7 @@ pub(crate) fn handle_swarm_autoabsorb(
             let wire_phase = e.get("phase").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
             let wire_freq = e.get("frequency").and_then(|v| v.as_f64()).unwrap_or(0.1) as f32;
             let now = kannaka_memory::provenance::now_ms();
-            let (decision, clean) = kannaka_memory::admit(
+            let (decision, clean, pending) = kannaka_memory::admit(
                 content, amp as f32, wire_phase, wire_freq, false,
                 kannaka_memory::SUBJECT_EXEMPLAR, memory_id, prov_sig.as_ref(),
                 &mut staging, &mut rep_store, cfg, now,
@@ -972,10 +978,14 @@ pub(crate) fn handle_swarm_autoabsorb(
                     let category = format!("swarm:{}", source);
                     match sys.remember_with_category(content, &category, clean.amplitude as f64) {
                         Ok(id) => {
+                            // #8: commit the pending promotion ONLY after the medium
+                            // write succeeds (no-op when dormant / non-Live).
+                            kannaka_memory::commit_promotion(pending, &mut rep_store, &mut staging, cfg);
                             eprintln!("[autoabsorb]   remembered {}", id);
                             state.record_absorb(&today_key, &source);
                             absorbed += 1;
                         }
+                        // #8: write failed — drop the pending, do not commit.
                         Err(e) => eprintln!("[autoabsorb]   remember failed: {e}"),
                     }
                 }

--- a/src/bin/handlers/swarm.rs
+++ b/src/bin/handlers/swarm.rs
@@ -386,9 +386,12 @@ pub(crate) fn handle_swarm_exemplars(
             // Order by mean_amplitude desc — strongest exemplars first.
             clusters.sort_by(|a, b| b.mean_amplitude.partial_cmp(&a.mean_amplitude)
                 .unwrap_or(std::cmp::Ordering::Equal));
+            // inc-1b: ALWAYS sign exemplar emits with the node key so peers running
+            // the corroboration gate can verify + accrue. Best-effort load.
+            let node_seed = kannaka_memory::provenance::node_signing_key(&data_dir()).ok();
             let mut published = 0;
             for c in clusters.iter().take(top_k) {
-                let payload = serde_json::json!({
+                let mut payload = serde_json::json!({
                     "agent_id": agent_id,
                     "cluster_id": c.cluster_id,
                     "size": c.size,
@@ -404,6 +407,33 @@ pub(crate) fn handle_swarm_exemplars(
                     "xi_diversity": c.xi_diversity,
                     "created_at": chrono::Utc::now().to_rfc3339(),
                 });
+                // Sign over (exemplar_id, content, amplitude) — the fields the
+                // absorbing node's admit() reconstructs. Only when both id+content
+                // are present and parseable.
+                if let (Some(seed), Some(content), Some(eid)) =
+                    (&node_seed, c.exemplar_content.as_deref(), c.exemplar_id.as_deref())
+                {
+                    if let Ok(mem_id) = uuid::Uuid::parse_str(eid) {
+                        let nonce = *uuid::Uuid::new_v4().as_bytes();
+                        let ts = kannaka_memory::provenance::now_ms();
+                        let sig = kannaka_memory::sign_mem(
+                            seed,
+                            kannaka_memory::SIGN_AGENT_ID,
+                            mem_id,
+                            &nonce,
+                            ts,
+                            content,
+                            kannaka_memory::SUBJECT_EXEMPLAR,
+                            kannaka_memory::provenance::amp_to_q16(c.mean_amplitude),
+                            kannaka_memory::PROV_TIER,
+                        );
+                        if let (Some(obj), Ok(v)) =
+                            (payload.as_object_mut(), serde_json::to_value(&sig))
+                        {
+                            obj.insert("provenance_sig".to_string(), v);
+                        }
+                    }
+                }
                 match transport.publish_exemplar(&agent_id, c.cluster_id, &payload) {
                     Ok(()) => published += 1,
                     Err(e) => eprintln!("[exemplars] cluster {} publish failed: {e}", c.cluster_id),
@@ -629,6 +659,12 @@ pub(crate) fn handle_swarm_absorb(
         bb.partial_cmp(&aa).unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    // inc-1b corroboration admit() chokepoint state. DORMANT unless the gate is
+    // enabled AND seeds are pinned (then it governs each absorb below).
+    let mut rep_store =
+        kannaka_memory::reputation::RepStore::load(&data_dir(), &cfg.swarm_trust);
+    let mut staging = kannaka_memory::absorb_gate::QuarantineStaging::load(&data_dir());
+
     for e in ordered.iter().take(top_k) {
         let source = e.get("agent_id").and_then(|v| v.as_str()).unwrap_or("?");
         if source == my_id {
@@ -667,11 +703,38 @@ pub(crate) fn handle_swarm_absorb(
         eprintln!("      \"{}\"", &content.chars().take(120).collect::<String>());
 
         if !dry_run {
-            // Tag with provenance so we can identify swarm-origin memories later.
-            let category = format!("swarm:{}", source);
-            match sys.remember_with_category(content, &category, amp.min(0.95)) {
-                Ok(id) => { eprintln!("      remembered as {}", id); absorbed += 1; }
-                Err(e) => { eprintln!("      remember failed: {e}"); }
+            // inc-1b: route through the corroboration admit() chokepoint. DORMANT
+            // ⇒ admit returns Live (current ungated behaviour) with a sanitized
+            // amplitude; ACTIVE ⇒ the decision governs.
+            let memory_id = e.get("exemplar_id").and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4);
+            let prov_sig: Option<kannaka_memory::ProvenanceSig> = e.get("provenance_sig")
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            let wire_phase = e.get("phase").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
+            let wire_freq = e.get("frequency").and_then(|v| v.as_f64()).unwrap_or(0.1) as f32;
+            let now = kannaka_memory::provenance::now_ms();
+            let (decision, clean) = kannaka_memory::admit(
+                content, amp as f32, wire_phase, wire_freq, false,
+                kannaka_memory::SUBJECT_EXEMPLAR, memory_id, prov_sig.as_ref(),
+                &mut staging, &mut rep_store, cfg, now,
+            );
+            use kannaka_memory::AdmitDecision::*;
+            match decision {
+                Live => {
+                    // Tag with provenance so we can identify swarm-origin memories later.
+                    let category = format!("swarm:{}", source);
+                    match sys.remember_with_category(content, &category, clean.amplitude as f64) {
+                        Ok(id) => { eprintln!("      remembered as {}", id); absorbed += 1; }
+                        Err(e) => { eprintln!("      remember failed: {e}"); }
+                    }
+                }
+                Quarantine | ProbationLive => {
+                    eprintln!("      quarantined (awaiting corroboration)");
+                }
+                Drop => {
+                    eprintln!("      dropped (invalid signature / echo)");
+                }
             }
         } else {
             absorbed += 1;
@@ -852,6 +915,12 @@ pub(crate) fn handle_swarm_autoabsorb(
     let mut skipped_resonant = 0usize;
     let mut skipped_low = 0usize;
 
+    // inc-1b corroboration admit() chokepoint state. DORMANT unless the gate is
+    // enabled AND seeds are pinned (then it governs each absorb below).
+    let mut rep_store =
+        kannaka_memory::reputation::RepStore::load(&data_dir(), &cfg.swarm_trust);
+    let mut staging = kannaka_memory::absorb_gate::QuarantineStaging::load(&data_dir());
+
     for e in ordered.iter() {
         let source = e.get("agent_id").and_then(|v| v.as_str()).unwrap_or("?").to_string();
         if source == *my_id { skipped_self += 1; continue; }
@@ -881,14 +950,41 @@ pub(crate) fn handle_swarm_autoabsorb(
         eprintln!("[autoabsorb] absorb from {} c{} amp={:.3} resonance={:.3}", source, cluster_id, amp, top_strength);
 
         if !dry_run {
-            let category = format!("swarm:{}", source);
-            match sys.remember_with_category(content, &category, amp.min(0.95)) {
-                Ok(id) => {
-                    eprintln!("[autoabsorb]   remembered {}", id);
-                    state.record_absorb(&today_key, &source);
-                    absorbed += 1;
+            // inc-1b: route through the corroboration admit() chokepoint. DORMANT
+            // ⇒ admit returns Live (current ungated behaviour) with a sanitized
+            // amplitude; ACTIVE ⇒ the decision governs.
+            let memory_id = e.get("exemplar_id").and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4);
+            let prov_sig: Option<kannaka_memory::ProvenanceSig> = e.get("provenance_sig")
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            let wire_phase = e.get("phase").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32;
+            let wire_freq = e.get("frequency").and_then(|v| v.as_f64()).unwrap_or(0.1) as f32;
+            let now = kannaka_memory::provenance::now_ms();
+            let (decision, clean) = kannaka_memory::admit(
+                content, amp as f32, wire_phase, wire_freq, false,
+                kannaka_memory::SUBJECT_EXEMPLAR, memory_id, prov_sig.as_ref(),
+                &mut staging, &mut rep_store, cfg, now,
+            );
+            use kannaka_memory::AdmitDecision::*;
+            match decision {
+                Live => {
+                    let category = format!("swarm:{}", source);
+                    match sys.remember_with_category(content, &category, clean.amplitude as f64) {
+                        Ok(id) => {
+                            eprintln!("[autoabsorb]   remembered {}", id);
+                            state.record_absorb(&today_key, &source);
+                            absorbed += 1;
+                        }
+                        Err(e) => eprintln!("[autoabsorb]   remember failed: {e}"),
+                    }
                 }
-                Err(e) => eprintln!("[autoabsorb]   remember failed: {e}"),
+                Quarantine | ProbationLive => {
+                    eprintln!("[autoabsorb]   quarantined (awaiting corroboration)");
+                }
+                Drop => {
+                    eprintln!("[autoabsorb]   dropped (invalid signature / echo)");
+                }
             }
         } else {
             absorbed += 1;

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -4348,8 +4348,6 @@ fn main() {
                         );
                     }
 
-                    let _ = sub.set_timeout(None);
-
                     let mut queen = kannaka_memory::QueenSync::new(
                         kannaka_memory::QueenConfig::default(),
                         &agent_id,
@@ -4386,7 +4384,87 @@ fn main() {
                         );
                     }
 
+                    // PART A anti-eclipse (heartbeat beacons over NATS). Resolve the
+                    // pinned seed set ONCE (config is loaded once for the listener's
+                    // life). ingest_beacon accepts only seed beacons; when dormant the
+                    // set is empty ⇒ every beacon is a NotSeed no-op (no behavior
+                    // change). This is the SAME `staging` admit() reads, so an ingested
+                    // fresh beacon un-freezes Live promotion.
+                    let seed_set: std::collections::HashSet<[u8; 32]> =
+                        rep_store.seeds().copied().collect();
+                    // A node whose OWN key is a pinned seed emits heartbeats. Only when
+                    // the gate is actually armed (gate_on) do we touch the node key, so
+                    // dormant nodes keep EXACT inc-0 behavior (no key load, no emit).
+                    let beacon_emit: Option<[u8; 32]> = if gate_on {
+                        match kannaka_memory::node_signing_key(&data_dir()) {
+                            Ok(seed) => {
+                                let me = kannaka_memory::verifying_key_bytes(&seed);
+                                if seed_set.contains(&me) {
+                                    eprintln!(
+                                        "[beacon] this node is a seed — emitting heartbeats \u{2264}1/epoch on {}",
+                                        kannaka_memory::BEACON_SUBJECT
+                                    );
+                                    Some(seed)
+                                } else {
+                                    None
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("[beacon] node key error — not emitting: {e}");
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    let mut last_beacon_epoch: Option<u64> = None;
+
+                    // A seed wakes on a per-epoch tick so it can emit even when the
+                    // swarm is quiet; a non-seed keeps the prior indefinite block (no
+                    // busy-loop, exact prior behavior).
+                    if beacon_emit.is_some() {
+                        let tick = std::time::Duration::from_millis(
+                            cfg.swarm_trust.epoch_length_ms.clamp(1_000, 60_000) as u64,
+                        );
+                        let _ = sub.set_timeout(Some(tick));
+                    } else {
+                        let _ = sub.set_timeout(None);
+                    }
+
                     loop {
+                        // PART A anti-eclipse EMIT (seed-only, \u{2264}1 per epoch). A node
+                        // that is itself a pinned seed publishes a signed heartbeat so an
+                        // ARMED gate anywhere on the swarm sees a fresh beacon and
+                        // un-freezes Live promotion. Non-seeds never emit.
+                        // TODO(ceremony): this listener owns emit + ingest for now. Which
+                        // production service is the canonical emitter (this listener vs
+                        // `serve` vs a dedicated beacon cron) is a seed-ceremony topology
+                        // decision — do NOT rewire serve/worker in this pass.
+                        if let Some(seed) = beacon_emit.as_ref() {
+                            let now = kannaka_memory::provenance::now_ms();
+                            let epoch = kannaka_memory::epoch_now(&cfg, now);
+                            if last_beacon_epoch != Some(epoch) {
+                                let beacon = kannaka_memory::Beacon::sign(
+                                    seed,
+                                    epoch,
+                                    kannaka_memory::EMPTY_REJECT_ROOT,
+                                );
+                                match transport.publish_beacon(&beacon) {
+                                    Ok(()) => {
+                                        last_beacon_epoch = Some(epoch);
+                                        // Keep THIS node's own gate fresh regardless of
+                                        // whether the broadcast echoes back to us.
+                                        let _ = staging.ingest_beacon(&beacon, &seed_set, epoch);
+                                        let _ = staging.save();
+                                        eprintln!("[beacon] published heartbeat for epoch {epoch}");
+                                    }
+                                    Err(e) => eprintln!(
+                                        "[beacon] publish failed for epoch {epoch}: {e}"
+                                    ),
+                                }
+                            }
+                        }
+
                         let msg = match sub.next_event() {
                             kannaka_memory::nats::SubEvent::Msg(m) => m,
                             kannaka_memory::nats::SubEvent::Timeout => continue,
@@ -4536,6 +4614,39 @@ fn main() {
                                     // source just needs sanitizing before it reaches the terminal.
                                     println!("[dream] {} completed dream: {} cycles, {} strengthened, {} pruned",
                                         kannaka_memory::sanitize_display(source_agent), cycles, strengthened, pruned);
+                                }
+                            }
+                        } else if msg.subject == kannaka_memory::BEACON_SUBJECT
+                            && auto_sync
+                            && !seed_set.is_empty()
+                        {
+                            // PART A anti-eclipse RECEIVE: verify + ingest a seed
+                            // heartbeat into the SAME `staging` admit() reads. Once a
+                            // fresh seed beacon lands, admit()'s freshness check passes
+                            // and Live promotion un-freezes. ingest_beacon rejects
+                            // non-seed / future / replayed epochs. Fully dormant (no
+                            // seeds pinned) ⇒ seed_set empty ⇒ this arm is skipped and
+                            // beacons are ignored silently (no behavior change, no noise).
+                            if let Some(beacon) = msg
+                                .as_json()
+                                .and_then(|v| serde_json::from_value::<kannaka_memory::Beacon>(v).ok())
+                            {
+                                let now = kannaka_memory::provenance::now_ms();
+                                let now_epoch = kannaka_memory::epoch_now(&cfg, now);
+                                match staging.ingest_beacon(&beacon, &seed_set, now_epoch) {
+                                    Ok(pk) => {
+                                        let _ = staging.save();
+                                        let pk_b64 = b64_encode_std(&pk);
+                                        eprintln!(
+                                            "[beacon] fresh seed beacon epoch {} from {}",
+                                            beacon.epoch,
+                                            &pk_b64[..pk_b64.len().min(12)]
+                                        );
+                                    }
+                                    // Our own broadcast echo / a replay re-ingests as
+                                    // Stale — expected, kept quiet.
+                                    Err(kannaka_memory::BeaconReject::Stale) => {}
+                                    Err(e) => eprintln!("[beacon] rejected: {e}"),
                                 }
                             }
                         }

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -65,6 +65,14 @@ use handlers_services::{handle_constellation, handle_market, handle_radio};
 mod handlers_identity;
 use handlers_identity::handle_identity;
 
+// inc-1 corroboration trust model — operator inspection of the reputation
+// ledger (`kannaka reputation show|list|hard-reject`). The seed/vouch/revoke
+// *write* verbs live under `kannaka identity` (handlers_identity) since they
+// manage the node's cryptographic swarm identity + trust root.
+#[path = "handlers/reputation.rs"]
+mod handlers_reputation;
+use handlers_reputation::handle_reputation;
+
 #[path = "handlers/ops.rs"]
 mod handlers_ops;
 use handlers_ops::{
@@ -583,6 +591,64 @@ pub(crate) fn parse_flag_value<T: std::str::FromStr>(
     }
 }
 
+/// Standard-alphabet base64 (padded) encode. The crate deliberately carries
+/// no `base64` dependency; this mirrors the codec in `provenance.rs` /
+/// `nats.rs` so a CLI-printed pubkey round-trips with the on-wire encoding
+/// (`ProvenanceSig`). Shared by the `identity` and `reputation` handlers.
+pub(crate) fn b64_encode_std(data: &[u8]) -> String {
+    const A: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(A[((n >> 18) & 63) as usize] as char);
+        out.push(A[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 { A[((n >> 6) & 63) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 2 { A[(n & 63) as usize] as char } else { '=' });
+    }
+    out
+}
+
+/// Decode standard-alphabet base64 into exactly 32 bytes — an ed25519
+/// verifying key or a blake3 mem-hash. Errors on any non-alphabet character or
+/// a wrong decoded length so the operator gets a clear message instead of a
+/// silent truncation. Same alphabet as [`b64_encode_std`], so keys round-trip
+/// with the provenance wire codec and `config.seed_pubkeys`.
+pub(crate) fn b64_decode_32(s: &str) -> Result<[u8; 32], String> {
+    let mut out: Vec<u8> = Vec::with_capacity(33);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in s.trim().as_bytes() {
+        if b == b'=' || b == b'\n' || b == b'\r' || b == b' ' {
+            continue;
+        }
+        let val: u32 = match b {
+            b'A'..=b'Z' => u32::from(b - b'A'),
+            b'a'..=b'z' => u32::from(b - b'a') + 26,
+            b'0'..=b'9' => u32::from(b - b'0') + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => return Err(format!("invalid base64 character '{}'", b as char)),
+        };
+        buf = (buf << 6) | val;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+    if out.len() != 32 {
+        return Err(format!("expected 32 bytes, decoded {}", out.len()));
+    }
+    let mut a = [0u8; 32];
+    a.copy_from_slice(&out);
+    Ok(a)
+}
+
 /// True when KANNAKA_READONLY requests no-persist mode. Mirrors
 /// `HrmStore::env_readonly` (any non-empty value other than "0"/"false").
 pub(crate) fn readonly_env_active() -> bool {
@@ -742,8 +808,10 @@ fn is_builtin_subcommand(verb: &str) -> bool {
         | "ask" | "chat" | "agent" | "voice"
         // swarm / nats
         | "swarm" | "events" | "substrate" | "attention" | "inbox"
-        // identity (SpaceChild SSO)
+        // identity (SpaceChild SSO + inc-1 crypto identity / trust root)
         | "identity"
+        // inc-1 corroboration trust model — reputation-ledger inspection
+        | "reputation"
         // constellation services
         | "radio" | "market" | "constellation"
         // ops / data movement
@@ -1194,10 +1262,18 @@ fn main() {
             handle_config(&cfg, &args[command_start..]);
             return;
         }
-        // SpaceChild SSO identity — pure HTTP + identity.json, never
-        // touches the HRM (keep it out of the 21 MB load below).
+        // SpaceChild SSO identity + inc-1 crypto identity/seed/vouch/revoke —
+        // pure config + node_key + reputation store, never touches the HRM
+        // (keep it out of the 21 MB load below).
         "identity" => {
             handle_identity(&args[command_start..]);
+            return;
+        }
+        // inc-1 corroboration trust model: operator inspection of the
+        // reputation ledger (config seeds + <data_dir>/reputation.{log,snapshot.gz}).
+        // No HRM needed — mirrors the identity fast path.
+        "reputation" => {
+            handle_reputation(&args[command_start..]);
             return;
         }
         // ADR-0037 belief: `on`/`off` only persist config (no HRM needed) and

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -4370,7 +4370,21 @@ fn main() {
                         kannaka_memory::reputation::RepStore::load(&data_dir(), &cfg.swarm_trust);
                     let mut staging =
                         kannaka_memory::absorb_gate::QuarantineStaging::load(&data_dir());
-                    let gate_on = kannaka_memory::gate_active(&cfg);
+                    // SECURITY (inc-1b): admit() treats "gate enabled but no live
+                    // seeds" as DORMANT (returns Live + sanitized). gate_on MUST
+                    // agree — otherwise an enabled gate with an unresolved / typo'd
+                    // seed would skip BOTH the inc-0 allowlist and admit's gate,
+                    // importing unsigned wire memory: fail-open below the inc-0
+                    // baseline. Align the predicate and warn on the misconfig.
+                    let gate_on = kannaka_memory::gate_active(&cfg)
+                        && rep_store.live_seed_count() > 0;
+                    if kannaka_memory::gate_active(&cfg) && rep_store.live_seed_count() == 0 {
+                        eprintln!(
+                            "[sync] WARNING: corroboration_gate_enabled=true but 0 live seeds \
+                             resolved from seed_pubkeys — running DORMANT (inc-0 allowlist) to \
+                             avoid fail-open. Pin seeds with `kannaka identity enroll-seed`."
+                        );
+                    }
 
                     loop {
                         let msg = match sub.next_event() {

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -1458,11 +1458,33 @@ fn main() {
                                 .try_cached_consciousness_metrics()
                                 .map(|m| m.num_clusters)
                                 .unwrap_or(0);
+                            // inc-1b: ALWAYS sign our own emits with the node key
+                            // (additive; lets peers running the corroboration gate
+                            // verify + accrue). Best-effort — a key error just omits
+                            // the signature (dormant peers ignore it anyway).
+                            let prov_sig = kannaka_memory::provenance::node_signing_key(&data_dir())
+                                .ok()
+                                .map(|seed| {
+                                    let nonce = *uuid::Uuid::new_v4().as_bytes();
+                                    let ts = kannaka_memory::provenance::now_ms();
+                                    kannaka_memory::sign_mem(
+                                        &seed,
+                                        kannaka_memory::SIGN_AGENT_ID,
+                                        mem.id,
+                                        &nonce,
+                                        ts,
+                                        &mem.content,
+                                        kannaka_memory::SUBJECT_MEMORY_NEW,
+                                        kannaka_memory::provenance::amp_to_q16(mem.amplitude),
+                                        kannaka_memory::PROV_TIER,
+                                    )
+                                });
                             if let Err(e) = transport.publish_memory_new_with_counts(
                                 mem,
                                 agent_id,
                                 total_mems,
                                 cluster_count,
+                                prov_sig.as_ref(),
                             ) {
                                 eprintln!("[nats] Warning: failed to publish memory sync: {}", e);
                             } else {
@@ -4264,6 +4286,16 @@ fn main() {
                     // the lifetime of the listener.
                     let trust = cfg.swarm_trust.clone();
 
+                    // inc-1b: the corroboration admit() chokepoint state. DORMANT
+                    // unless corroboration_gate_enabled AND seeds are pinned, in
+                    // which case the memory.new import gate below routes through
+                    // admit(). Loaded once — reused across the listen loop.
+                    let mut rep_store =
+                        kannaka_memory::reputation::RepStore::load(&data_dir(), &cfg.swarm_trust);
+                    let mut staging =
+                        kannaka_memory::absorb_gate::QuarantineStaging::load(&data_dir());
+                    let gate_on = kannaka_memory::gate_active(&cfg);
+
                     loop {
                         let msg = match sub.next_event() {
                             kannaka_memory::nats::SubEvent::Msg(m) => m,
@@ -4322,7 +4354,7 @@ fn main() {
                                         match serde_json::from_value::<kannaka_memory::HyperMemory>(
                                             mem_json.clone(),
                                         ) {
-                                            Ok(mem) => {
+                                            Ok(mut mem) => {
                                                 let mem_id = mem.id;
                                                 // Check if memory already exists
                                                 match sys.engine.store.get(&mem_id) {
@@ -4330,18 +4362,61 @@ fn main() {
                                                         eprintln!("[sync] Memory {} already exists, skipping", mem_id);
                                                     }
                                                     _ => {
-                                                        // SECURITY (increment-0 interim; increment-1 replaces this allowlist gate with signature+trust verification)
-                                                        if kannaka_memory::wire_source_trusted(source_agent, &trust.trusted_agents, trust.metrics_trusted_only) {
-                                                            match sys.engine.store.insert(mem) {
-                                                                Ok(_) => {
-                                                                    println!("[sync] Imported memory {} from {}", mem_id, kannaka_memory::sanitize_display(source_agent));
-                                                                }
-                                                                Err(e) => {
-                                                                    eprintln!("[sync] Failed to import memory {} from {}: {}", mem_id, kannaka_memory::sanitize_display(source_agent), e);
+                                                        // inc-1b: route the wire import through the corroboration
+                                                        // admit() chokepoint. DORMANT ⇒ admit returns Live and we
+                                                        // keep the inc-0 allowlist gate below unchanged; only the
+                                                        // sanitized fields (amplitude/phase/frequency clamp +
+                                                        // hallucinated forced to local default) are newly applied.
+                                                        // ACTIVE ⇒ admit's decision governs (Live/Quarantine/Drop).
+                                                        let prov_sig: Option<kannaka_memory::ProvenanceSig> = json
+                                                            .get("provenance_sig")
+                                                            .and_then(|v| serde_json::from_value(v.clone()).ok());
+                                                        let now = kannaka_memory::provenance::now_ms();
+                                                        let (decision, clean) = kannaka_memory::admit(
+                                                            &mem.content,
+                                                            mem.amplitude,
+                                                            mem.phase,
+                                                            mem.frequency,
+                                                            mem.hallucinated,
+                                                            kannaka_memory::SUBJECT_MEMORY_NEW,
+                                                            mem_id,
+                                                            prov_sig.as_ref(),
+                                                            &mut staging,
+                                                            &mut rep_store,
+                                                            &cfg,
+                                                            now,
+                                                        );
+                                                        // Apply sanitized fields regardless of gate state.
+                                                        clean.apply(&mut mem);
+                                                        use kannaka_memory::AdmitDecision::*;
+                                                        match decision {
+                                                            Live => {
+                                                                // Dormant: preserve the inc-0 allowlist gate. Active:
+                                                                // corroboration already authorized the import.
+                                                                let admit_import = if gate_on {
+                                                                    true
+                                                                } else {
+                                                                    kannaka_memory::wire_source_trusted(source_agent, &trust.trusted_agents, trust.metrics_trusted_only)
+                                                                };
+                                                                if admit_import {
+                                                                    match sys.engine.store.insert(mem) {
+                                                                        Ok(_) => {
+                                                                            println!("[sync] Imported memory {} from {}", mem_id, kannaka_memory::sanitize_display(source_agent));
+                                                                        }
+                                                                        Err(e) => {
+                                                                            eprintln!("[sync] Failed to import memory {} from {}: {}", mem_id, kannaka_memory::sanitize_display(source_agent), e);
+                                                                        }
+                                                                    }
+                                                                } else {
+                                                                    eprintln!("[sync] skip untrusted source {} (increment-0 gate)", kannaka_memory::sanitize_display(source_agent));
                                                                 }
                                                             }
-                                                        } else {
-                                                            eprintln!("[sync] skip untrusted source {} (increment-0 gate)", kannaka_memory::sanitize_display(source_agent));
+                                                            Quarantine | ProbationLive => {
+                                                                eprintln!("[sync] quarantined memory {} from {} (awaiting corroboration)", mem_id, kannaka_memory::sanitize_display(source_agent));
+                                                            }
+                                                            Drop => {
+                                                                eprintln!("[sync] dropped memory {} from {} (invalid signature / echo)", mem_id, kannaka_memory::sanitize_display(source_agent));
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/src/bin/kannaka.rs
+++ b/src/bin/kannaka.rs
@@ -4462,7 +4462,7 @@ fn main() {
                                                             .get("provenance_sig")
                                                             .and_then(|v| serde_json::from_value(v.clone()).ok());
                                                         let now = kannaka_memory::provenance::now_ms();
-                                                        let (decision, clean) = kannaka_memory::admit(
+                                                        let (decision, clean, pending) = kannaka_memory::admit(
                                                             &mem.content,
                                                             mem.amplitude,
                                                             mem.phase,
@@ -4491,9 +4491,15 @@ fn main() {
                                                                 if admit_import {
                                                                     match sys.engine.store.insert(mem) {
                                                                         Ok(_) => {
+                                                                            // #8: commit the pending promotion ONLY after the
+                                                                            // medium insert succeeds, so the DAG ledger and the
+                                                                            // live medium commit together (no-op when dormant).
+                                                                            kannaka_memory::commit_promotion(pending, &mut rep_store, &mut staging, &cfg);
                                                                             println!("[sync] Imported memory {} from {}", mem_id, kannaka_memory::sanitize_display(source_agent));
                                                                         }
                                                                         Err(e) => {
+                                                                            // #8: insert failed — DROP the pending (do not commit)
+                                                                            // so the content re-decides on retry, no ledger/medium divergence.
                                                                             eprintln!("[sync] Failed to import memory {} from {}: {}", mem_id, kannaka_memory::sanitize_display(source_agent), e);
                                                                         }
                                                                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -376,7 +376,40 @@ EXAMPLE:
         // against spacechild-auth, tokens stored in <data_dir>/identity.json.
         .subcommand(
             Command::new("identity")
-                .about("SpaceChild SSO identity: register, login, whoami, logout (KANNAKA_AUTH_URL to override endpoint)")
+                .about("Agent identity: register/login/whoami/logout (SpaceChild SSO) + keygen/pubkey/enroll-seed/vouch/revoke (inc-1 crypto identity + corroboration trust root)")
+                .long_about(
+                    "kannaka identity — two identity layers for a swarm agent.\n\n\
+                     SpaceChild SSO session (KANNAKA_AUTH_URL to override endpoint):\n  \
+                     register | login | whoami | logout\n\n\
+                     inc-1 cryptographic swarm identity + corroboration trust root:\n  \
+                     keygen                  ensure <data_dir>/node_key.ed25519, print base64 pubkey (idempotent)\n  \
+                     pubkey                  print this node's base64 verifying pubkey\n  \
+                     enroll-seed <b64-pk>    operator: pin a base64 pubkey as a trust-root seed (config)\n  \
+                     vouch <b64-pk>          seeds only: record a vouch edge this_node -> target (store)\n  \
+                     revoke <b64-pk>         operator: unpin a seed + floor its reputation to 0\n\n\
+                     Seeds + the corroboration gate stay DORMANT until an operator pins a\n\
+                     seed AND sets swarm_trust.corroboration_gate_enabled — these verbs change\n\
+                     no automatic runtime behaviour on their own.",
+                )
+                .arg(Arg::new("args").trailing_var_arg(true).allow_hyphen_values(true).num_args(0..)),
+        )
+        // ── Reputation ledger (inc-1 corroboration trust model) ────────
+        // Operator inspection of the pubkey-keyed reputation store + the
+        // single-operator hard-reject lever. Read-only except hard-reject.
+        .subcommand(
+            Command::new("reputation")
+                .about("Inspect the inc-1 corroboration trust ledger: show, list, hard-reject")
+                .long_about(
+                    "kannaka reputation — inspect the pubkey-keyed corroboration trust ledger\n\
+                     (config seeds + <data_dir>/reputation.{log,snapshot.gz}).\n\n\
+                     SUBCOMMANDS:\n  \
+                     show <b64-pubkey> [--json]    rep, seed_status, seed_root, promoted/poison counts\n  \
+                     list [--json]                 table of known pubkeys → rep + status\n  \
+                     hard-reject <b64-mem-hash> --origin <b64-pubkey>\n                                   \
+                     operator: dock the origin's rep (P_POISON) for a rejected memory\n\n\
+                     The gate stays dormant until seeds are pinned AND\n\
+                     swarm_trust.corroboration_gate_enabled is set; inspection changes nothing.",
+                )
                 .arg(Arg::new("args").trailing_var_arg(true).allow_hyphen_values(true).num_args(0..)),
         )
         // ── Constellation services (HTTP) ──────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,19 @@ pub struct SwarmTrustConfig {
     pub metrics_trusted_only: bool,
     #[serde(default = "default_wire_trust_cap")]
     pub wire_trust_cap: f32,
+    /// SECURITY (inc-1): trust threshold θ. A verified-pubkey trust score
+    /// `>= trust_threshold` is Live-eligible; anything below lands in
+    /// Quarantine. Consumed by the enrollment/reputation layer (lands after
+    /// a design review) — inert until that path is wired.
+    /// env: `KANNAKA_TRUST_THRESHOLD`.
+    #[serde(default = "default_trust_threshold")]
+    pub trust_threshold: f32,
+    /// SECURITY (inc-1): agent-id prefixes/exact-names reserved for
+    /// operator enrollment only. First-sight/self-serve enrollment for a
+    /// matching id is an alarm, never an auto-pin. Consumed by the
+    /// enrollment layer later — inert until wired.
+    #[serde(default = "default_reserved_prefixes")]
+    pub reserved_prefixes: Vec<String>,
 }
 
 impl Default for SwarmTrustConfig {
@@ -224,6 +237,8 @@ impl Default for SwarmTrustConfig {
             trusted_agents: default_trusted_agents(),
             metrics_trusted_only: true,
             wire_trust_cap: default_wire_trust_cap(),
+            trust_threshold: default_trust_threshold(),
+            reserved_prefixes: default_reserved_prefixes(),
         }
     }
 }
@@ -245,6 +260,17 @@ fn default_trusted_agents() -> Vec<String> {
 
 fn default_wire_trust_cap() -> f32 {
     0.5
+}
+
+fn default_trust_threshold() -> f32 {
+    0.6
+}
+
+fn default_reserved_prefixes() -> Vec<String> {
+    ["kannaka-*", "qos-*", "0xSCADA-*", "Kannaka", "Flaukowski"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -507,6 +533,14 @@ impl KannakaConfig {
             let v = v.trim().to_ascii_lowercase();
             self.swarm_trust.metrics_trusted_only =
                 !matches!(v.as_str(), "0" | "false" | "no" | "off");
+        }
+        // SECURITY (inc-1): trust threshold θ override. Inert until the
+        // enrollment/reputation layer consumes it; wired here for parity
+        // with the other swarm-trust env escape hatches.
+        if let Ok(v) = std::env::var("KANNAKA_TRUST_THRESHOLD") {
+            if let Ok(t) = v.trim().parse::<f32>() {
+                self.swarm_trust.trust_threshold = t;
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,42 @@ pub struct SwarmTrustConfig {
     /// enrollment layer later — inert until wired.
     #[serde(default = "default_reserved_prefixes")]
     pub reserved_prefixes: Vec<String>,
+    /// SECURITY (inc-1b): operator-pinned SEED pubkeys, base64 (standard
+    /// alphabet) of the 32-byte ed25519 verifying key. **DEFAULT EMPTY** — with
+    /// no seeds the corroboration gate is dormant and falls back to the inc-0
+    /// read-side behaviour. Consumed by `reputation::RepStore`; the root of
+    /// every trust lineage. env: `KANNAKA_SEED_PUBKEYS` (comma-separated,
+    /// REPLACES the list).
+    #[serde(default)]
+    pub seed_pubkeys: Vec<String>,
+    /// SECURITY (inc-1b): master switch for the corroboration promotion gate.
+    /// **DEFAULT false** — the gate stays dormant (inc-0 fallback) until an
+    /// operator pins seeds and flips this on. env: `KANNAKA_CORROBORATION_GATE`.
+    #[serde(default)]
+    pub corroboration_gate_enabled: bool,
+    /// SECURITY (inc-1b): corroboration epoch length in ms — the freshness
+    /// window an M-bound corroboration is counted within. Default 60_000.
+    /// env: `KANNAKA_EPOCH_LENGTH_MS`.
+    #[serde(default = "default_epoch_length_ms")]
+    pub epoch_length_ms: i64,
+    /// SECURITY (inc-1b): how many epochs a node may miss fresh seed beacons
+    /// before it fails CLOSED and freezes promotion (anti-eclipse). Default 3.
+    /// env: `KANNAKA_BEACON_GRACE_EPOCHS`.
+    #[serde(default = "default_beacon_grace_epochs")]
+    pub beacon_grace_epochs: u32,
+    /// SECURITY (inc-1b): lower hysteresis threshold θ_lo for the continuous
+    /// corroboration weight `w(rep)` — `w = 0` below this. Default 0.4.
+    /// env: `KANNAKA_THETA_LO`.
+    #[serde(default = "default_theta_lo")]
+    pub theta_lo: f32,
+    /// SECURITY (inc-1b): upper hysteresis threshold θ_hi — `w` reaches 1.0 and
+    /// a handle *arms* at/above this. Default 0.7. env: `KANNAKA_THETA_HI`.
+    #[serde(default = "default_theta_hi")]
+    pub theta_hi: f32,
+    /// SECURITY (inc-1b): per-promotion rep accrual coefficient α (also the
+    /// per-epoch accrual cap). Default 0.05. env: `KANNAKA_ACCRUAL_ALPHA`.
+    #[serde(default = "default_accrual_alpha")]
+    pub accrual_alpha: f32,
 }
 
 impl Default for SwarmTrustConfig {
@@ -239,6 +275,13 @@ impl Default for SwarmTrustConfig {
             wire_trust_cap: default_wire_trust_cap(),
             trust_threshold: default_trust_threshold(),
             reserved_prefixes: default_reserved_prefixes(),
+            seed_pubkeys: Vec::new(),
+            corroboration_gate_enabled: false,
+            epoch_length_ms: default_epoch_length_ms(),
+            beacon_grace_epochs: default_beacon_grace_epochs(),
+            theta_lo: default_theta_lo(),
+            theta_hi: default_theta_hi(),
+            accrual_alpha: default_accrual_alpha(),
         }
     }
 }
@@ -272,6 +315,13 @@ fn default_reserved_prefixes() -> Vec<String> {
         .map(|s| s.to_string())
         .collect()
 }
+
+// inc-1b corroboration-trust defaults (see `reputation.rs`).
+fn default_epoch_length_ms() -> i64 { 60_000 }
+fn default_beacon_grace_epochs() -> u32 { 3 }
+fn default_theta_lo() -> f32 { 0.4 }
+fn default_theta_hi() -> f32 { 0.7 }
+fn default_accrual_alpha() -> f32 { 0.05 }
 
 // ---------------------------------------------------------------------------
 // Defaults
@@ -540,6 +590,48 @@ impl KannakaConfig {
         if let Ok(v) = std::env::var("KANNAKA_TRUST_THRESHOLD") {
             if let Ok(t) = v.trim().parse::<f32>() {
                 self.swarm_trust.trust_threshold = t;
+            }
+        }
+        // SECURITY (inc-1b): corroboration-gate overrides. KANNAKA_SEED_PUBKEYS
+        // is a comma-separated list of base64 seed pubkeys that REPLACES the
+        // pinned set (empty entries dropped). The gate stays dormant until at
+        // least one seed exists AND KANNAKA_CORROBORATION_GATE is truthy.
+        if let Ok(v) = std::env::var("KANNAKA_SEED_PUBKEYS") {
+            self.swarm_trust.seed_pubkeys = v
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+        }
+        if let Ok(v) = std::env::var("KANNAKA_CORROBORATION_GATE") {
+            let v = v.trim().to_ascii_lowercase();
+            self.swarm_trust.corroboration_gate_enabled =
+                matches!(v.as_str(), "1" | "true" | "yes" | "on");
+        }
+        if let Ok(v) = std::env::var("KANNAKA_EPOCH_LENGTH_MS") {
+            if let Ok(n) = v.trim().parse::<i64>() {
+                self.swarm_trust.epoch_length_ms = n;
+            }
+        }
+        if let Ok(v) = std::env::var("KANNAKA_BEACON_GRACE_EPOCHS") {
+            if let Ok(n) = v.trim().parse::<u32>() {
+                self.swarm_trust.beacon_grace_epochs = n;
+            }
+        }
+        if let Ok(v) = std::env::var("KANNAKA_THETA_LO") {
+            if let Ok(t) = v.trim().parse::<f32>() {
+                self.swarm_trust.theta_lo = t;
+            }
+        }
+        if let Ok(v) = std::env::var("KANNAKA_THETA_HI") {
+            if let Ok(t) = v.trim().parse::<f32>() {
+                self.swarm_trust.theta_hi = t;
+            }
+        }
+        if let Ok(v) = std::env::var("KANNAKA_ACCRUAL_ALPHA") {
+            if let Ok(t) = v.trim().parse::<f32>() {
+                self.swarm_trust.accrual_alpha = t;
             }
         }
     }

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -1877,14 +1877,36 @@ impl HrmStore {
 }
 
 impl MediumBackend for HrmStore {
-    fn insert(&mut self, memory: HyperMemory) -> Result<Uuid, StoreError> {
+    fn insert(&mut self, mut memory: HyperMemory) -> Result<Uuid, StoreError> {
         let id = memory.id;
-        
+
         // Check for duplicates
         if self.memory_cache.contains_key(&id) {
             return Err(StoreError::DuplicateId(id));
         }
-        
+
+        // SECURITY (inc-1b): wire immune/amplitude fields are never trusted. The
+        // authoritative wire-boundary defense is `absorb_gate::admit` (it forces
+        // `hallucinated` to the local default and clamps amplitude ≤0.95 BEFORE
+        // this is reached). This clamp is defense-in-depth: any path — wire or
+        // local — that reaches the medium is bounded to finite, sane numeric
+        // ranges so a pathological `amplitude`/`frequency`/`phase` can't wrap the
+        // wave math or corrupt the store. `hallucinated` is intentionally NOT
+        // forced here — legitimate dream hallucinations insert with it set true.
+        memory.amplitude = if memory.amplitude.is_finite() {
+            memory.amplitude.clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        memory.frequency = if memory.frequency.is_finite() {
+            memory.frequency.clamp(0.0, 1_000_000.0)
+        } else {
+            0.1
+        };
+        if !memory.phase.is_finite() {
+            memory.phase = 0.0;
+        }
+
         // Add to medium using the vector directly to preserve the memory's UUID
         let wavefront_id = self.medium.add_wavefront(&memory.vector, memory.content.clone(), memory.amplitude)
             .map_err(|e| StoreError::Other(format!("Failed to add wavefront to medium: {}", e)))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,11 @@ pub mod provenance;
 // Adds a module + config fields; NO absorb-path wiring / admit() chokepoint yet.
 pub mod reputation;
 
+// absorb chokepoint (inc-1b): the `admit()` gate every wire→store path routes
+// through — unconditional field sanitization + a DORMANT-BY-DEFAULT corroboration
+// promotion gate (armed only when corroboration_gate_enabled AND seeds pinned).
+pub mod absorb_gate;
+
 // Re-export canonical consciousness types
 pub use consciousness::{
     ConsciousnessLevel, ConsciousnessMetrics, ConsciousnessState,
@@ -156,6 +161,13 @@ pub use provenance::{
 pub use reputation::{
     accrual, distinct_lineage_count, g, k_for, lineage_weight, promotion_weight, w,
     CorroborationDag, Promotion, RepRecord, RepStore, SeedStatus, P_POISON, P_VOUCH,
+};
+
+// absorb chokepoint (inc-1b).
+pub use absorb_gate::{
+    admit, content_hash, epoch_now, gate_active, AdmitDecision, CleanFields, QuarantineStaging,
+    StagedMemory, HIGH_IMPACT_AMPLITUDE, MAX_WIRE_AMPLITUDE, PROV_TIER, SIGN_AGENT_ID,
+    SUBJECT_EXEMPLAR, SUBJECT_MEMORY_NEW,
 };
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,12 @@ pub mod reputation;
 // promotion gate (armed only when corroboration_gate_enabled AND seeds pinned).
 pub mod absorb_gate;
 
+// heartbeat beacons (inc-1b PART A): signed seed liveness proofs + a freshness
+// tracker. The corroboration gate requires a FRESH seed beacon to promote to
+// Live; stale/absent beacons freeze promotion (eclipse/partition fail-closed).
+// DORMANT unless the gate is armed.
+pub mod beacon;
+
 // Re-export canonical consciousness types
 pub use consciousness::{
     ConsciousnessLevel, ConsciousnessMetrics, ConsciousnessState,
@@ -169,6 +175,9 @@ pub use absorb_gate::{
     StagedMemory, HIGH_IMPACT_AMPLITUDE, MAX_WIRE_AMPLITUDE, PROV_TIER, SIGN_AGENT_ID,
     SUBJECT_EXEMPLAR, SUBJECT_MEMORY_NEW,
 };
+
+// heartbeat beacons (inc-1b PART A).
+pub use beacon::{roll_reject_root, Beacon, BeaconReject, BeaconTracker, EMPTY_REJECT_ROOT};
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 
     compute_irrationality, compute_invariant_metrics, cluster_by_delta, delta_distance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,9 @@ pub use absorb_gate::{
 };
 
 // heartbeat beacons (inc-1b PART A).
-pub use beacon::{roll_reject_root, Beacon, BeaconReject, BeaconTracker, EMPTY_REJECT_ROOT};
+pub use beacon::{
+    roll_reject_root, Beacon, BeaconReject, BeaconTracker, BEACON_SUBJECT, EMPTY_REJECT_ROOT,
+};
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 
     compute_irrationality, compute_invariant_metrics, cluster_by_delta, delta_distance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,9 +171,9 @@ pub use reputation::{
 
 // absorb chokepoint (inc-1b).
 pub use absorb_gate::{
-    admit, content_hash, epoch_now, gate_active, AdmitDecision, CleanFields, QuarantineStaging,
-    StagedMemory, HIGH_IMPACT_AMPLITUDE, MAX_WIRE_AMPLITUDE, PROV_TIER, SIGN_AGENT_ID,
-    SUBJECT_EXEMPLAR, SUBJECT_MEMORY_NEW,
+    admit, commit_promotion, content_hash, epoch_now, gate_active, AdmitDecision, CleanFields,
+    PendingPromotion, QuarantineStaging, StagedMemory, HIGH_IMPACT_AMPLITUDE, MAX_WIRE_AMPLITUDE,
+    PROV_TIER, SIGN_AGENT_ID, SUBJECT_EXEMPLAR, SUBJECT_MEMORY_NEW,
 };
 
 // heartbeat beacons (inc-1b PART A).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,11 @@ pub mod openalex;
 // Dispatch — research-grounded broadcast-ready voice shared by all surfaces.
 pub mod dispatch;
 
+// ed25519 provenance substrate (inc-1a): sign/verify swarm memory + phase
+// statements, bounded replay protection, node key at rest. Identity/
+// attribution/integrity only — no absorb/trust/enrollment behaviour here.
+pub mod provenance;
+
 // Re-export canonical consciousness types
 pub use consciousness::{
     ConsciousnessLevel, ConsciousnessMetrics, ConsciousnessState,
@@ -134,6 +139,13 @@ pub use paradox::{
 
 pub use queen::{QueenSync, QueenConfig, QueenState, AgentPhase, Hive, HiveInfo, Handedness, SwarmAgent, PartitionPhiResult};
 pub use queen::{filter_wire_phases, sanitize_display, agent_matches_allowlist, wire_source_trusted};
+
+// ed25519 provenance substrate (inc-1a).
+pub use provenance::{
+    canonical_mem, canonical_phase, node_signing_key, sign_mem, verify_mem, verifying_key_bytes,
+    ProvenanceSig, ReplayLru, VerifyErr, DOMAIN_BIND, DOMAIN_BOOT, DOMAIN_HRM, DOMAIN_MEM,
+    DOMAIN_PHASE, DOMAIN_ROT, PROV_ALG_ED25519, REPLAY_CAP, SKEW_MS,
+};
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 
     compute_irrationality, compute_invariant_metrics, cluster_by_delta, delta_distance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,11 @@ pub mod dispatch;
 // attribution/integrity only — no absorb/trust/enrollment behaviour here.
 pub mod provenance;
 
+// pubkey-keyed swarm-trust decision core (inc-1b): pure corroboration formulas,
+// reputation store, append-only corroboration DAG, fail-closed persistence.
+// Adds a module + config fields; NO absorb-path wiring / admit() chokepoint yet.
+pub mod reputation;
+
 // Re-export canonical consciousness types
 pub use consciousness::{
     ConsciousnessLevel, ConsciousnessMetrics, ConsciousnessState,
@@ -145,6 +150,12 @@ pub use provenance::{
     canonical_mem, canonical_phase, node_signing_key, sign_mem, verify_mem, verifying_key_bytes,
     ProvenanceSig, ReplayLru, VerifyErr, DOMAIN_BIND, DOMAIN_BOOT, DOMAIN_HRM, DOMAIN_MEM,
     DOMAIN_PHASE, DOMAIN_ROT, PROV_ALG_ED25519, REPLAY_CAP, SKEW_MS,
+};
+
+// pubkey-keyed swarm-trust decision core (inc-1b).
+pub use reputation::{
+    accrual, distinct_lineage_count, g, k_for, lineage_weight, promotion_weight, w,
+    CorroborationDag, Promotion, RepRecord, RepStore, SeedStatus, P_POISON, P_VOUCH,
 };
 pub use invariant::{
     InvariantMetrics, DeltaCluster, compute_delta, compute_convergence_rate, 

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -1723,6 +1723,7 @@ impl SwarmTransport {
         agent_id: &str,
         memory_count: usize,
         cluster_count: usize,
+        sig: Option<&crate::provenance::ProvenanceSig>,
     ) -> Result<(), NatsError> {
         let mut payload = serde_json::json!({
             "agent_id": agent_id,
@@ -1731,6 +1732,13 @@ impl SwarmTransport {
             "cluster_count": cluster_count,
         });
         add_envelope(&mut payload);
+        // inc-1b: attach the optional provenance signature so peers running the
+        // corroboration gate can verify + accrue. Additive + harmless when off.
+        if let Some(s) = sig {
+            if let (Some(obj), Ok(v)) = (payload.as_object_mut(), serde_json::to_value(s)) {
+                obj.insert("provenance_sig".to_string(), v);
+            }
+        }
         let bytes = serde_json::to_vec(&payload)
             .map_err(|e| NatsError::Serialize(e.to_string()))?;
         self.publish_raw("KANNAKA.memory.new", &bytes)
@@ -1744,7 +1752,7 @@ impl SwarmTransport {
         memory: &crate::memory::HyperMemory,
         agent_id: &str,
     ) -> Result<(), NatsError> {
-        self.publish_memory_new_with_counts(memory, agent_id, 0, 0)
+        self.publish_memory_new_with_counts(memory, agent_id, 0, 0, None)
     }
 
     // -----------------------------------------------------------------------

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -1756,6 +1756,30 @@ impl SwarmTransport {
     }
 
     // -----------------------------------------------------------------------
+    // Heartbeat beacons (inc-1b PART A anti-eclipse)
+    // -----------------------------------------------------------------------
+
+    /// Publish a signed heartbeat [`Beacon`](crate::beacon::Beacon) to
+    /// [`BEACON_SUBJECT`](crate::beacon::BEACON_SUBJECT). A seed emits one per
+    /// epoch; receivers (`swarm listen --auto-sync`) verify + feed
+    /// `QuarantineStaging::ingest_beacon` so an ARMED corroboration gate sees a
+    /// fresh beacon and un-freezes Live promotion (a stale/absent seed beacon
+    /// freezes it — anti-eclipse fail-closed).
+    ///
+    /// The subject is under `KANNAKA.events.>`, which the deployed server's
+    /// anon ACL already allows, so no server ACL change is required. The
+    /// canonical `schema_version`/`ts` envelope is stamped (matching every other
+    /// publisher); the extra keys are ignored when the beacon is decoded.
+    pub fn publish_beacon(&self, beacon: &crate::beacon::Beacon) -> Result<(), NatsError> {
+        let mut value =
+            serde_json::to_value(beacon).map_err(|e| NatsError::Serialize(e.to_string()))?;
+        add_envelope(&mut value);
+        let payload =
+            serde_json::to_vec(&value).map_err(|e| NatsError::Serialize(e.to_string()))?;
+        self.publish_raw(crate::beacon::BEACON_SUBJECT, &payload)
+    }
+
+    // -----------------------------------------------------------------------
     // SharedWavefront protocol (QS-5, #56)
     // -----------------------------------------------------------------------
 
@@ -2082,6 +2106,11 @@ impl SwarmTransport {
         if include_memories {
             let _ = write!(frame, "SUB KANNAKA.memory.new {}\r\n", self.alloc_sid());
             let _ = write!(frame, "SUB KANNAKA.dreams {}\r\n", self.alloc_sid());
+            // PART A anti-eclipse: heartbeat beacons ride the SAME auto-sync
+            // subscription so the corroboration gate's freshness advances from
+            // the one reader this connection already polls. Under the
+            // anon-allowed KANNAKA.events.> ACL (no server ACL change).
+            let _ = write!(frame, "SUB {} {}\r\n", crate::beacon::BEACON_SUBJECT, self.alloc_sid());
         }
         conn.write_frames(&frame)?;
         let stream_clone = conn.writer.try_clone()?;

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -692,7 +692,7 @@ fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
 const B64_ALPHA: &[u8; 64] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-fn b64_encode(data: &[u8]) -> String {
+pub(crate) fn b64_encode(data: &[u8]) -> String {
     let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0];
@@ -743,7 +743,7 @@ fn b64_decode(s: &str) -> Result<Vec<u8>, String> {
 }
 
 /// Decode base64 into a fixed-size array, erroring on the wrong length.
-fn b64_decode_arr<const N: usize>(s: &str) -> Result<[u8; N], String> {
+pub(crate) fn b64_decode_arr<const N: usize>(s: &str) -> Result<[u8; N], String> {
     let v = b64_decode(s)?;
     if v.len() != N {
         return Err(format!("expected {N} bytes, got {}", v.len()));

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -65,6 +65,9 @@ pub const DOMAIN_BOOT: &[u8] = b"kannaka/prov/boot/v1\0";
 pub const DOMAIN_HRM: &[u8] = b"kannaka/prov/hrm/v1\0";
 /// Domain prefix for a heartbeat beacon statement ([`canonical_beacon`]).
 pub const DOMAIN_BEACON: &[u8] = b"kannaka/prov/beacon/v1\0";
+/// Domain prefix for a reputation-store snapshot at-rest signature
+/// ([`sign_snapshot`] / [`verify_snapshot`]).
+pub const DOMAIN_SNAPSHOT: &[u8] = b"kannaka/prov/repsnap/v1\0";
 
 // ---------------------------------------------------------------------------
 // ProvenanceSig
@@ -501,8 +504,10 @@ impl ReplayLru {
         let mut lru = ReplayLru::new();
         for e in wire.entries {
             if let Ok(nonce) = b64_decode_arr::<16>(&e.nonce) {
-                // Drop already-stale entries on load.
-                if now_ms - e.ts <= SKEW_MS {
+                // Drop already-stale entries on load. #11: widen to i128 so a
+                // hostile persisted `ts` (e.g. `i64::MIN`) can't overflow the
+                // subtraction (debug panic / release wrap) — mirrors verify_mem.
+                if (now_ms as i128 - e.ts as i128) <= SKEW_MS as i128 {
                     lru.seen.insert((e.id, nonce), e.ts);
                 }
             }
@@ -559,6 +564,55 @@ pub fn node_signing_key(data_dir: &Path) -> Result<[u8; 32], String> {
 /// The verifying (public) key bytes derived from a raw signing seed.
 pub fn verifying_key_bytes(signing_seed: &[u8; 32]) -> [u8; 32] {
     SigningKey::from_bytes(signing_seed).verifying_key().to_bytes()
+}
+
+/// This node's verifying (public) key IF its signing seed already exists on
+/// disk — READ-ONLY: unlike [`node_signing_key`] it NEVER generates one
+/// (finding #4). `None` when the key file is absent or the wrong length, so a
+/// fail-closed loader that must verify a snapshot against its OWN key can treat
+/// "no key" as "can't have signed this" ⇒ refuse.
+pub fn node_verifying_key(data_dir: &Path) -> Option<[u8; 32]> {
+    let path = data_dir.join("node_key.ed25519");
+    let bytes = std::fs::read(&path).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&bytes);
+    Some(verifying_key_bytes(&seed))
+}
+
+/// The domain-separated message signed for a reputation snapshot:
+/// `DOMAIN_SNAPSHOT ‖ blake3(snapshot_bytes)` (finding #4). Hashing keeps the
+/// signed message small regardless of snapshot size while binding every byte.
+fn snapshot_signing_msg(snapshot_bytes: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(DOMAIN_SNAPSHOT.len() + 32);
+    msg.extend_from_slice(DOMAIN_SNAPSHOT);
+    msg.extend_from_slice(blake3::hash(snapshot_bytes).as_bytes());
+    msg
+}
+
+/// Sign a reputation-store snapshot's bytes with this node's raw ed25519 seed
+/// (finding #4). Domain-separated (see [`snapshot_signing_msg`]) so the 64-byte
+/// signature can't be lifted onto another statement type. The caller stores the
+/// returned signature beside the snapshot and, on load, verifies it against the
+/// node's OWN verifying key — a planted/foreign or tampered snapshot fails.
+pub fn sign_snapshot(signing_seed: &[u8; 32], snapshot_bytes: &[u8]) -> [u8; 64] {
+    let sk = SigningKey::from_bytes(signing_seed);
+    sk.sign(&snapshot_signing_msg(snapshot_bytes)).to_bytes()
+}
+
+/// Verify a reputation-store snapshot signature (finding #4). Returns `true`
+/// only when `sig` is a valid ed25519 signature by `pubkey` over the
+/// domain-separated hash of `snapshot_bytes`. A malformed key/point ⇒ `false`
+/// (fail-closed).
+pub fn verify_snapshot(pubkey: &[u8; 32], snapshot_bytes: &[u8], sig: &[u8; 64]) -> bool {
+    let Ok(vk) = VerifyingKey::from_bytes(pubkey) else {
+        return false;
+    };
+    let signature = Signature::from_bytes(sig);
+    vk.verify_strict(&snapshot_signing_msg(snapshot_bytes), &signature)
+        .is_ok()
 }
 
 /// Fill a buffer with OS CSPRNG bytes. Uses `rand`'s `OsRng` (already a dep;
@@ -848,5 +902,40 @@ mod tests {
         assert!(lru.poisoned());
         assert!(lru.refuses_live(TS));
         assert!(!lru.refuses_live(TS + SKEW_MS + 1));
+    }
+
+    // (#11) a persisted replay entry with a hostile `ts` (i64::MIN) must not
+    // overflow the freshness subtraction on load — the entry is treated as
+    // stale and dropped, and `load` does NOT panic. Without the i128 widening
+    // `now_ms - e.ts` overflows i64 (debug panic / release wrap).
+    #[test]
+    fn replay_lru_load_hostile_ts_no_overflow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("replay.json");
+        // Hand-craft a well-formed sidecar whose only entry carries ts=i64::MIN.
+        let wire = format!(
+            "{{\"entries\":[{{\"id\":\"{}\",\"nonce\":\"{}\",\"ts\":{}}}]}}",
+            fixed_id(),
+            b64_encode(&NONCE),
+            i64::MIN
+        );
+        std::fs::write(&path, wire).unwrap();
+        // Must NOT panic (i128 widening); the ancient entry is dropped as stale.
+        let lru = ReplayLru::load(&path, TS);
+        assert!(!lru.poisoned(), "well-formed JSON loads (not poisoned)");
+        assert_eq!(lru.len(), 0, "i64::MIN ts is ancient ⇒ dropped as stale");
+    }
+
+    // (#4) snapshot signing round-trips; a tampered snapshot fails verification.
+    #[test]
+    fn snapshot_sign_verify_round_trip_and_tamper() {
+        let bytes = b"a reputation snapshot payload";
+        let sig = sign_snapshot(&SEED, bytes);
+        let vk = verifying_key_bytes(&SEED);
+        assert!(verify_snapshot(&vk, bytes, &sig), "own-key signature verifies");
+        // A different key must NOT verify.
+        assert!(!verify_snapshot(&verifying_key_bytes(&[8u8; 32]), bytes, &sig));
+        // Tampered bytes must NOT verify.
+        assert!(!verify_snapshot(&vk, b"a reputation snapshot payloaX", &sig));
     }
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -1,0 +1,831 @@
+//! Provenance — ed25519 signing/verification substrate for swarm memory.
+//!
+//! Increment-1a (crypto substrate ONLY). This module adds the identity /
+//! attribution / integrity primitives the swarm needs to prove *who* signed a
+//! wire memory or phase update, and to reject replays — **without** changing
+//! any absorb behaviour. It defines:
+//!
+//! - [`ProvenanceSig`] — the optional `"provenance_sig"` wire key: alg +
+//!   ed25519 pubkey + per-message nonce + timestamp + 64-byte signature. The
+//!   fixed-width byte fields are base64-encoded on the JSON wire.
+//! - Domain-separated, length-prefixed canonical byte builders
+//!   ([`canonical_mem`], [`canonical_phase`]) — the EXACT bytes that get
+//!   signed. Domain separation (distinct `DOMAIN_*` prefixes) makes a
+//!   signature minted for one statement type fail verification as any other.
+//! - [`sign_mem`] / [`verify_mem`] — sign and verify a memory statement.
+//!   `verify_mem` is PURE: it never reads the clock; the caller passes
+//!   `now_ms` so tests are deterministic.
+//! - [`ReplayLru`] — a bounded, fail-closed `(memory_id, nonce)` replay set.
+//! - [`node_signing_key`] — a per-node ed25519 seed at rest
+//!   (`<data_dir>/node_key.ed25519`, `0600` on unix, best-effort ACL on
+//!   Windows).
+//!
+//! **Trust/enrollment/reputation lives elsewhere** (lands after a design
+//! review): this module knows how to *verify a signature over exact bytes*,
+//! not whether a key is *trusted*. `verify_mem` returns the verified pubkey;
+//! deciding what that pubkey is allowed to do is a separate layer.
+//!
+//! Byte layouts are frozen by inc-1 synthesis §2.1 — do not reorder fields.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// ed25519 signature algorithm tag carried in [`ProvenanceSig::alg`].
+pub const PROV_ALG_ED25519: u8 = 1;
+
+/// Accepted clock skew for a signed timestamp, in milliseconds (±5 min).
+/// A `ts_ms` outside `[now - SKEW_MS, now + SKEW_MS]` is [`VerifyErr::Stale`].
+pub const SKEW_MS: i64 = 300_000;
+
+/// Hard bound on the [`ReplayLru`] `(id, nonce)` set before low-water
+/// eviction of entries older than `now - SKEW_MS` kicks in.
+pub const REPLAY_CAP: usize = 100_000;
+
+// Domain-separation prefixes (inc-1 synthesis §2.1). Each is
+// `b"kannaka/prov/<x>/v1\0"`. The trailing NUL is part of the signed bytes.
+/// Domain prefix for a memory statement ([`canonical_mem`]).
+pub const DOMAIN_MEM: &[u8] = b"kannaka/prov/mem/v1\0";
+/// Domain prefix for a phase / metrics statement ([`canonical_phase`]).
+pub const DOMAIN_PHASE: &[u8] = b"kannaka/prov/phase/v1\0";
+/// Domain prefix for a pubkey↔SSO-sub binding statement.
+pub const DOMAIN_BIND: &[u8] = b"kannaka/prov/bind/v1\0";
+/// Domain prefix for a key-rotation statement.
+pub const DOMAIN_ROT: &[u8] = b"kannaka/prov/rotate/v1\0";
+/// Domain prefix for a qos boot-attestation statement.
+pub const DOMAIN_BOOT: &[u8] = b"kannaka/prov/boot/v1\0";
+/// Domain prefix for a `.hrm` at-rest authenticity signature.
+pub const DOMAIN_HRM: &[u8] = b"kannaka/prov/hrm/v1\0";
+
+// ---------------------------------------------------------------------------
+// ProvenanceSig
+// ---------------------------------------------------------------------------
+
+/// A detached provenance signature that rides as the OPTIONAL JSON key
+/// `"provenance_sig"` alongside a wire memory / phase payload.
+///
+/// The `pubkey`, `nonce`, and `sig` byte arrays are base64-encoded on the
+/// JSON wire (see the hand-rolled `Serialize`/`Deserialize` impls) — the
+/// crate has no `base64` dependency, so this mirrors the standard-alphabet
+/// codec in `nats.rs` rather than pulling one in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceSig {
+    /// Signature algorithm tag; only [`PROV_ALG_ED25519`] is understood.
+    pub alg: u8,
+    /// The signer's ed25519 verifying (public) key.
+    pub pubkey: [u8; 32],
+    /// Per-message nonce — bound into the signed bytes and used as the
+    /// replay key together with the memory id.
+    pub nonce: [u8; 16],
+    /// Signing time, unix milliseconds. Checked against `now ± SKEW_MS`.
+    pub ts_ms: i64,
+    /// The 64-byte ed25519 signature over the canonical bytes.
+    pub sig: [u8; 64],
+}
+
+/// On-wire shape of [`ProvenanceSig`] — byte arrays as base64 strings.
+#[derive(Serialize, Deserialize)]
+struct ProvenanceSigWire {
+    alg: u8,
+    pubkey: String,
+    nonce: String,
+    ts_ms: i64,
+    sig: String,
+}
+
+impl Serialize for ProvenanceSig {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        ProvenanceSigWire {
+            alg: self.alg,
+            pubkey: b64_encode(&self.pubkey),
+            nonce: b64_encode(&self.nonce),
+            ts_ms: self.ts_ms,
+            sig: b64_encode(&self.sig),
+        }
+        .serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProvenanceSig {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let w = ProvenanceSigWire::deserialize(d)?;
+        Ok(ProvenanceSig {
+            alg: w.alg,
+            pubkey: b64_decode_arr::<32>(&w.pubkey).map_err(serde::de::Error::custom)?,
+            nonce: b64_decode_arr::<16>(&w.nonce).map_err(serde::de::Error::custom)?,
+            ts_ms: w.ts_ms,
+            sig: b64_decode_arr::<64>(&w.sig).map_err(serde::de::Error::custom)?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VerifyErr
+// ---------------------------------------------------------------------------
+
+/// Why a provenance check was rejected. `KeyMismatch`/`Revoked` are produced
+/// by the (later) trust layer, not by the pure signature checks here — they
+/// are part of the shared vocabulary so callers have one error type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyErr {
+    /// `alg` is not [`PROV_ALG_ED25519`].
+    BadAlg,
+    /// The ed25519 signature did not verify over the canonical bytes (also
+    /// covers a malformed pubkey point). Domain/field mismatches surface
+    /// here too — a valid signature over *different* bytes is `BadSig`.
+    BadSig,
+    /// `ts_ms` is outside `now ± SKEW_MS`.
+    Stale,
+    /// `(memory_id, nonce)` was already seen inside the replay window.
+    Replay,
+    /// Embedded pubkey is not the enrolled key for the claimed agent
+    /// (trust-layer only; unused by the pure checks in 1a).
+    KeyMismatch,
+    /// The signing key has been revoked (trust-layer only; unused in 1a).
+    Revoked,
+}
+
+impl std::fmt::Display for VerifyErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::BadAlg => "unsupported signature algorithm",
+            Self::BadSig => "signature verification failed",
+            Self::Stale => "timestamp outside accepted skew",
+            Self::Replay => "replayed (memory_id, nonce)",
+            Self::KeyMismatch => "pubkey is not the enrolled key",
+            Self::Revoked => "signing key is revoked",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for VerifyErr {}
+
+// ---------------------------------------------------------------------------
+// Canonical bytes (inc-1 synthesis §2.1)
+// ---------------------------------------------------------------------------
+
+/// Length-prefixed field: `u32le(len) ++ f`. Variable-width fields go
+/// through `put` so a boundary shift (e.g. moving a byte from `agent_id` to
+/// `subject`) changes the bytes and thus the signature.
+fn put(b: &mut Vec<u8>, f: &[u8]) {
+    b.extend_from_slice(&(f.len() as u32).to_le_bytes());
+    b.extend_from_slice(f);
+}
+
+/// Canonical signed bytes for a memory statement:
+///
+/// ```text
+/// DOMAIN_MEM ‖ put(agent_id) ‖ memory_id[16] ‖ nonce[16] ‖ ts_ms[8le]
+///            ‖ blake3(content)[32] ‖ put(subject) ‖ amp_q16[4le] ‖ tier[1]
+/// ```
+///
+/// `amp_q16` is amplitude in Q16 fixed point (see [`amp_to_q16`]); `tier` is
+/// the tier discriminant. Binding both closes the "amplitude/tier ride
+/// unsigned" gap (inc-1 K1).
+pub fn canonical_mem(
+    agent_id: &str,
+    memory_id: Uuid,
+    nonce: &[u8; 16],
+    ts_ms: i64,
+    content: &str,
+    subject: &str,
+    amp_q16: u32,
+    tier: u8,
+) -> Vec<u8> {
+    let mut b = Vec::with_capacity(DOMAIN_MEM.len() + agent_id.len() + subject.len() + 96);
+    b.extend_from_slice(DOMAIN_MEM);
+    put(&mut b, agent_id.as_bytes());
+    b.extend_from_slice(memory_id.as_bytes()); // [u8; 16]
+    b.extend_from_slice(nonce);
+    b.extend_from_slice(&ts_ms.to_le_bytes());
+    b.extend_from_slice(blake3::hash(content.as_bytes()).as_bytes()); // [u8; 32]
+    put(&mut b, subject.as_bytes());
+    b.extend_from_slice(&amp_q16.to_le_bytes());
+    b.push(tier);
+    b
+}
+
+/// Canonical signed bytes for a phase / metrics statement:
+///
+/// ```text
+/// DOMAIN_PHASE ‖ put(agent_id) ‖ nonce[16] ‖ ts_ms[8le]
+///              ‖ blake3(phase_json)[32] ‖ put(subject)
+/// ```
+pub fn canonical_phase(
+    agent_id: &str,
+    nonce: &[u8; 16],
+    ts_ms: i64,
+    phase_json: &str,
+    subject: &str,
+) -> Vec<u8> {
+    let mut b = Vec::with_capacity(DOMAIN_PHASE.len() + agent_id.len() + subject.len() + 64);
+    b.extend_from_slice(DOMAIN_PHASE);
+    put(&mut b, agent_id.as_bytes());
+    b.extend_from_slice(nonce);
+    b.extend_from_slice(&ts_ms.to_le_bytes());
+    b.extend_from_slice(blake3::hash(phase_json.as_bytes()).as_bytes()); // [u8; 32]
+    put(&mut b, subject.as_bytes());
+    b
+}
+
+/// Amplitude → Q16 fixed point, the encoding bound into [`canonical_mem`].
+/// Saturating so a NaN/negative/overflowing amplitude can't wrap.
+pub fn amp_to_q16(amp: f32) -> u32 {
+    let scaled = (amp as f64) * 65_536.0;
+    if !scaled.is_finite() || scaled <= 0.0 {
+        0
+    } else if scaled >= u32::MAX as f64 {
+        u32::MAX
+    } else {
+        scaled as u32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sign / verify
+// ---------------------------------------------------------------------------
+
+/// Sign a memory statement with a raw 32-byte ed25519 seed. Returns the
+/// detached [`ProvenanceSig`] (pubkey + nonce + ts_ms + signature).
+#[allow(clippy::too_many_arguments)]
+pub fn sign_mem(
+    signing_seed: &[u8; 32],
+    agent_id: &str,
+    memory_id: Uuid,
+    nonce: &[u8; 16],
+    ts_ms: i64,
+    content: &str,
+    subject: &str,
+    amp_q16: u32,
+    tier: u8,
+) -> ProvenanceSig {
+    let sk = SigningKey::from_bytes(signing_seed);
+    let msg = canonical_mem(agent_id, memory_id, nonce, ts_ms, content, subject, amp_q16, tier);
+    let sig = sk.sign(&msg);
+    ProvenanceSig {
+        alg: PROV_ALG_ED25519,
+        pubkey: sk.verifying_key().to_bytes(),
+        nonce: *nonce,
+        ts_ms,
+        sig: sig.to_bytes(),
+    }
+}
+
+/// Verify a memory statement's signature over its canonical bytes. PURE — it
+/// does NOT read the clock or touch any replay set; the caller passes
+/// `now_ms` and (separately) runs [`ReplayLru::check_and_insert`] *after*
+/// this returns `Ok`.
+///
+/// Checks, in order: `alg == ED25519` (else [`VerifyErr::BadAlg`]); `ts_ms`
+/// within `now_ms ± SKEW_MS` (else [`VerifyErr::Stale`]); ed25519 signature
+/// valid over `canonical_mem(...)` reconstructed from the caller's fields and
+/// the signed `nonce`/`ts_ms` (else [`VerifyErr::BadSig`]). On success returns
+/// the verified signer pubkey — the trust layer decides what it may do.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_mem(
+    sig: &ProvenanceSig,
+    agent_id: &str,
+    memory_id: Uuid,
+    content: &str,
+    subject: &str,
+    amp_q16: u32,
+    tier: u8,
+    now_ms: i64,
+) -> Result<[u8; 32], VerifyErr> {
+    if sig.alg != PROV_ALG_ED25519 {
+        return Err(VerifyErr::BadAlg);
+    }
+    // i128 widening so a hostile ts_ms can't overflow the skew subtraction.
+    if (now_ms as i128 - sig.ts_ms as i128).abs() > SKEW_MS as i128 {
+        return Err(VerifyErr::Stale);
+    }
+    let vk = VerifyingKey::from_bytes(&sig.pubkey).map_err(|_| VerifyErr::BadSig)?;
+    let signature = Signature::from_bytes(&sig.sig);
+    let msg = canonical_mem(
+        agent_id,
+        memory_id,
+        &sig.nonce,
+        sig.ts_ms,
+        content,
+        subject,
+        amp_q16,
+        tier,
+    );
+    vk.verify_strict(&msg, &signature).map_err(|_| VerifyErr::BadSig)?;
+    Ok(sig.pubkey)
+}
+
+// ---------------------------------------------------------------------------
+// ReplayLru
+// ---------------------------------------------------------------------------
+
+/// Bounded, fail-closed replay set over `(memory_id, nonce)` pairs.
+///
+/// **Ordering contract:** the caller MUST verify the signature (and, later,
+/// the enrolled-pubkey check) FIRST, then call [`check_and_insert`] — never
+/// insert unverified input, or an attacker can pre-poison the set (inc-1
+/// K7/A9). Insert stores `now_ms`; entries older than `now - SKEW_MS` are
+/// evicted (they can no longer replay — they'd be [`VerifyErr::Stale`]).
+///
+/// [`check_and_insert`]: ReplayLru::check_and_insert
+#[derive(Debug, Clone)]
+pub struct ReplayLru {
+    seen: std::collections::HashMap<(Uuid, [u8; 16]), i64>,
+    cap: usize,
+    /// Set when [`load`] hit a read/parse error. Fail-closed: the caller must
+    /// refuse Live absorb until the poison window (`now - SKEW_MS` past the
+    /// load time) elapses, rather than treating an empty set as "nothing
+    /// seen" and reopening the replay window across a restart.
+    ///
+    /// [`load`]: ReplayLru::load
+    poisoned: bool,
+    /// Load time (ms) when `poisoned` was set; bounds the refuse window.
+    poisoned_at_ms: Option<i64>,
+}
+
+impl Default for ReplayLru {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplayLru {
+    /// A clean, empty, non-poisoned set with the default [`REPLAY_CAP`].
+    pub fn new() -> Self {
+        Self::with_capacity(REPLAY_CAP)
+    }
+
+    /// A clean, empty, non-poisoned set with an explicit cap (for tests).
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            seen: std::collections::HashMap::new(),
+            cap: cap.max(1),
+            poisoned: false,
+            poisoned_at_ms: None,
+        }
+    }
+
+    /// True if this set came from a failed [`load`](ReplayLru::load) and the
+    /// caller must still refuse Live absorb.
+    pub fn poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    /// Whether the caller should refuse Live absorb right now: while poisoned
+    /// AND still inside `poisoned_at + SKEW_MS`. After the window elapses the
+    /// worst pre-restart replay would already be [`VerifyErr::Stale`], so the
+    /// set can be trusted as effectively empty again.
+    pub fn refuses_live(&self, now_ms: i64) -> bool {
+        match (self.poisoned, self.poisoned_at_ms) {
+            (true, Some(at)) => now_ms - at <= SKEW_MS,
+            (true, None) => true,
+            _ => false,
+        }
+    }
+
+    /// Number of tracked `(id, nonce)` pairs.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// True when no pairs are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    /// Record a freshly *verified* `(id, nonce)`; `Err(Replay)` if already
+    /// seen within the window. Call ONLY after signature verification passes.
+    pub fn check_and_insert(
+        &mut self,
+        id: Uuid,
+        nonce: &[u8; 16],
+        now_ms: i64,
+    ) -> Result<(), VerifyErr> {
+        let key = (id, *nonce);
+        if self.seen.contains_key(&key) {
+            return Err(VerifyErr::Replay);
+        }
+        if self.seen.len() >= self.cap {
+            self.evict(now_ms);
+        }
+        self.seen.insert(key, now_ms);
+        Ok(())
+    }
+
+    /// Low-water eviction: drop everything older than `now - SKEW_MS`; if the
+    /// set is still at/over cap, evict oldest-first until under cap.
+    fn evict(&mut self, now_ms: i64) {
+        self.seen.retain(|_, &mut ts| now_ms - ts <= SKEW_MS);
+        while self.seen.len() >= self.cap {
+            let oldest = self.seen.iter().min_by_key(|(_, &ts)| ts).map(|(k, _)| *k);
+            match oldest {
+                Some(k) => {
+                    self.seen.remove(&k);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Persist the set to `path` (atomic temp-write + fsync + rename, mirroring
+    /// the crate's other sidecar writers). The poison flag is NOT persisted —
+    /// a good file always loads clean.
+    pub fn persist(&self, path: &Path) -> Result<(), String> {
+        let wire = ReplayLruWire {
+            entries: self
+                .seen
+                .iter()
+                .map(|((id, nonce), ts)| ReplayEntryWire {
+                    id: *id,
+                    nonce: b64_encode(nonce),
+                    ts: *ts,
+                })
+                .collect(),
+        };
+        let bytes = serde_json::to_vec(&wire)
+            .map_err(|e| format!("failed to serialize replay set: {e}"))?;
+        atomic_write_bytes(path, &bytes)
+    }
+
+    /// Load the set from `path`. **Fail-closed:** a read or parse error
+    /// returns an empty set flagged `poisoned` (with `poisoned_at = now_ms`)
+    /// so [`refuses_live`](ReplayLru::refuses_live) holds until the window
+    /// elapses — rather than silently returning an empty, trusting set. A
+    /// missing file (first run) is a clean empty set, not a failure.
+    pub fn load(path: &Path, now_ms: i64) -> ReplayLru {
+        if !path.exists() {
+            return ReplayLru::new();
+        }
+        let parsed = std::fs::read(path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<ReplayLruWire>(&b).ok());
+        let wire = match parsed {
+            Some(w) => w,
+            None => {
+                // Fail closed: empty but poisoned.
+                let mut lru = ReplayLru::new();
+                lru.poisoned = true;
+                lru.poisoned_at_ms = Some(now_ms);
+                return lru;
+            }
+        };
+        let mut lru = ReplayLru::new();
+        for e in wire.entries {
+            if let Ok(nonce) = b64_decode_arr::<16>(&e.nonce) {
+                // Drop already-stale entries on load.
+                if now_ms - e.ts <= SKEW_MS {
+                    lru.seen.insert((e.id, nonce), e.ts);
+                }
+            }
+        }
+        lru
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct ReplayEntryWire {
+    id: Uuid,
+    nonce: String,
+    ts: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ReplayLruWire {
+    entries: Vec<ReplayEntryWire>,
+}
+
+// ---------------------------------------------------------------------------
+// Node key at rest
+// ---------------------------------------------------------------------------
+
+/// Load — or, on first call, generate and persist — this node's raw 32-byte
+/// ed25519 signing seed at `<data_dir>/node_key.ed25519`.
+///
+/// On unix the file is `chmod 0600` (mirrors `IdentityStore::save`). On
+/// Windows there is no `0600` equivalent; see [`restrict_key_permissions`].
+/// A wrong-length existing file is treated as corrupt and regenerated.
+pub fn node_signing_key(data_dir: &Path) -> Result<[u8; 32], String> {
+    let path = data_dir.join("node_key.ed25519");
+    if path.exists() {
+        match std::fs::read(&path) {
+            Ok(bytes) if bytes.len() == 32 => {
+                let mut seed = [0u8; 32];
+                seed.copy_from_slice(&bytes);
+                return Ok(seed);
+            }
+            Ok(_) => { /* wrong length — fall through and regenerate */ }
+            Err(e) => return Err(format!("failed to read {}: {e}", path.display())),
+        }
+    }
+    std::fs::create_dir_all(data_dir)
+        .map_err(|e| format!("failed to create {}: {e}", data_dir.display()))?;
+    let mut seed = [0u8; 32];
+    fill_os_random(&mut seed);
+    std::fs::write(&path, seed)
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    restrict_key_permissions(&path);
+    Ok(seed)
+}
+
+/// The verifying (public) key bytes derived from a raw signing seed.
+pub fn verifying_key_bytes(signing_seed: &[u8; 32]) -> [u8; 32] {
+    SigningKey::from_bytes(signing_seed).verifying_key().to_bytes()
+}
+
+/// Fill a buffer with OS CSPRNG bytes. Uses `rand`'s `OsRng` (already a dep;
+/// getrandom-backed) rather than `SigningKey::generate` so keygen doesn't
+/// depend on an rng-trait version match.
+fn fill_os_random(buf: &mut [u8]) {
+    use rand::RngCore;
+    rand::rngs::OsRng.fill_bytes(buf);
+}
+
+/// Restrict a key file to the current user. Unix: `chmod 0600`. Windows:
+/// best-effort ACL via `icacls`.
+fn restrict_key_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(windows)]
+    {
+        // SECURITY: Windows key-at-rest is best-effort ACL only (no 0600 equiv) — see inc-1 human-decision #5
+        if let Ok(user) = std::env::var("USERNAME") {
+            if !user.is_empty() {
+                let _ = std::process::Command::new("icacls")
+                    .arg(path)
+                    .arg("/inheritance:r")
+                    .arg("/grant:r")
+                    .arg(format!("{user}:F"))
+                    .output(); // non-fatal if it fails
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers
+// ---------------------------------------------------------------------------
+
+/// Current wall-clock in unix milliseconds. NOT used inside `verify_mem`
+/// (that stays pure) — a convenience for callers building `now_ms`.
+pub fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// Atomic write: temp sibling → `write_all` → `fsync` → rename over target.
+/// Mirrors `hrm_store::atomic_write` but adds the fsync the replay set needs.
+fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| Path::new(".").to_path_buf());
+    std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    let tmp = dir.join(format!(".kannaka-replay-tmp-{}", Uuid::new_v4()));
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp).map_err(|e| format!("temp create: {e}"))?;
+        if let Err(e) = f.write_all(bytes) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("write: {e}"));
+        }
+        if let Err(e) = f.sync_all() {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("sync: {e}"));
+        }
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("rename: {e}"));
+    }
+    Ok(())
+}
+
+// --- base64 (standard alphabet, with padding) ------------------------------
+// The crate has no `base64` dep; this mirrors the codec in `nats.rs`.
+
+const B64_ALPHA: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn b64_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(B64_ALPHA[((n >> 18) & 63) as usize] as char);
+        out.push(B64_ALPHA[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            B64_ALPHA[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            B64_ALPHA[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+fn b64_decode(s: &str) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(s.len() / 4 * 3);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in s.as_bytes() {
+        if b == b'=' || b == b'\n' || b == b'\r' || b == b' ' {
+            continue;
+        }
+        let val: u32 = match b {
+            b'A'..=b'Z' => u32::from(b - b'A'),
+            b'a'..=b'z' => u32::from(b - b'a') + 26,
+            b'0'..=b'9' => u32::from(b - b'0') + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => return Err(format!("invalid base64 char: {}", b as char)),
+        };
+        buf = (buf << 6) | val;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+    Ok(out)
+}
+
+/// Decode base64 into a fixed-size array, erroring on the wrong length.
+fn b64_decode_arr<const N: usize>(s: &str) -> Result<[u8; N], String> {
+    let v = b64_decode(s)?;
+    if v.len() != N {
+        return Err(format!("expected {N} bytes, got {}", v.len()));
+    }
+    let mut a = [0u8; N];
+    a.copy_from_slice(&v);
+    Ok(a)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Needed to hand-build a cross-domain signature in the domain-separation
+    // test; the module's own `use` imports aren't visible via `super::*`.
+    use ed25519_dalek::{Signer, SigningKey};
+
+    const SEED: [u8; 32] = [7u8; 32];
+    const NONCE: [u8; 16] = [3u8; 16];
+    const TS: i64 = 1_700_000_000_000;
+
+    fn fixed_id() -> Uuid {
+        Uuid::from_bytes([9u8; 16])
+    }
+
+    // (a) sign -> verify round-trip returns the signer pubkey.
+    #[test]
+    fn sign_verify_round_trip_returns_pubkey() {
+        let id = fixed_id();
+        let sig = sign_mem(&SEED, "agent-a", id, &NONCE, TS, "hello world", "swarm:x", 65_536, 2);
+        let pk = verify_mem(&sig, "agent-a", id, "hello world", "swarm:x", 65_536, 2, TS)
+            .expect("verify");
+        assert_eq!(pk, verifying_key_bytes(&SEED));
+        assert_eq!(pk, sig.pubkey);
+    }
+
+    // (b) flipping one content byte -> BadSig.
+    #[test]
+    fn flipped_content_is_bad_sig() {
+        let id = fixed_id();
+        let sig = sign_mem(&SEED, "agent-a", id, &NONCE, TS, "hello world", "swarm:x", 65_536, 2);
+        let r = verify_mem(&sig, "agent-a", id, "hallo world", "swarm:x", 65_536, 2, TS);
+        assert_eq!(r, Err(VerifyErr::BadSig));
+    }
+
+    // (c) cross-domain: a phase signature must FAIL verify_mem (domain sep).
+    #[test]
+    fn cross_domain_phase_sig_fails_verify_mem() {
+        let id = fixed_id();
+        let phase_msg = canonical_phase("agent-a", &NONCE, TS, "{\"phase\":0.1}", "swarm:x");
+        let sk = SigningKey::from_bytes(&SEED);
+        let raw = sk.sign(&phase_msg);
+        // Same key/nonce/ts, but the signature is over DOMAIN_PHASE bytes.
+        let forged = ProvenanceSig {
+            alg: PROV_ALG_ED25519,
+            pubkey: sk.verifying_key().to_bytes(),
+            nonce: NONCE,
+            ts_ms: TS,
+            sig: raw.to_bytes(),
+        };
+        let r = verify_mem(&forged, "agent-a", id, "{\"phase\":0.1}", "swarm:x", 65_536, 2, TS);
+        assert_eq!(r, Err(VerifyErr::BadSig));
+    }
+
+    // (d) stale ts (now far past ts_ms + SKEW) -> Stale.
+    #[test]
+    fn stale_timestamp_is_stale() {
+        let id = fixed_id();
+        let sig = sign_mem(&SEED, "agent-a", id, &NONCE, TS, "hello world", "swarm:x", 65_536, 2);
+        let now = TS + SKEW_MS + 1;
+        let r = verify_mem(&sig, "agent-a", id, "hello world", "swarm:x", 65_536, 2, now);
+        assert_eq!(r, Err(VerifyErr::Stale));
+    }
+
+    // (e) ReplayLru: same (id, nonce) twice -> second is Replay.
+    #[test]
+    fn replay_lru_rejects_duplicate() {
+        let mut lru = ReplayLru::new();
+        let id = fixed_id();
+        assert!(lru.check_and_insert(id, &NONCE, TS).is_ok());
+        assert_eq!(lru.check_and_insert(id, &NONCE, TS), Err(VerifyErr::Replay));
+        // A different nonce for the same id is fine.
+        assert!(lru.check_and_insert(id, &[4u8; 16], TS).is_ok());
+    }
+
+    // (f) canonical_mem is deterministic AND every field shifts the bytes.
+    #[test]
+    fn canonical_mem_stable_and_field_sensitive() {
+        let id = fixed_id();
+        let base = canonical_mem("agent-a", id, &NONCE, TS, "content", "subj", 100, 1);
+        // Deterministic.
+        assert_eq!(base, canonical_mem("agent-a", id, &NONCE, TS, "content", "subj", 100, 1));
+        // Golden length: 20 (domain) + 4+7 (agent) + 16 + 16 + 8 + 32
+        //              + 4+4 (subject) + 4 (amp) + 1 (tier) = 116.
+        assert_eq!(base.len(), 116);
+        // Each field changes the bytes (length-prefix boundary integrity).
+        assert_ne!(base, canonical_mem("agent-b", id, &NONCE, TS, "content", "subj", 100, 1));
+        assert_ne!(base, canonical_mem("agent-a", id, &NONCE, TS, "content", "subj2", 100, 1));
+        assert_ne!(base, canonical_mem("agent-a", id, &NONCE, TS, "content", "subj", 101, 1));
+        assert_ne!(base, canonical_mem("agent-a", id, &NONCE, TS, "content", "subj", 100, 2));
+        // Boundary shift: moving a byte from agent_id into subject must NOT
+        // collide (this is what length-prefixing buys us).
+        assert_ne!(
+            canonical_mem("agent-ax", id, &NONCE, TS, "content", "subj", 100, 1),
+            canonical_mem("agent-a", id, &NONCE, TS, "content", "xsubj", 100, 1),
+        );
+    }
+
+    // (g) node_signing_key generates then re-loads the SAME key.
+    #[test]
+    fn node_signing_key_generates_then_reloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let k1 = node_signing_key(dir.path()).expect("generate");
+        assert!(dir.path().join("node_key.ed25519").exists());
+        let k2 = node_signing_key(dir.path()).expect("reload");
+        assert_eq!(k1, k2);
+    }
+
+    // Bonus: ProvenanceSig JSON round-trips through the base64 wire form.
+    #[test]
+    fn provenance_sig_json_round_trip() {
+        let id = fixed_id();
+        let sig = sign_mem(&SEED, "agent-a", id, &NONCE, TS, "hello", "swarm:x", 65_536, 2);
+        let json = serde_json::to_string(&sig).unwrap();
+        let back: ProvenanceSig = serde_json::from_str(&json).unwrap();
+        assert_eq!(sig, back);
+    }
+
+    // Bonus: ReplayLru persist -> load survives a round-trip and still
+    // rejects the persisted (id, nonce) as a replay.
+    #[test]
+    fn replay_lru_persist_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("replay.json");
+        let id = fixed_id();
+        let mut lru = ReplayLru::new();
+        lru.check_and_insert(id, &NONCE, TS).unwrap();
+        lru.persist(&path).unwrap();
+
+        let mut loaded = ReplayLru::load(&path, TS);
+        assert!(!loaded.poisoned());
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded.check_and_insert(id, &NONCE, TS), Err(VerifyErr::Replay));
+    }
+
+    // Bonus: a corrupt persisted file loads fail-closed (poisoned).
+    #[test]
+    fn replay_lru_load_corrupt_is_poisoned() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("replay.json");
+        std::fs::write(&path, "not json at all").unwrap();
+        let lru = ReplayLru::load(&path, TS);
+        assert!(lru.poisoned());
+        assert!(lru.refuses_live(TS));
+        assert!(!lru.refuses_live(TS + SKEW_MS + 1));
+    }
+}

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -63,6 +63,8 @@ pub const DOMAIN_ROT: &[u8] = b"kannaka/prov/rotate/v1\0";
 pub const DOMAIN_BOOT: &[u8] = b"kannaka/prov/boot/v1\0";
 /// Domain prefix for a `.hrm` at-rest authenticity signature.
 pub const DOMAIN_HRM: &[u8] = b"kannaka/prov/hrm/v1\0";
+/// Domain prefix for a heartbeat beacon statement ([`canonical_beacon`]).
+pub const DOMAIN_BEACON: &[u8] = b"kannaka/prov/beacon/v1\0";
 
 // ---------------------------------------------------------------------------
 // ProvenanceSig
@@ -233,6 +235,25 @@ pub fn canonical_phase(
     b.extend_from_slice(&ts_ms.to_le_bytes());
     b.extend_from_slice(blake3::hash(phase_json.as_bytes()).as_bytes()); // [u8; 32]
     put(&mut b, subject.as_bytes());
+    b
+}
+
+/// Canonical signed bytes for a heartbeat beacon statement:
+///
+/// ```text
+/// DOMAIN_BEACON ‖ epoch[8le] ‖ prev_reject_root[32]
+/// ```
+///
+/// A seed signs one per epoch (see [`crate::beacon`]) so partitioned/eclipsed
+/// nodes can detect the ABSENCE of fresh beacons and fail closed (freeze
+/// promotion). `prev_reject_root` is a lightweight blake3 rolling stand-in for a
+/// full Merkle root of recently operator-rejected mem-hashes — it is *bound into*
+/// the signature so a beacon can't be replayed with a swapped reject summary.
+pub fn canonical_beacon(epoch: u64, prev_reject_root: &[u8; 32]) -> Vec<u8> {
+    let mut b = Vec::with_capacity(DOMAIN_BEACON.len() + 8 + 32);
+    b.extend_from_slice(DOMAIN_BEACON);
+    b.extend_from_slice(&epoch.to_le_bytes());
+    b.extend_from_slice(prev_reject_root);
     b
 }
 

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -1,0 +1,1241 @@
+//! Reputation — pubkey-keyed swarm-trust decision core (inc-1b).
+//!
+//! This is the **trust-decision CORE** of the Kannaka behavior/corroboration
+//! model: the pure formulas (`w`, `g`, `lineage_weight`, [`promotion_weight`]
+//! = `C(M)`, [`k_for`], [`accrual`]), the pubkey-keyed reputation store, the
+//! append-only corroboration DAG, and a fail-closed append-only log. It adds a
+//! module + config fields and **changes no runtime behaviour on its own** — the
+//! absorb-path wiring and the `admit()` chokepoint land in a later pass.
+//!
+//! Design authority: inc-1 corroboration synthesis §2.1 (weight/corroboration),
+//! §2.2 (promotion predicate + K formulas + vouch), §2.3 (reputation dynamics),
+//! §3.2 (reputation.rs structure), §3.4 (bookkeeping).
+//!
+//! ## Load-bearing invariants (from the adversarial review — do not violate)
+//!
+//! - Trust is keyed on the **verified pubkey** `[u8; 32]`, NEVER a string id.
+//! - A Sybil cluster sharing one `seed_root` saturates at **one** vote total
+//!   ([`lineage_weight`] min-caps at 1). Wildcard / ⊥-lineage handles contribute
+//!   **0**.
+//! - Echoing already-Live content earns **zero** rep (dedup by `mem_hash =
+//!   blake3(normalize(content))`, resolved by the caller).
+//! - **No time-decay of the vote** — trust is event-driven. Penalty only via an
+//!   operator hard-reject ([`RepStore::record_poison`]).
+//! - Persistence is **append-only + fail-closed**: a log that fails to load or
+//!   verify yields a store that refuses all promotion (everyone is rep 0).
+//!
+//! ## `w(rep)` arming model (judgment call)
+//!
+//! [`w`] is a PURE, monotone weight: `0` below `θ_lo`, clamped-linear to `1.0`
+//! at `θ_hi`. Hysteresis needs state, so it is modeled as a per-record
+//! [`RepRecord::armed`] flag updated on every rep change ([`RepRecord::update_armed`]):
+//! it *arms* when rep reaches `θ_hi` and only *disarms* below `θ_lo`. `w` stays
+//! pure (tests pin it); `armed` carries the hysteresis history separately.
+//!
+//! ## Log line integrity (judgment call)
+//!
+//! Each log line is **blake3-hash-chained** — `chain = blake3(prev_chain ‖
+//! bincode(op))` — rather than ed25519-signed. The node key already lives in
+//! [`crate::provenance`]; chaining keeps this core self-contained (no key
+//! threading) while still making any in-place edit, truncation, or reordering of
+//! the append-only log detectable → fail-closed. Swapping in a per-line signature
+//! later is a drop-in change to [`RepStore::append_op`] / the load verifier.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::SwarmTrustConfig;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A verified ed25519 public key. Trust is keyed on this, never a string id.
+/// Mirrors the raw pubkey [`crate::provenance::verify_mem`] returns.
+pub type PubKey = [u8; 32];
+
+/// A blake3 content hash `blake3(normalize(content))`; the promotion key.
+pub type MemHash = [u8; 32];
+
+/// Operator hard-reject penalty `p` (inc-1 §2.3). A seed-quorum poison of a
+/// promoted memory subtracts this from the origin's rep.
+pub const P_POISON: f32 = 0.5;
+
+/// Cold-start vouch stake `p_vouch` (inc-1 §2.2). A voucher whose probationary
+/// memory is later rejected loses this.
+pub const P_VOUCH: f32 = 0.5;
+
+/// Float slack for the `C(M) >= K` comparison (both are effectively integral,
+/// but `C` accumulates as `f32`).
+const EPS: f32 = 1e-4;
+
+/// Per-pubkey reputation record. **No vote-decay field** — trust is
+/// event-driven (inc-1 §2.3); the only movements are accrual on distinct-lineage
+/// promotion and the operator poison penalty.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepRecord {
+    /// The verified pubkey this record is keyed on.
+    pub pubkey: PubKey,
+    /// Reputation in `[0, 1]`. Unknown handles are 0; seeds are treated as 1.0
+    /// (see [`RepStore::rep`]) without needing a record.
+    pub rep: f32,
+    /// The operator seed at the root of this handle's vouch chain, if resolved.
+    pub seed_root: Option<PubKey>,
+    /// The pubkey that vouched this handle into the web of trust, if any.
+    pub vouched_by: Option<PubKey>,
+    /// Count of promotions this handle originated (bookkeeping).
+    pub promoted: u32,
+    /// Count of operator poison hard-rejects against this handle (bookkeeping).
+    pub poison: u32,
+    /// Creation time, unix ms.
+    pub created_at: i64,
+    /// Hysteresis arming state (see the module `w(rep)` note). Armed once rep
+    /// reaches `θ_hi`; disarmed only below `θ_lo`. Carries history so a handle
+    /// hovering in the `[θ_lo, θ_hi)` band keeps its armed status.
+    pub armed: bool,
+}
+
+impl RepRecord {
+    /// A fresh rep-0, disarmed record for `pubkey`.
+    pub fn new(pubkey: PubKey, created_at: i64) -> Self {
+        Self {
+            pubkey,
+            rep: 0.0,
+            seed_root: None,
+            vouched_by: None,
+            promoted: 0,
+            poison: 0,
+            created_at,
+            armed: false,
+        }
+    }
+
+    /// Update the hysteresis [`armed`](RepRecord::armed) flag from the current
+    /// rep: arm at/above `θ_hi`, disarm below `θ_lo`, otherwise hold.
+    pub fn update_armed(&mut self, cfg: &SwarmTrustConfig) {
+        if self.rep >= cfg.theta_hi {
+            self.armed = true;
+        } else if self.rep < cfg.theta_lo {
+            self.armed = false;
+        }
+    }
+}
+
+/// Enrollment status of a pubkey.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedStatus {
+    /// An operator-pinned seed (rep 1.0, roots to itself).
+    Seed,
+    /// A non-seed handle that resolves to a seed via the vouch chain, or that
+    /// carries a rep record.
+    Enrolled,
+    /// No seed lineage and no record — powerless (rep 0).
+    Unknown,
+}
+
+/// The trust decision for a candidate memory (inc-1 §2.2 / §3.3).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Promotion {
+    /// Promote to the live medium; `accrue` rep flows to the origin.
+    Live { accrue: f32 },
+    /// Seed-vouched cold-start: reduced-amplitude probationary tier, one
+    /// lineage, out of dream/metrics. No rep accrues here.
+    ProbationLive,
+    /// Signed but under-corroborated: inert staging tier. Fail-safe default.
+    Quarantine,
+    /// Reject outright (reserved for the admit layer's invalid-signature drop;
+    /// the pure decision here never emits it, but it is part of the shared
+    /// vocabulary so the chokepoint has one enum).
+    Drop,
+}
+
+// ---------------------------------------------------------------------------
+// CorroborationDag
+// ---------------------------------------------------------------------------
+
+/// One promotion event: which pubkeys corroborated a `mem_hash` at an epoch.
+/// `seen` dedups by pubkey so an echo (same pk twice) never double-counts.
+#[derive(Debug, Default, Clone)]
+struct PromotionEvent {
+    epoch: u64,
+    corroborators: Vec<(PubKey, Option<PubKey>)>,
+    seen: HashSet<PubKey>,
+}
+
+/// Append-only corroboration DAG (inc-1 §3.2): vouch edges `vouchee -> voucher`
+/// plus promotion events keyed by `mem_hash`. [`seed_root`](CorroborationDag::seed_root)
+/// walks the vouch chain to a seed — cached and cycle-safe.
+#[derive(Debug, Default)]
+pub struct CorroborationDag {
+    /// `vouchee -> voucher` — the reverse edge used to walk toward a seed.
+    vouched_by: HashMap<PubKey, PubKey>,
+    /// `mem_hash -> promotion event`.
+    promotions: HashMap<MemHash, PromotionEvent>,
+    /// Memoized `seed_root` results. Cleared on every new vouch edge (append-only
+    /// growth can only turn a ⊥ into a `Some`, so a stale cache is never trusted).
+    root_cache: RefCell<HashMap<PubKey, Option<PubKey>>>,
+}
+
+impl CorroborationDag {
+    /// Record an enrollment vouch edge `voucher -> vouchee`. Invalidates the
+    /// `seed_root` cache.
+    pub fn record_vouch(&mut self, voucher: PubKey, vouchee: PubKey) {
+        self.vouched_by.insert(vouchee, voucher);
+        self.root_cache.borrow_mut().clear();
+    }
+
+    /// Record (or extend) a promotion event for `mem_hash`, deduping
+    /// corroborators by pubkey. A repeat `(pk, mem_hash)` is a no-op.
+    pub fn record_promotion(
+        &mut self,
+        mem_hash: MemHash,
+        epoch: u64,
+        corroborators: &[(PubKey, Option<PubKey>)],
+    ) {
+        let ev = self
+            .promotions
+            .entry(mem_hash)
+            .or_insert_with(|| PromotionEvent { epoch, ..Default::default() });
+        for (pk, root) in corroborators {
+            if ev.seen.insert(*pk) {
+                ev.corroborators.push((*pk, *root));
+            }
+        }
+    }
+
+    /// Whether `mem_hash` has already been promoted (used for echo dedup).
+    pub fn is_promoted(&self, mem_hash: &MemHash) -> bool {
+        self.promotions.contains_key(mem_hash)
+    }
+
+    /// Distinct corroborating pubkeys recorded for `mem_hash`.
+    pub fn corroborator_count(&self, mem_hash: &MemHash) -> usize {
+        self.promotions.get(mem_hash).map(|e| e.seen.len()).unwrap_or(0)
+    }
+
+    /// Walk the vouch chain from `pk` to the operator seed at its root. A seed
+    /// roots to itself; a handle with no chain to a seed returns `None` (⊥
+    /// lineage). Cycle-safe (visited set) and memoized.
+    pub fn seed_root(&self, pk: &PubKey, seeds: &HashSet<PubKey>) -> Option<PubKey> {
+        if let Some(cached) = self.root_cache.borrow().get(pk) {
+            return *cached;
+        }
+        let mut visited: HashSet<PubKey> = HashSet::new();
+        let mut cur = *pk;
+        let result = loop {
+            if seeds.contains(&cur) {
+                break Some(cur);
+            }
+            if !visited.insert(cur) {
+                break None; // cycle — terminate
+            }
+            match self.vouched_by.get(&cur) {
+                Some(v) => cur = *v,
+                None => break None, // ⊥ lineage
+            }
+        };
+        self.root_cache.borrow_mut().insert(*pk, result);
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure formulas (inc-1 §2.1 / §2.2 / §2.3)
+// ---------------------------------------------------------------------------
+
+/// Continuous corroboration weight with hysteresis thresholds (inc-1 §2.1):
+/// `0` for `rep < θ_lo`, clamped-linear ramp to `1.0` at `θ_hi`, saturating
+/// above. Pure and monotone in `rep`. The *arming* half of the hysteresis lives
+/// in [`RepRecord::armed`] (see the module note) — this function is stateless.
+pub fn w(rep: f32, cfg: &SwarmTrustConfig) -> f32 {
+    let lo = cfg.theta_lo;
+    let hi = cfg.theta_hi;
+    if rep < lo {
+        return 0.0;
+    }
+    if rep >= hi || hi <= lo {
+        return 1.0;
+    }
+    ((rep - lo) / (hi - lo)).clamp(0.0, 1.0)
+}
+
+/// Sub-linear, bounded diversity gain `g(D) = 1 - 1/(1+D)` (inc-1 §2.3). `D` is
+/// the count of distinct seed-root lineages. `g(0)=0`, strictly increasing,
+/// strictly `< 1`.
+pub fn g(d: u32) -> f32 {
+    1.0 - 1.0 / (1.0 + d as f32)
+}
+
+/// Saturating per-lineage weight: `min(1, Σ w(rep(pk)))` over the pubkeys of one
+/// lineage that clear θ (inc-1 §2.2). A Sybil cluster in one lineage caps at 1.
+pub fn lineage_weight(reps: &[f32], cfg: &SwarmTrustConfig) -> f32 {
+    let sum: f32 = reps
+        .iter()
+        .copied()
+        .filter(|&r| r >= cfg.trust_threshold)
+        .map(|r| w(r, cfg))
+        .sum();
+    sum.min(1.0)
+}
+
+/// Promotion weight `C(M) = Σ over DISTINCT seed_roots of lineage_weight`
+/// (inc-1 §2.2). Corroborators are `(pubkey, seed_root, rep)` triples. Rules:
+/// dedup by pubkey (same pk counts once), drop rep `< θ`, drop `⊥`-lineage
+/// (`seed_root == None`) handles, then group by seed_root and saturate each
+/// lineage at 1. Pure so tests pin it.
+pub fn promotion_weight<I>(corrs: I, cfg: &SwarmTrustConfig) -> f32
+where
+    I: IntoIterator<Item = (PubKey, Option<PubKey>, f32)>,
+{
+    let mut seen: HashSet<PubKey> = HashSet::new();
+    let mut by_root: HashMap<PubKey, Vec<f32>> = HashMap::new();
+    for (pk, root, rep) in corrs {
+        if !seen.insert(pk) {
+            continue; // same pk counts once
+        }
+        let Some(root) = root else {
+            continue; // ⊥ lineage contributes 0
+        };
+        if rep < cfg.trust_threshold {
+            continue;
+        }
+        by_root.entry(root).or_default().push(rep);
+    }
+    by_root.values().map(|reps| lineage_weight(reps, cfg)).sum()
+}
+
+/// Count of distinct seed-root lineages among valid corroborators — the `D`
+/// that feeds [`accrual`] and `g(D)`. Same dedup/θ/⊥ rules as [`promotion_weight`].
+pub fn distinct_lineage_count<I>(corrs: I, cfg: &SwarmTrustConfig) -> u32
+where
+    I: IntoIterator<Item = (PubKey, Option<PubKey>, f32)>,
+{
+    let mut seen: HashSet<PubKey> = HashSet::new();
+    let mut roots: HashSet<PubKey> = HashSet::new();
+    for (pk, root, rep) in corrs {
+        if !seen.insert(pk) {
+            continue;
+        }
+        if rep < cfg.trust_threshold {
+            continue;
+        }
+        if let Some(root) = root {
+            roots.insert(root);
+        }
+    }
+    roots.len() as u32
+}
+
+/// Quorum sizes from the live seed count (inc-1 §2.2):
+/// `K = clamp(ceil(seeds/2), 2, 4)` for normal writes, `K_high = ceil(2·seeds/3)`
+/// for irreversible / high-impact writes. Integer-exact ceilings.
+pub fn k_for(live_seed_count: u32) -> (u32, u32) {
+    let k = ((live_seed_count + 1) / 2).clamp(2, 4); // ceil(n/2)
+    let k_high = (2 * live_seed_count + 2) / 3; // ceil(2n/3)
+    (k, k_high)
+}
+
+/// Per-promotion rep accrual `α · g(D)` (inc-1 §2.3). The per-epoch cap is
+/// enforced by [`RepStore::record_promotion`], not here.
+pub fn accrual(d: u32, cfg: &SwarmTrustConfig) -> f32 {
+    cfg.accrual_alpha * g(d)
+}
+
+// ---------------------------------------------------------------------------
+// Append-only log ops
+// ---------------------------------------------------------------------------
+
+/// A single append-only reputation-log operation. Deltas (`accrue`, `penalty`)
+/// are stored so a replay reproduces rep exactly and independently of any later
+/// config drift.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum LogOp {
+    /// Enrollment vouch edge `voucher -> vouchee`.
+    Vouch { voucher: PubKey, vouchee: PubKey },
+    /// A promotion event (origin accrued `accrue`, already epoch-capped/echo-zeroed).
+    Promotion {
+        mem_hash: MemHash,
+        origin: PubKey,
+        epoch: u64,
+        accrue: f32,
+        corroborators: Vec<(PubKey, Option<PubKey>)>,
+    },
+    /// An operator hard-reject subtracting `penalty` from `pk`.
+    Poison { pk: PubKey, penalty: f32 },
+}
+
+/// A hash-chained log line: `chain = blake3(prev_chain ‖ bincode(op))`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LogLine {
+    op: LogOp,
+    chain: [u8; 32],
+}
+
+/// Compact gzip snapshot payload (bincode inner, so `[u8;32]` map keys are fine).
+#[derive(Debug, Serialize, Deserialize)]
+struct Snapshot {
+    log_head: [u8; 32],
+    seeds: Vec<PubKey>,
+    reps: Vec<RepRecord>,
+    /// `(vouchee, voucher)` edges.
+    vouch_edges: Vec<(PubKey, PubKey)>,
+    /// `(mem_hash, epoch, corroborators)`.
+    promotions: Vec<(MemHash, u64, Vec<(PubKey, Option<PubKey>)>)>,
+}
+
+// ---------------------------------------------------------------------------
+// RepStore
+// ---------------------------------------------------------------------------
+
+/// Pubkey-keyed reputation store + corroboration DAG + fail-closed persistence
+/// (inc-1 §3.2). Construct with [`in_memory`](RepStore::in_memory) (tests) or
+/// [`load`](RepStore::load) (from `<data_dir>/reputation.{log,snapshot.gz}`).
+#[derive(Debug)]
+pub struct RepStore {
+    reps: HashMap<PubKey, RepRecord>,
+    seeds: HashSet<PubKey>,
+    dag: CorroborationDag,
+    /// Fail-closed flag: a load that failed to parse/verify sets this and every
+    /// [`decide`](RepStore::decide) returns [`Promotion::Quarantine`].
+    poisoned: bool,
+    /// Running blake3 chain head over the append-only log.
+    log_head: [u8; 32],
+    /// `Some` when persistence is enabled; `None` for in-memory test stores.
+    data_dir: Option<PathBuf>,
+    /// Transient per-epoch accrual bookkeeping `pk -> (epoch, accrued)` — enforces
+    /// the anti-burst cap. Not persisted (epochs advance; the cap is per-epoch).
+    epoch_accrual: HashMap<PubKey, (u64, f32)>,
+}
+
+impl RepStore {
+    /// An in-memory store seeded from `cfg.seed_pubkeys`, no persistence.
+    pub fn in_memory(cfg: &SwarmTrustConfig) -> Self {
+        Self {
+            reps: HashMap::new(),
+            seeds: seeds_from_cfg(cfg),
+            dag: CorroborationDag::default(),
+            poisoned: false,
+            log_head: [0u8; 32],
+            data_dir: None,
+            epoch_accrual: HashMap::new(),
+        }
+    }
+
+    /// A persistence-backed store rooted at `data_dir` (does not read existing
+    /// state — use [`load`](RepStore::load) for that).
+    pub fn new_at(cfg: &SwarmTrustConfig, data_dir: PathBuf) -> Self {
+        let mut s = Self::in_memory(cfg);
+        s.data_dir = Some(data_dir);
+        s
+    }
+
+    /// A fail-closed store: poisoned, refuses all promotion.
+    fn poisoned_store(cfg: &SwarmTrustConfig, data_dir: Option<PathBuf>) -> Self {
+        let mut s = Self::in_memory(cfg);
+        s.poisoned = true;
+        s.data_dir = data_dir;
+        s
+    }
+
+    /// True when the store is fail-closed and refuses every promotion (a corrupt
+    /// or unverifiable log). Callers must treat everyone as rep 0.
+    pub fn refuses_promotion(&self) -> bool {
+        self.poisoned
+    }
+
+    /// Number of live (operator-pinned) seeds — the input to [`k_for`].
+    pub fn live_seed_count(&self) -> u32 {
+        self.seeds.len() as u32
+    }
+
+    /// Reputation of a pubkey: seeds are `1.0`, a record's rep otherwise, `0.0`
+    /// for an unknown handle.
+    pub fn rep(&self, pk: &PubKey) -> f32 {
+        if self.seeds.contains(pk) {
+            return 1.0;
+        }
+        self.reps.get(pk).map(|r| r.rep).unwrap_or(0.0)
+    }
+
+    /// Enrollment status of a pubkey.
+    pub fn seed_status(&self, pk: &PubKey) -> SeedStatus {
+        if self.seeds.contains(pk) {
+            SeedStatus::Seed
+        } else if self.seed_root_of(pk).is_some() || self.reps.contains_key(pk) {
+            SeedStatus::Enrolled
+        } else {
+            SeedStatus::Unknown
+        }
+    }
+
+    /// Authoritative seed_root for a pubkey (seed ⇒ itself, else DAG walk).
+    pub fn seed_root_of(&self, pk: &PubKey) -> Option<PubKey> {
+        self.dag.seed_root(pk, &self.seeds)
+    }
+
+    /// Read access to the corroboration DAG.
+    pub fn dag(&self) -> &CorroborationDag {
+        &self.dag
+    }
+
+    // --- decision -------------------------------------------------------
+
+    /// Decide the fate of a candidate memory (inc-1 §2.2). Pure w.r.t. store
+    /// state — mutates nothing. Corroborators are `(pubkey, recorded_seed_root)`;
+    /// the seed_root and rep are re-resolved authoritatively from this store, so
+    /// caller-supplied lineage claims cannot inflate `C(M)`.
+    ///
+    /// - Fail-closed (poisoned) ⇒ [`Quarantine`](Promotion::Quarantine).
+    /// - Already-Live `mem_hash` (echo) ⇒ `Live { accrue: 0.0 }`.
+    /// - Seed origin, normal write ⇒ `Live`. Seed origin, `high_impact` ⇒
+    ///   requires `K_high` DISTINCT lineages (a lone seed is 1 lineage ⇒
+    ///   `Quarantine`).
+    /// - Non-seed origin ⇒ `Live` iff `C(M) ≥ K_eff`. `resonance_ok` with ≥1
+    ///   valid echo lowers `K` by 1 (floor 2); `high_impact` forces `K_high`
+    ///   (never reduced). A seed among the corroborators without full quorum ⇒
+    ///   `ProbationLive`; otherwise `Quarantine`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn decide(
+        &self,
+        mem_hash: MemHash,
+        origin_pk: PubKey,
+        corroborators: &[(PubKey, Option<PubKey>)],
+        epoch: u64,
+        live_seed_count: u32,
+        high_impact: bool,
+        resonance_ok: bool,
+        cfg: &SwarmTrustConfig,
+    ) -> Promotion {
+        let _ = epoch; // bound into corroboration envelopes for the admit layer;
+                       // the pure predicate does not use it.
+        if self.poisoned {
+            return Promotion::Quarantine;
+        }
+        if self.dag.is_promoted(&mem_hash) {
+            return Promotion::Live { accrue: 0.0 }; // echo — already Live, earns nothing
+        }
+
+        let (k, k_high) = k_for(live_seed_count);
+
+        // Authoritative triples: recompute seed_root + rep from this store.
+        let triples: Vec<(PubKey, Option<PubKey>, f32)> = corroborators
+            .iter()
+            .map(|(pk, _)| (*pk, self.seed_root_of(pk), self.rep(pk)))
+            .collect();
+
+        if self.seeds.contains(&origin_pk) {
+            if high_impact {
+                let mut roots: HashSet<PubKey> = triples
+                    .iter()
+                    .filter(|(_, _, rep)| *rep >= cfg.trust_threshold)
+                    .filter_map(|(_, root, _)| *root)
+                    .collect();
+                roots.insert(origin_pk); // the origin seed is its own lineage
+                if roots.len() as u32 >= k_high {
+                    return Promotion::Live { accrue: 0.0 };
+                }
+                return Promotion::Quarantine;
+            }
+            return Promotion::Live { accrue: 0.0 };
+        }
+
+        // Non-seed origin: corroboration quorum.
+        let c = promotion_weight(triples.iter().copied(), cfg);
+        let d = distinct_lineage_count(triples.iter().copied(), cfg);
+
+        let k_eff = if resonance_ok && d >= 1 {
+            k.saturating_sub(1).max(2) // field resonance lowers K by ≤1, floor 2
+        } else {
+            k
+        };
+        let required = if high_impact { k_high.max(2) } else { k_eff };
+
+        if c + EPS >= required as f32 {
+            Promotion::Live { accrue: accrual(d, cfg) }
+        } else if triples.iter().any(|(pk, _, _)| self.seeds.contains(pk)) {
+            Promotion::ProbationLive // seed endorsement without full quorum
+        } else {
+            Promotion::Quarantine
+        }
+    }
+
+    // --- bookkeeping (mutate + persist) ---------------------------------
+
+    /// Record an enrollment vouch edge `voucher -> vouchee` and resolve the
+    /// vouchee's seed_root. Appends to the log.
+    pub fn record_vouch(&mut self, voucher_pk: PubKey, vouchee_pk: PubKey) {
+        self.apply_vouch(voucher_pk, vouchee_pk);
+        let _ = self.append_op(&LogOp::Vouch { voucher: voucher_pk, vouchee: vouchee_pk });
+    }
+
+    /// Record a promotion of `mem_hash` originated by `origin_pk`, accruing
+    /// `α·g(D)` (per-epoch capped) to the origin — UNLESS `mem_hash` is already
+    /// Live, in which case this is an echo: the corroboration edge is recorded
+    /// but **no rep accrues and no memory is created**. Appends to the log.
+    pub fn record_promotion(
+        &mut self,
+        mem_hash: MemHash,
+        origin_pk: PubKey,
+        epoch: u64,
+        corroborators: Vec<(PubKey, Option<PubKey>)>,
+        cfg: &SwarmTrustConfig,
+    ) {
+        let accrue = if self.dag.is_promoted(&mem_hash) {
+            0.0 // echo earns nothing
+        } else {
+            let d = distinct_lineage_count(
+                corroborators.iter().map(|(pk, root)| (*pk, *root, self.rep(pk))),
+                cfg,
+            );
+            let raw = accrual(d, cfg);
+            self.epoch_capped(origin_pk, epoch, raw, cfg)
+        };
+        self.apply_promotion(mem_hash, origin_pk, epoch, &corroborators, accrue, cfg);
+        let _ = self.append_op(&LogOp::Promotion {
+            mem_hash,
+            origin: origin_pk,
+            epoch,
+            accrue,
+            corroborators,
+        });
+    }
+
+    /// Operator hard-reject: subtract `p` from `pk`'s rep and count the poison.
+    /// The only rep-lowering lever (no peer-triggered penalty exists). Appends
+    /// to the log.
+    pub fn record_poison(&mut self, pk: PubKey, cfg: &SwarmTrustConfig) {
+        self.apply_poison(pk, P_POISON, cfg);
+        let _ = self.append_op(&LogOp::Poison { pk, penalty: P_POISON });
+    }
+
+    // --- state mutation (no persistence; also used by replay) -----------
+
+    fn apply_vouch(&mut self, voucher: PubKey, vouchee: PubKey) {
+        self.dag.record_vouch(voucher, vouchee);
+        let sr = self.dag.seed_root(&vouchee, &self.seeds);
+        let rec = self
+            .reps
+            .entry(vouchee)
+            .or_insert_with(|| RepRecord::new(vouchee, now_ms()));
+        rec.vouched_by = Some(voucher);
+        rec.seed_root = sr;
+    }
+
+    fn apply_promotion(
+        &mut self,
+        mem_hash: MemHash,
+        origin_pk: PubKey,
+        epoch: u64,
+        corroborators: &[(PubKey, Option<PubKey>)],
+        accrue: f32,
+        cfg: &SwarmTrustConfig,
+    ) {
+        let is_echo = self.dag.is_promoted(&mem_hash);
+        self.dag.record_promotion(mem_hash, epoch, corroborators);
+        if is_echo {
+            return; // no rep change on echo
+        }
+        let sr = self.seed_root_of(&origin_pk);
+        let rec = self
+            .reps
+            .entry(origin_pk)
+            .or_insert_with(|| RepRecord::new(origin_pk, now_ms()));
+        rec.rep = (rec.rep + accrue).clamp(0.0, 1.0);
+        rec.promoted += 1;
+        if rec.seed_root.is_none() {
+            rec.seed_root = sr;
+        }
+        rec.update_armed(cfg);
+    }
+
+    fn apply_poison(&mut self, pk: PubKey, penalty: f32, cfg: &SwarmTrustConfig) {
+        let rec = self.reps.entry(pk).or_insert_with(|| RepRecord::new(pk, now_ms()));
+        rec.rep = (rec.rep - penalty).clamp(0.0, 1.0);
+        rec.poison += 1;
+        rec.update_armed(cfg);
+    }
+
+    /// Clamp `raw` accrual to what remains of this epoch's cap (`accrual_alpha`)
+    /// for `pk`, so a burst of promotions in one epoch cannot spike rep.
+    fn epoch_capped(&mut self, pk: PubKey, epoch: u64, raw: f32, cfg: &SwarmTrustConfig) -> f32 {
+        let cap = cfg.accrual_alpha;
+        let entry = self.epoch_accrual.entry(pk).or_insert((epoch, 0.0));
+        if entry.0 != epoch {
+            *entry = (epoch, 0.0);
+        }
+        let allowed = (cap - entry.1).max(0.0);
+        let actual = raw.min(allowed);
+        entry.1 += actual;
+        actual
+    }
+
+    fn apply_op(&mut self, op: &LogOp, cfg: &SwarmTrustConfig) {
+        match op {
+            LogOp::Vouch { voucher, vouchee } => self.apply_vouch(*voucher, *vouchee),
+            LogOp::Promotion { mem_hash, origin, epoch, accrue, corroborators } => {
+                self.apply_promotion(*mem_hash, *origin, *epoch, corroborators, *accrue, cfg)
+            }
+            LogOp::Poison { pk, penalty } => self.apply_poison(*pk, *penalty, cfg),
+        }
+    }
+
+    // --- persistence ----------------------------------------------------
+
+    /// Append a hash-chained line to `<data_dir>/reputation.log`. A no-op for
+    /// in-memory stores. Advances [`log_head`](RepStore::log_head) on success.
+    fn append_op(&mut self, op: &LogOp) -> Result<(), String> {
+        let Some(dir) = self.data_dir.clone() else {
+            return Ok(()); // in-memory: no persistence
+        };
+        let op_bytes =
+            bincode::serialize(op).map_err(|e| format!("reputation: encode op: {e}"))?;
+        let mut h = blake3::Hasher::new();
+        h.update(&self.log_head);
+        h.update(&op_bytes);
+        let chain = *h.finalize().as_bytes();
+        let line = LogLine { op: op.clone(), chain };
+        let json = serde_json::to_string(&line)
+            .map_err(|e| format!("reputation: encode line: {e}"))?;
+
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("reputation: mkdir {}: {e}", dir.display()))?;
+        let path = dir.join("reputation.log");
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| format!("reputation: open {}: {e}", path.display()))?;
+        f.write_all(json.as_bytes())
+            .and_then(|_| f.write_all(b"\n"))
+            .map_err(|e| format!("reputation: append: {e}"))?;
+        self.log_head = chain;
+        Ok(())
+    }
+
+    /// Load a store from `<data_dir>/reputation.snapshot.gz` (if present) + the
+    /// hash-chained `reputation.log`. **Fail-closed**: any snapshot decode error,
+    /// log read error, unparsable line, or broken hash chain yields a poisoned
+    /// store that refuses all promotion (inc-1 §3.2). A missing file is a clean
+    /// empty store, not a failure. Seeds are always taken from `cfg`.
+    pub fn load(data_dir: &Path, cfg: &SwarmTrustConfig) -> RepStore {
+        let mut store = RepStore::new_at(cfg, data_dir.to_path_buf());
+
+        // 1. Optional compact snapshot.
+        let snap_path = data_dir.join("reputation.snapshot.gz");
+        if snap_path.exists() {
+            match read_snapshot(&snap_path) {
+                Some(snap) => store.apply_snapshot(snap),
+                None => return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf())),
+            }
+        }
+
+        // 2. Replay the hash-chained log on top.
+        let log_path = data_dir.join("reputation.log");
+        if log_path.exists() {
+            let text = match std::fs::read_to_string(&log_path) {
+                Ok(t) => t,
+                Err(_) => return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf())),
+            };
+            let mut head = store.log_head;
+            for line in text.lines() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let ll: LogLine = match serde_json::from_str(line) {
+                    Ok(l) => l,
+                    Err(_) => return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf())),
+                };
+                let op_bytes = match bincode::serialize(&ll.op) {
+                    Ok(b) => b,
+                    Err(_) => return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf())),
+                };
+                let mut h = blake3::Hasher::new();
+                h.update(&head);
+                h.update(&op_bytes);
+                let expect = *h.finalize().as_bytes();
+                if expect != ll.chain {
+                    return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf()));
+                }
+                head = expect;
+                store.apply_op(&ll.op, cfg);
+            }
+            store.log_head = head;
+        }
+
+        store
+    }
+
+    fn apply_snapshot(&mut self, snap: Snapshot) {
+        self.log_head = snap.log_head;
+        // Seeds already come from cfg; union in any snapshot-recorded seeds too.
+        for s in snap.seeds {
+            self.seeds.insert(s);
+        }
+        for (vouchee, voucher) in snap.vouch_edges {
+            self.dag.record_vouch(voucher, vouchee);
+        }
+        for (mem_hash, epoch, corrs) in snap.promotions {
+            self.dag.record_promotion(mem_hash, epoch, &corrs);
+        }
+        for rec in snap.reps {
+            self.reps.insert(rec.pubkey, rec);
+        }
+    }
+
+    fn snapshot(&self) -> Snapshot {
+        let mut vouch_edges = Vec::new();
+        for (vouchee, voucher) in &self.dag.vouched_by {
+            vouch_edges.push((*vouchee, *voucher));
+        }
+        let mut promotions = Vec::new();
+        for (mem_hash, ev) in &self.dag.promotions {
+            promotions.push((*mem_hash, ev.epoch, ev.corroborators.clone()));
+        }
+        Snapshot {
+            log_head: self.log_head,
+            seeds: self.seeds.iter().copied().collect(),
+            reps: self.reps.values().cloned().collect(),
+            vouch_edges,
+            promotions,
+        }
+    }
+
+    /// Compact the append-only log into a gzip snapshot at
+    /// `<data_dir>/reputation.snapshot.gz` and truncate the log, preserving the
+    /// chain head so subsequent appends stay verifiable. No-op for in-memory
+    /// stores. Mirrors the crate's atomic temp-write + rename discipline.
+    pub fn compact(&self) -> Result<(), String> {
+        let Some(dir) = self.data_dir.clone() else {
+            return Ok(());
+        };
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("reputation: mkdir {}: {e}", dir.display()))?;
+        let bytes = bincode::serialize(&self.snapshot())
+            .map_err(|e| format!("reputation: encode snapshot: {e}"))?;
+        let mut enc =
+            flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(&bytes)
+            .map_err(|e| format!("reputation: gzip: {e}"))?;
+        let gz = enc.finish().map_err(|e| format!("reputation: gzip finish: {e}"))?;
+        atomic_write(&dir.join("reputation.snapshot.gz"), &gz)?;
+        // Truncate the log — the snapshot captures state up to log_head; new
+        // appends chain forward from the same head.
+        atomic_write(&dir.join("reputation.log"), b"")?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Seed pubkey set from `cfg.seed_pubkeys` (base64). Invalid entries are
+/// dropped — an empty set means the corroboration gate is dormant (no root yet).
+fn seeds_from_cfg(cfg: &SwarmTrustConfig) -> HashSet<PubKey> {
+    cfg.seed_pubkeys
+        .iter()
+        .filter_map(|s| b64_decode_32(s.trim()))
+        .collect()
+}
+
+/// Current wall-clock in unix milliseconds.
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// Atomic write: temp sibling → `write_all` → `sync_all` → rename over target.
+/// Mirrors the sidecar writers elsewhere in the crate.
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("reputation: mkdir {}: {e}", dir.display()))?;
+    let tmp = dir.join(format!(".kannaka-rep-tmp-{}", uuid::Uuid::new_v4()));
+    {
+        let mut f = std::fs::File::create(&tmp).map_err(|e| format!("reputation: tmp: {e}"))?;
+        if let Err(e) = f.write_all(bytes) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("reputation: write: {e}"));
+        }
+        if let Err(e) = f.sync_all() {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("reputation: sync: {e}"));
+        }
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("reputation: rename: {e}"));
+    }
+    Ok(())
+}
+
+/// Read + gunzip + bincode-decode a snapshot; `None` on any error (fail-closed).
+fn read_snapshot(path: &Path) -> Option<Snapshot> {
+    let gz = std::fs::read(path).ok()?;
+    let mut dec = flate2::read::GzDecoder::new(&gz[..]);
+    let mut bytes = Vec::new();
+    std::io::Read::read_to_end(&mut dec, &mut bytes).ok()?;
+    bincode::deserialize(&bytes).ok()
+}
+
+// --- base64 (standard alphabet) — decode-only, mirrors provenance's codec ---
+
+fn b64_decode_32(s: &str) -> Option<PubKey> {
+    let mut out: Vec<u8> = Vec::with_capacity(32);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in s.as_bytes() {
+        if b == b'=' || b == b'\n' || b == b'\r' || b == b' ' {
+            continue;
+        }
+        let val: u32 = match b {
+            b'A'..=b'Z' => u32::from(b - b'A'),
+            b'a'..=b'z' => u32::from(b - b'a') + 26,
+            b'0'..=b'9' => u32::from(b - b'0') + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => return None,
+        };
+        buf = (buf << 6) | val;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+    if out.len() != 32 {
+        return None;
+    }
+    let mut a = [0u8; 32];
+    a.copy_from_slice(&out);
+    Some(a)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> SwarmTrustConfig {
+        SwarmTrustConfig::default() // theta_lo=0.4, theta_hi=0.7, theta=0.6, alpha=0.05
+    }
+
+    fn pk(n: u8) -> PubKey {
+        [n; 32]
+    }
+    fn hash(n: u8) -> MemHash {
+        [n; 32]
+    }
+    fn rr(p: PubKey, rep: f32) -> RepRecord {
+        let mut r = RepRecord::new(p, 0);
+        r.rep = rep;
+        r
+    }
+
+    // (a) w(rep) hysteresis: 0 at 0.3, rises 0.4→0.7, 1.0 at ≥0.7; monotone.
+    #[test]
+    fn w_hysteresis_and_monotone() {
+        let c = cfg();
+        assert_eq!(w(0.3, &c), 0.0);
+        assert_eq!(w(0.4, &c), 0.0); // ramp starts at θ_lo
+        assert!((w(0.55, &c) - 0.5).abs() < 1e-4, "midpoint ramp");
+        assert_eq!(w(0.7, &c), 1.0);
+        assert_eq!(w(0.9, &c), 1.0);
+        let mut prev = -1.0;
+        for i in 0..=100 {
+            let r = i as f32 / 100.0;
+            let v = w(r, &c);
+            assert!(v >= prev - 1e-6, "w must be monotone non-decreasing");
+            prev = v;
+        }
+        // Arming hysteresis is carried on the record, not in w().
+        let mut rec = rr(pk(1), 0.8);
+        rec.update_armed(&c);
+        assert!(rec.armed, "rep ≥ θ_hi arms");
+        rec.rep = 0.5;
+        rec.update_armed(&c); // in the band — holds armed
+        assert!(rec.armed, "stays armed inside [θ_lo, θ_hi)");
+        rec.rep = 0.3;
+        rec.update_armed(&c); // below θ_lo — disarms
+        assert!(!rec.armed, "disarms below θ_lo");
+    }
+
+    // (b) g(D) sub-linear + bounded (< 1).
+    #[test]
+    fn g_sublinear_bounded() {
+        assert_eq!(g(0), 0.0);
+        assert!((g(1) - 0.5).abs() < 1e-4);
+        assert!((g(2) - 2.0 / 3.0).abs() < 1e-4);
+        assert!(g(3) < 1.0 && g(1000) < 1.0, "bounded below 1");
+        assert!(g(2) > g(1), "strictly increasing");
+        // sub-linear: marginal gain shrinks.
+        assert!(g(2) - g(1) < g(1) - g(0) + 1e-6);
+    }
+
+    // (c) lineage saturation: 5 pubkeys sharing ONE seed_root ⇒ C = 1, not 5.
+    #[test]
+    fn lineage_saturates_at_one() {
+        let c = cfg();
+        let root = pk(1);
+        let corrs: Vec<_> = (10u8..15).map(|n| (pk(n), Some(root), 0.8f32)).collect();
+        let cm = promotion_weight(corrs.iter().copied(), &c);
+        assert!((cm - 1.0).abs() < 1e-4, "one lineage saturates at 1, got {cm}");
+        assert_eq!(distinct_lineage_count(corrs.iter().copied(), &c), 1);
+    }
+
+    // (d) distinct lineages: 3 seed-disjoint lineages ⇒ C = 3 ⇒ K = 2 satisfied.
+    #[test]
+    fn distinct_lineages_sum() {
+        let c = cfg();
+        let corrs = vec![
+            (pk(10), Some(pk(1)), 0.8f32),
+            (pk(11), Some(pk(2)), 0.8f32),
+            (pk(12), Some(pk(3)), 0.8f32),
+        ];
+        let cm = promotion_weight(corrs.iter().copied(), &c);
+        assert!((cm - 3.0).abs() < 1e-4, "three lineages ⇒ C=3, got {cm}");
+        let (k, _) = k_for(3);
+        assert_eq!(k, 2);
+        assert!(cm + EPS >= k as f32, "C=3 satisfies K=2");
+    }
+
+    // k_for schedule spot-checks (inc-1 §2.2 table).
+    #[test]
+    fn k_for_schedule() {
+        assert_eq!(k_for(6), (3, 4)); // the 6-seed roster
+        assert_eq!(k_for(3), (2, 2));
+        assert_eq!(k_for(0), (2, 0)); // dormant floor
+        assert_eq!(k_for(2), (2, 2));
+    }
+
+    fn store_with_6_seeds() -> (RepStore, Vec<PubKey>) {
+        let c = cfg();
+        let mut store = RepStore::in_memory(&c);
+        let seeds: Vec<PubKey> = (1u8..=6).map(pk).collect();
+        for s in &seeds {
+            store.seeds.insert(*s);
+        }
+        (store, seeds)
+    }
+
+    // (e) decide across the branches.
+    #[test]
+    fn decide_branches() {
+        let c = cfg();
+        let (mut store, seeds) = store_with_6_seeds();
+        let origin = pk(100); // non-seed
+
+        // Two enrolled non-seed handles sharing ONE seed_root (seeds[0]).
+        let a = pk(50);
+        let b = pk(51);
+        store.reps.insert(a, rr(a, 0.8));
+        store.reps.insert(b, rr(b, 0.8));
+        store.record_vouch(seeds[0], a);
+        store.record_vouch(seeds[0], b);
+
+        // C < K ⇒ Quarantine (one lineage = 1 < K=3), no seed among corroborators.
+        let corr_ck = vec![(a, store.seed_root_of(&a)), (b, store.seed_root_of(&b))];
+        let d1 = store.decide(hash(1), origin, &corr_ck, 1, 6, false, false, &c);
+        assert_eq!(d1, Promotion::Quarantine, "C<K ⇒ Quarantine");
+
+        // C ≥ K ⇒ Live with accrual > 0 (three seed-disjoint lineages).
+        let corr_live: Vec<_> = seeds[0..3].iter().map(|s| (*s, Some(*s))).collect();
+        let d2 = store.decide(hash(2), origin, &corr_live, 1, 6, false, false, &c);
+        match d2 {
+            Promotion::Live { accrue } => assert!(accrue > 0.0, "accrual must be > 0"),
+            other => panic!("expected Live, got {other:?}"),
+        }
+
+        // Seed origin, normal write ⇒ Live.
+        let d3 = store.decide(hash(3), seeds[0], &[], 1, 6, false, false, &c);
+        assert_eq!(d3, Promotion::Live { accrue: 0.0 }, "seed normal ⇒ Live");
+
+        // Seed origin, high-impact, ALONE ⇒ Quarantine (1 lineage < K_high=4).
+        let d4 = store.decide(hash(4), seeds[0], &[], 1, 6, true, false, &c);
+        assert_eq!(d4, Promotion::Quarantine, "lone seed high-impact ⇒ Quarantine");
+
+        // Seed endorsement without full quorum ⇒ ProbationLive (cold-start).
+        let d5 = store.decide(hash(5), origin, &[(seeds[0], Some(seeds[0]))], 1, 6, false, false, &c);
+        assert_eq!(d5, Promotion::ProbationLive, "lone seed vouch ⇒ ProbationLive");
+    }
+
+    // (f) echo earns nothing: re-corroborating a recorded mem by the same pk
+    // does not double-count and accrues no rep.
+    #[test]
+    fn echo_earns_nothing() {
+        let c = cfg();
+        let mut store = RepStore::in_memory(&c);
+        let s1 = pk(1);
+        store.seeds.insert(s1);
+        let origin = pk(100);
+        let mem = hash(7);
+
+        store.record_promotion(mem, origin, 1, vec![(s1, Some(s1))], &c);
+        let rep1 = store.rep(&origin);
+        let cc1 = store.dag.corroborator_count(&mem);
+        assert!(rep1 > 0.0, "first promotion accrues");
+        assert_eq!(cc1, 1);
+
+        // Echo: same mem, repeated corroborator.
+        store.record_promotion(mem, origin, 1, vec![(s1, Some(s1)), (s1, Some(s1))], &c);
+        let rep2 = store.rep(&origin);
+        let cc2 = store.dag.corroborator_count(&mem);
+        assert_eq!(rep1, rep2, "echo must not accrue");
+        assert_eq!(cc1, cc2, "duplicate corroborator must not double-count");
+    }
+
+    // per-epoch accrual cap: a burst in one epoch cannot exceed alpha.
+    #[test]
+    fn accrual_epoch_capped() {
+        let c = cfg();
+        let mut store = RepStore::in_memory(&c);
+        let s: Vec<PubKey> = (1u8..=6).map(pk).collect();
+        for k in &s {
+            store.seeds.insert(*k);
+        }
+        let origin = pk(100);
+        // Many distinct promotions in the SAME epoch.
+        for i in 0..20u8 {
+            let corrs: Vec<_> = s[0..3].iter().map(|x| (*x, Some(*x))).collect();
+            store.record_promotion(hash(50 + i), origin, 1, corrs, &c);
+        }
+        assert!(
+            store.rep(&origin) <= c.accrual_alpha + 1e-4,
+            "one epoch's accrual capped at alpha, got {}",
+            store.rep(&origin)
+        );
+    }
+
+    // (g) fail-closed load: a corrupt reputation.log ⇒ a store that refuses
+    // promotion (and decide returns Quarantine for everyone).
+    #[test]
+    fn fail_closed_on_corrupt_log() {
+        let c = cfg();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("reputation.log"), "not a valid json line\n").unwrap();
+        let store = RepStore::load(dir.path(), &c);
+        assert!(store.refuses_promotion(), "corrupt log ⇒ fail-closed");
+        let d = store.decide(hash(1), pk(1), &[], 1, 6, false, false, &c);
+        assert_eq!(d, Promotion::Quarantine, "poisoned store quarantines all");
+    }
+
+    // A broken hash chain (tampered line) is also fail-closed.
+    #[test]
+    fn fail_closed_on_broken_chain() {
+        let c = cfg();
+        let dir = tempfile::tempdir().unwrap();
+        // Write one valid op, then tamper the chain field.
+        {
+            let mut store = RepStore::new_at(&c, dir.path().to_path_buf());
+            store.record_vouch(pk(1), pk(2));
+        }
+        let log_path = dir.path().join("reputation.log");
+        let text = std::fs::read_to_string(&log_path).unwrap();
+        // Flip the chain: replace the recorded 32-byte array's first element.
+        let tampered = text.replacen("\"chain\":[", "\"chain\":[255,", 1);
+        // Drop one element so length stays 32 (remove a trailing ",0").
+        let tampered = tampered.replacen(",0]}", "]}", 1);
+        std::fs::write(&log_path, tampered).unwrap();
+        let store = RepStore::load(dir.path(), &c);
+        assert!(store.refuses_promotion(), "tampered chain ⇒ fail-closed");
+    }
+
+    // A clean append-only log round-trips through load and preserves rep.
+    #[test]
+    fn log_round_trip_preserves_rep() {
+        let c = cfg();
+        let dir = tempfile::tempdir().unwrap();
+        // Seed via cfg so the loaded store agrees on seeds.
+        let mut cfg2 = c.clone();
+        // Use a base64 seed so seeds_from_cfg picks it up on reload.
+        let seed_b64 = b64_encode_test(&pk(9));
+        cfg2.seed_pubkeys = vec![seed_b64];
+        let origin = pk(100);
+        {
+            let mut store = RepStore::load(dir.path(), &cfg2);
+            let corrs = vec![(pk(9), Some(pk(9)))];
+            store.record_promotion(hash(1), origin, 1, corrs, &cfg2);
+            assert!(store.rep(&origin) > 0.0);
+        }
+        let reloaded = RepStore::load(dir.path(), &cfg2);
+        assert!(!reloaded.refuses_promotion());
+        assert!(reloaded.rep(&origin) > 0.0, "rep survived reload");
+        assert!(reloaded.dag().is_promoted(&hash(1)));
+    }
+
+    // compact → snapshot → reload preserves state and clears the log.
+    #[test]
+    fn compact_snapshot_reload() {
+        let c = cfg();
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg2 = c.clone();
+        cfg2.seed_pubkeys = vec![b64_encode_test(&pk(9))];
+        let origin = pk(100);
+        {
+            let mut store = RepStore::load(dir.path(), &cfg2);
+            store.record_promotion(hash(1), origin, 1, vec![(pk(9), Some(pk(9)))], &cfg2);
+            store.compact().unwrap();
+        }
+        assert!(dir.path().join("reputation.snapshot.gz").exists());
+        let reloaded = RepStore::load(dir.path(), &cfg2);
+        assert!(!reloaded.refuses_promotion());
+        assert!(reloaded.rep(&origin) > 0.0, "rep survived compact+reload");
+        assert!(reloaded.dag().is_promoted(&hash(1)));
+    }
+
+    // (h) seed_root DAG walk resolves a vouch chain to the seed; a cycle
+    // terminates with None.
+    #[test]
+    fn seed_root_walk_and_cycle() {
+        let mut dag = CorroborationDag::default();
+        let mut seeds: HashSet<PubKey> = HashSet::new();
+        let s = pk(1);
+        seeds.insert(s);
+        let a = pk(2);
+        let b = pk(3);
+        dag.record_vouch(s, a); // s vouches a
+        dag.record_vouch(a, b); // a vouches b
+        assert_eq!(dag.seed_root(&b, &seeds), Some(s), "chain resolves to seed");
+        assert_eq!(dag.seed_root(&a, &seeds), Some(s));
+        assert_eq!(dag.seed_root(&s, &seeds), Some(s), "seed roots to itself");
+        assert_eq!(dag.seed_root(&pk(200), &seeds), None, "unknown ⇒ ⊥");
+
+        // Cycle with no seed must terminate (not hang) and return None.
+        let mut dag2 = CorroborationDag::default();
+        let empty: HashSet<PubKey> = HashSet::new();
+        let x = pk(10);
+        let y = pk(11);
+        dag2.record_vouch(x, y);
+        dag2.record_vouch(y, x); // x ↔ y cycle
+        assert_eq!(dag2.seed_root(&x, &empty), None, "cycle terminates ⇒ None");
+        assert_eq!(dag2.seed_root(&y, &empty), None);
+    }
+
+    // Minimal base64 encoder for the persistence round-trip tests.
+    fn b64_encode_test(data: &[u8]) -> String {
+        const A: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::new();
+        for chunk in data.chunks(3) {
+            let b0 = chunk[0];
+            let b1 = *chunk.get(1).unwrap_or(&0);
+            let b2 = *chunk.get(2).unwrap_or(&0);
+            let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+            out.push(A[((n >> 18) & 63) as usize] as char);
+            out.push(A[((n >> 12) & 63) as usize] as char);
+            out.push(if chunk.len() > 1 { A[((n >> 6) & 63) as usize] as char } else { '=' });
+            out.push(if chunk.len() > 2 { A[(n & 63) as usize] as char } else { '=' });
+        }
+        out
+    }
+}

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -482,6 +482,27 @@ impl RepStore {
         &self.dag
     }
 
+    /// Read-only: the reputation record for `pk`, if one exists. Exposes the
+    /// bookkeeping counters (`promoted`, `poison`, `armed`, `seed_root`) to the
+    /// operator inspection CLI (`kannaka reputation show`). Pure — no state
+    /// change and no effect on the (dormant) promotion gate.
+    pub fn record(&self, pk: &PubKey) -> Option<&RepRecord> {
+        self.reps.get(pk)
+    }
+
+    /// Read-only: iterate the operator-pinned seed pubkeys (CLI listing). A
+    /// seed need not carry a [`RepRecord`], so enumerate this alongside
+    /// [`records`](RepStore::records) to get every *known* pubkey.
+    pub fn seeds(&self) -> impl Iterator<Item = &PubKey> {
+        self.seeds.iter()
+    }
+
+    /// Read-only: iterate every reputation record (CLI listing). Does not
+    /// include seeds that have no record — union with [`seeds`](RepStore::seeds).
+    pub fn records(&self) -> impl Iterator<Item = &RepRecord> {
+        self.reps.values()
+    }
+
     // --- decision -------------------------------------------------------
 
     /// Decide the fate of a candidate memory (inc-1 §2.2). Pure w.r.t. store

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -1150,25 +1150,42 @@ mod tests {
         assert_eq!(d, Promotion::Quarantine, "poisoned store quarantines all");
     }
 
-    // A broken hash chain (tampered line) is also fail-closed.
+    // A broken hash chain (tampered line) is fail-closed — via the hash-chain
+    // COMPARE, not the parse-error path. The tamper must stay length-preserving
+    // ([u8;32] still deserializes) so it actually reaches the compare.
     #[test]
     fn fail_closed_on_broken_chain() {
         let c = cfg();
         let dir = tempfile::tempdir().unwrap();
-        // Write one valid op, then tamper the chain field.
         {
             let mut store = RepStore::new_at(&c, dir.path().to_path_buf());
             store.record_vouch(pk(1), pk(2));
         }
         let log_path = dir.path().join("reputation.log");
         let text = std::fs::read_to_string(&log_path).unwrap();
-        // Flip the chain: replace the recorded 32-byte array's first element.
-        let tampered = text.replacen("\"chain\":[", "\"chain\":[255,", 1);
-        // Drop one element so length stays 32 (remove a trailing ",0").
-        let tampered = tampered.replacen(",0]}", "]}", 1);
-        std::fs::write(&log_path, tampered).unwrap();
+
+        // Positive control: the UNtampered log must load clean. This proves the
+        // assertion below can only trip on the tamper, not on a load-path bug.
+        assert!(
+            !RepStore::load(dir.path(), &c).refuses_promotion(),
+            "untampered log must load clean"
+        );
+
+        // Length-preserving tamper: flip one byte of the 32-element `chain`
+        // array in place. The line still deserializes into [u8;32], so load
+        // reaches the hash-chain compare — where the flipped byte != the
+        // recomputed hash byte ⇒ poisoned.
+        let mut line: serde_json::Value =
+            serde_json::from_str(text.lines().next().unwrap()).unwrap();
+        let first = line["chain"][0].as_u64().unwrap();
+        line["chain"][0] = serde_json::json!((first ^ 0xFF) & 0xFF);
+        std::fs::write(&log_path, serde_json::to_string(&line).unwrap() + "\n").unwrap();
+
         let store = RepStore::load(dir.path(), &c);
-        assert!(store.refuses_promotion(), "tampered chain ⇒ fail-closed");
+        assert!(
+            store.refuses_promotion(),
+            "tampered chain ⇒ fail-closed via hash-chain compare"
+        );
     }
 
     // A clean append-only log round-trips through load and preserves rep.

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -49,6 +49,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::config::SwarmTrustConfig;
+use crate::provenance;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -385,6 +386,12 @@ struct Snapshot {
     vouch_edges: Vec<(PubKey, PubKey)>,
     /// `(mem_hash, epoch, corroborators)`.
     promotions: Vec<(MemHash, u64, Vec<(PubKey, Option<PubKey>)>)>,
+    /// #10: per-pubkey `(epoch, accrued)` anti-burst cap state, so a compact
+    /// that truncates the log doesn't reopen a fresh full α mid-epoch. `default`
+    /// so a pre-#10 snapshot (no field) still deserializes (empty ⇒ rebuilt from
+    /// the replayed log where possible).
+    #[serde(default)]
+    epoch_accrual: Vec<(PubKey, u64, f32)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -556,7 +563,11 @@ impl RepStore {
                     .filter_map(|(_, root, _)| *root)
                     .collect();
                 roots.insert(origin_pk); // the origin seed is its own lineage
-                if roots.len() as u32 >= k_high {
+                // #9: floor K_high at 2 (mirrors the non-seed branch's
+                // `k_high.max(2)`) so a LONE seed — a single lineage < 2 — can
+                // never self-promote a high-impact write at n=1 (`k_for(1)`
+                // yields raw K_high=0, which would otherwise admit `1 >= 0`).
+                if roots.len() as u32 >= k_high.max(2) {
                     return Promotion::Live { accrue: 0.0 };
                 }
                 return Promotion::Quarantine;
@@ -745,10 +756,13 @@ impl RepStore {
     pub fn load(data_dir: &Path, cfg: &SwarmTrustConfig) -> RepStore {
         let mut store = RepStore::new_at(cfg, data_dir.to_path_buf());
 
-        // 1. Optional compact snapshot.
+        // 1. Optional compact snapshot. #4: the snapshot MUST carry a valid
+        // signature by THIS node's own key. An unsigned, foreign, or tampered
+        // snapshot is fail-closed (poisoned) rather than unioned — it must never
+        // bypass the log's hash chain to inject seeds/reps/promotions.
         let snap_path = data_dir.join("reputation.snapshot.gz");
         if snap_path.exists() {
-            match read_snapshot(&snap_path) {
+            match read_verified_snapshot(data_dir) {
                 Some(snap) => store.apply_snapshot(snap),
                 None => return RepStore::poisoned_store(cfg, Some(data_dir.to_path_buf())),
             }
@@ -783,6 +797,11 @@ impl RepStore {
                 }
                 head = expect;
                 store.apply_op(&ll.op, cfg);
+                // #10: rebuild the per-epoch accrual cap from each promotion so
+                // a mid-epoch restart can't re-grant a fresh full α.
+                if let LogOp::Promotion { origin, epoch, accrue, .. } = &ll.op {
+                    store.reconstruct_epoch_accrual(*origin, *epoch, *accrue);
+                }
             }
             store.log_head = head;
         }
@@ -805,6 +824,23 @@ impl RepStore {
         for rec in snap.reps {
             self.reps.insert(rec.pubkey, rec);
         }
+        // #10: restore the per-epoch accrual cap captured at compact time.
+        for (pk, epoch, accrued) in snap.epoch_accrual {
+            self.epoch_accrual.insert(pk, (epoch, accrued));
+        }
+    }
+
+    /// Rebuild the transient per-epoch accrual cap from a replayed `Promotion`
+    /// op (finding #10). The log stores the ALREADY-capped `accrue` delta and
+    /// its epoch; replaying in append order leaves each pk's entry at its most
+    /// recent epoch's running total, so a mid-epoch restart cannot re-grant a
+    /// fresh full α (the anti-burst cap survives the restart).
+    fn reconstruct_epoch_accrual(&mut self, pk: PubKey, epoch: u64, accrue: f32) {
+        let entry = self.epoch_accrual.entry(pk).or_insert((epoch, 0.0));
+        if entry.0 != epoch {
+            *entry = (epoch, 0.0);
+        }
+        entry.1 += accrue;
     }
 
     fn snapshot(&self) -> Snapshot {
@@ -822,6 +858,13 @@ impl RepStore {
             reps: self.reps.values().cloned().collect(),
             vouch_edges,
             promotions,
+            // #10: persist the per-epoch accrual cap so a compact (which
+            // truncates the log) still preserves the anti-burst state.
+            epoch_accrual: self
+                .epoch_accrual
+                .iter()
+                .map(|(pk, (e, a))| (*pk, *e, *a))
+                .collect(),
         }
     }
 
@@ -842,7 +885,17 @@ impl RepStore {
         enc.write_all(&bytes)
             .map_err(|e| format!("reputation: gzip: {e}"))?;
         let gz = enc.finish().map_err(|e| format!("reputation: gzip finish: {e}"))?;
+        // #4: sign the snapshot with THIS node's ed25519 key and store the
+        // signature + signer pubkey in a sidecar, so a planted/foreign or
+        // tampered snapshot fails verification on load (fail-closed).
+        let seed = provenance::node_signing_key(&dir)?;
+        let signer = provenance::verifying_key_bytes(&seed);
+        let sig = provenance::sign_snapshot(&seed, &gz);
+        let mut sidecar = Vec::with_capacity(96);
+        sidecar.extend_from_slice(&signer); // signer pubkey[32] (diagnostic)
+        sidecar.extend_from_slice(&sig); // ed25519 sig[64] over the gz bytes
         atomic_write(&dir.join("reputation.snapshot.gz"), &gz)?;
+        atomic_write(&dir.join("reputation.snapshot.sig"), &sidecar)?;
         // Truncate the log — the snapshot captures state up to log_head; new
         // appends chain forward from the same head.
         atomic_write(&dir.join("reputation.log"), b"")?;
@@ -896,9 +949,25 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-/// Read + gunzip + bincode-decode a snapshot; `None` on any error (fail-closed).
-fn read_snapshot(path: &Path) -> Option<Snapshot> {
-    let gz = std::fs::read(path).ok()?;
+/// Verify (finding #4) + read + gunzip + bincode-decode a snapshot. `None` on
+/// ANY failure (fail-closed): missing/short signature sidecar, no node key on
+/// disk, a signature that does not verify against THIS node's own key, or a
+/// decode error. The `.sig` sidecar is `signer_pubkey[32] ‖ sig[64]`; the
+/// signature is checked over the on-disk gz bytes using the node's OWN
+/// verifying key, so a foreign/planted snapshot (signed by a different key) or
+/// a tampered one is refused.
+fn read_verified_snapshot(data_dir: &Path) -> Option<Snapshot> {
+    let gz = std::fs::read(data_dir.join("reputation.snapshot.gz")).ok()?;
+    let sidecar = std::fs::read(data_dir.join("reputation.snapshot.sig")).ok()?;
+    if sidecar.len() != 96 {
+        return None; // unsigned / malformed sidecar ⇒ fail-closed
+    }
+    let mut sig = [0u8; 64];
+    sig.copy_from_slice(&sidecar[32..96]);
+    let vk = provenance::node_verifying_key(data_dir)?; // no key ⇒ can't verify
+    if !provenance::verify_snapshot(&vk, &gz, &sig) {
+        return None; // foreign/tampered ⇒ fail-closed
+    }
     let mut dec = flate2::read::GzDecoder::new(&gz[..]);
     let mut bytes = Vec::new();
     std::io::Read::read_to_end(&mut dec, &mut bytes).ok()?;
@@ -1229,6 +1298,108 @@ mod tests {
         assert!(!reloaded.refuses_promotion());
         assert!(reloaded.rep(&origin) > 0.0, "rep survived compact+reload");
         assert!(reloaded.dag().is_promoted(&hash(1)));
+    }
+
+    // (#9) a LONE seed cannot self-promote a HIGH-IMPACT write at n=1: with one
+    // live seed, K_high floors at 2 and one seed is a single lineage (1 < 2) ⇒
+    // Quarantine. Guards the seed-branch `k_high.max(2)`.
+    #[test]
+    fn lone_seed_high_impact_quarantines() {
+        let c = cfg();
+        let mut store = RepStore::in_memory(&c);
+        let s = pk(1);
+        store.seeds.insert(s);
+        assert_eq!(store.live_seed_count(), 1);
+        assert_eq!(k_for(1), (2, 1)); // raw K_high=1 — the bug would admit `1 >= 1`
+        // Lone seed, high-impact, no other lineages ⇒ Quarantine (1 < max(1,2)).
+        let d = store.decide(hash(1), s, &[], 1, 1, /* high_impact = */ true, false, &c);
+        assert_eq!(d, Promotion::Quarantine, "lone seed high-impact at n=1 ⇒ Quarantine");
+        // Sanity: a NORMAL lone-seed write is still Live (inc-0 behaviour intact).
+        let d_norm = store.decide(hash(2), s, &[], 1, 1, false, false, &c);
+        assert_eq!(d_norm, Promotion::Live { accrue: 0.0 }, "normal lone-seed write ⇒ Live");
+    }
+
+    // (#10) the per-epoch accrual cap survives a restart: a mid-epoch crash must
+    // NOT re-grant a fresh full α. Promote (accrue), reload from the log, promote
+    // again in the SAME epoch — total accrual stays capped at α.
+    #[test]
+    fn epoch_cap_survives_reload() {
+        let c = cfg();
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg2 = c.clone();
+        // 3 seed-disjoint lineages so a promotion accrues real rep (D=3).
+        cfg2.seed_pubkeys = vec![
+            b64_encode_test(&pk(1)),
+            b64_encode_test(&pk(2)),
+            b64_encode_test(&pk(3)),
+        ];
+        let origin = pk(100);
+        let epoch = 7u64;
+        let corrs = || vec![(pk(1), Some(pk(1))), (pk(2), Some(pk(2))), (pk(3), Some(pk(3)))];
+        {
+            let mut store = RepStore::load(dir.path(), &cfg2);
+            store.record_promotion(hash(1), origin, epoch, corrs(), &cfg2);
+            assert!(store.rep(&origin) > 0.0, "first promotion accrues");
+        }
+        // Mid-epoch restart: the log replay must rebuild the epoch cap.
+        let mut reloaded = RepStore::load(dir.path(), &cfg2);
+        assert!(!reloaded.refuses_promotion());
+        // Second promotion, SAME epoch, different content.
+        reloaded.record_promotion(hash(2), origin, epoch, corrs(), &cfg2);
+        assert!(
+            reloaded.rep(&origin) <= cfg2.accrual_alpha + 1e-4,
+            "epoch cap survived reload — no fresh α (rep={})",
+            reloaded.rep(&origin)
+        );
+    }
+
+    // (#4) a node-signed snapshot loads clean; a tampered or unsigned snapshot
+    // fails the signature check ⇒ fail-closed (poisoned), never unioned.
+    #[test]
+    fn snapshot_signature_gates_load() {
+        let c = cfg();
+        let mut cfg2 = c.clone();
+        cfg2.seed_pubkeys = vec![b64_encode_test(&pk(9))];
+        let origin = pk(100);
+
+        let make_snapshot = |dir: &Path| {
+            let mut store = RepStore::load(dir, &cfg2);
+            store.record_promotion(hash(1), origin, 1, vec![(pk(9), Some(pk(9)))], &cfg2);
+            store.compact().unwrap();
+        };
+
+        // (i) clean: compact writes a node-signed snapshot; reload verifies + loads.
+        {
+            let dir = tempfile::tempdir().unwrap();
+            make_snapshot(dir.path());
+            assert!(dir.path().join("reputation.snapshot.gz").exists());
+            assert!(dir.path().join("reputation.snapshot.sig").exists(), "snapshot is signed");
+            let reloaded = RepStore::load(dir.path(), &cfg2);
+            assert!(!reloaded.refuses_promotion(), "node-signed snapshot loads clean");
+            assert!(reloaded.rep(&origin) > 0.0, "state survived signed compact+reload");
+        }
+
+        // (ii) tampered snapshot bytes ⇒ signature fails ⇒ poisoned.
+        {
+            let dir = tempfile::tempdir().unwrap();
+            make_snapshot(dir.path());
+            let gz_path = dir.path().join("reputation.snapshot.gz");
+            let mut gz = std::fs::read(&gz_path).unwrap();
+            let mid = gz.len() / 2;
+            gz[mid] ^= 0xFF;
+            std::fs::write(&gz_path, &gz).unwrap();
+            let reloaded = RepStore::load(dir.path(), &cfg2);
+            assert!(reloaded.refuses_promotion(), "tampered snapshot ⇒ fail-closed");
+        }
+
+        // (iii) unsigned snapshot (sig sidecar removed) ⇒ poisoned.
+        {
+            let dir = tempfile::tempdir().unwrap();
+            make_snapshot(dir.path());
+            std::fs::remove_file(dir.path().join("reputation.snapshot.sig")).unwrap();
+            let reloaded = RepStore::load(dir.path(), &cfg2);
+            assert!(reloaded.refuses_promotion(), "unsigned snapshot ⇒ fail-closed");
+        }
     }
 
     // (h) seed_root DAG walk resolves a vouch chain to the seed; a cycle

--- a/tests/inc1_corroboration.rs
+++ b/tests/inc1_corroboration.rs
@@ -16,8 +16,8 @@ use std::collections::HashSet;
 use uuid::Uuid;
 
 use kannaka_memory::absorb_gate::{
-    admit, content_hash, epoch_now, AdmitDecision, QuarantineStaging, PROV_TIER, SIGN_AGENT_ID,
-    SUBJECT_MEMORY_NEW,
+    admit, commit_promotion, content_hash, epoch_now, AdmitDecision, QuarantineStaging, PROV_TIER,
+    SIGN_AGENT_ID, SUBJECT_MEMORY_NEW,
 };
 use kannaka_memory::beacon::Beacon;
 use kannaka_memory::config::KannakaConfig;
@@ -95,9 +95,14 @@ fn admit_one(
 ) -> AdmitDecision {
     let id = Uuid::new_v4();
     let sig = sign(signing, id, content, amp, now);
-    let (dec, _clean) = admit(
+    let (dec, _clean, pending) = admit(
         content, amp, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id, Some(&sig), staging, rep, c, now,
     );
+    // #8: admit now DEFERS the promotion commit to the medium-insert point.
+    // These library-level tests have no live medium, so a Live decision commits
+    // immediately (simulating a successful insert); non-Live ⇒ pending is None,
+    // and commit_promotion is a no-op.
+    commit_promotion(pending, rep, staging, c);
     dec
 }
 

--- a/tests/inc1_corroboration.rs
+++ b/tests/inc1_corroboration.rs
@@ -1,0 +1,391 @@
+//! inc-1 corroboration gate — end-to-end runtime tests (synthesis §3.5).
+//!
+//! These drive the REAL library surface — [`admit`] over a [`QuarantineStaging`]
+//! + [`RepStore`], with a pinned-seed set and ed25519-signed wire memories — and
+//! assert a concrete observable per scenario (a decision variant, a rep value, a
+//! store/staging count, a promotion record). No binary spawn: the library API is
+//! the same code path the wired swarm callers use, and driving it directly keeps
+//! the assertions deterministic (synthesis's "prefer admit/RepStore" guidance).
+//!
+//! Everything here runs with the gate ARMED (seeds pinned +
+//! `corroboration_gate_enabled`). The dormant/default path (no seeds ⇒ no
+//! behaviour change) is covered by the in-crate `absorb_gate` unit tests.
+
+use std::collections::HashSet;
+
+use uuid::Uuid;
+
+use kannaka_memory::absorb_gate::{
+    admit, content_hash, epoch_now, AdmitDecision, QuarantineStaging, PROV_TIER, SIGN_AGENT_ID,
+    SUBJECT_MEMORY_NEW,
+};
+use kannaka_memory::beacon::Beacon;
+use kannaka_memory::config::KannakaConfig;
+use kannaka_memory::provenance::{amp_to_q16, sign_mem, verifying_key_bytes, ProvenanceSig};
+use kannaka_memory::reputation::{distinct_lineage_count, k_for, Promotion, PubKey, RepStore};
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+const NON_SEED: [u8; 32] = [200u8; 32];
+
+/// Standard-alphabet base64 (matches the crate's provenance/reputation codec).
+fn b64(data: &[u8]) -> String {
+    const A: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = ((b0 as u32) << 16) | ((b1 as u32) << 8) | (b2 as u32);
+        out.push(A[((n >> 18) & 63) as usize] as char);
+        out.push(A[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 { A[((n >> 6) & 63) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 2 { A[(n & 63) as usize] as char } else { '=' });
+    }
+    out
+}
+
+/// The base64 pubkeys for a set of raw signing seeds — the operator seed roster.
+fn seed_pubkeys(signing: &[[u8; 32]]) -> Vec<String> {
+    signing.iter().map(|s| b64(&verifying_key_bytes(s))).collect()
+}
+
+/// The pubkey set (for beacon ingest) for a set of raw signing seeds.
+fn seed_set(signing: &[[u8; 32]]) -> HashSet<PubKey> {
+    signing.iter().map(|s| verifying_key_bytes(s)).collect()
+}
+
+/// A gate-armed config over the given seed roster.
+fn cfg(signing: &[[u8; 32]]) -> KannakaConfig {
+    let mut c = KannakaConfig::default();
+    c.swarm_trust.corroboration_gate_enabled = true;
+    c.swarm_trust.seed_pubkeys = seed_pubkeys(signing);
+    c.swarm_trust.epoch_length_ms = 60_000;
+    c
+}
+
+/// Sign `content` exactly as `admit` will verify it (fixed agent-id/tier/subject).
+fn sign(signing: &[u8; 32], mem_id: Uuid, content: &str, amp: f32, now: i64) -> ProvenanceSig {
+    let nonce = *Uuid::new_v4().as_bytes();
+    sign_mem(
+        signing,
+        SIGN_AGENT_ID,
+        mem_id,
+        &nonce,
+        now,
+        content,
+        SUBJECT_MEMORY_NEW,
+        amp_to_q16(amp),
+        PROV_TIER,
+    )
+}
+
+/// One `admit` call at amplitude `amp`, `now`.
+#[allow(clippy::too_many_arguments)]
+fn admit_one(
+    staging: &mut QuarantineStaging,
+    rep: &mut RepStore,
+    c: &KannakaConfig,
+    signing: &[u8; 32],
+    content: &str,
+    amp: f32,
+    now: i64,
+) -> AdmitDecision {
+    let id = Uuid::new_v4();
+    let sig = sign(signing, id, content, amp, now);
+    let (dec, _clean) = admit(
+        content, amp, 0.0, 0.1, false, SUBJECT_MEMORY_NEW, id, Some(&sig), staging, rep, c, now,
+    );
+    dec
+}
+
+/// Feed a fresh seed heartbeat so the anti-eclipse gate won't freeze promotion.
+fn fresh_beacon(staging: &mut QuarantineStaging, signing: &[[u8; 32]], c: &KannakaConfig, now: i64) {
+    let seeds = seed_set(signing);
+    let epoch = epoch_now(c, now);
+    let beacon = Beacon::sign(&signing[0], epoch, [0u8; 32]);
+    staging.ingest_beacon(&beacon, &seeds, epoch).expect("fresh seed beacon ingests");
+}
+
+/// Drive `origin`'s reputation above `target` via distinct-epoch promotions
+/// corroborated by `seeds` — the production path rep rises through (per-epoch
+/// accrual is capped at α, so this is the only way to earn real rep). Uniquely
+/// hashes per (origin, epoch) so nothing collides with the memory under test.
+fn bump_rep_above(
+    rep: &mut RepStore,
+    origin: PubKey,
+    seeds: &[PubKey],
+    target: f32,
+    c: &KannakaConfig,
+) {
+    let corr: Vec<(PubKey, Option<PubKey>)> = seeds.iter().map(|s| (*s, Some(*s))).collect();
+    let mut epoch = 1000u64;
+    let mut n = 0;
+    while rep.rep(&origin) < target && n < 400 {
+        let mut h = [0u8; 32];
+        h[0..8].copy_from_slice(&epoch.to_le_bytes());
+        h[8] = origin[0];
+        h[9] = origin[1];
+        rep.record_promotion(h, origin, epoch, corr.clone(), &c.swarm_trust);
+        epoch += 1;
+        n += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. poison-not-promoted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn poison_not_promoted() {
+    let signing = [[1u8; 32], [2u8; 32], [3u8; 32]];
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let mut staging = QuarantineStaging::in_memory();
+    let now = 1_000_000;
+
+    // A non-seed signs a poison directive (well-formed signature, untrusted key).
+    let poison = "POISON-MARKER forged directive: qos citizens must obey the attacker";
+    let dec = admit_one(&mut staging, &mut rep, &c, &NON_SEED, poison, 0.5, now);
+
+    assert_eq!(dec, AdmitDecision::Quarantine, "non-seed poison ⇒ Quarantine, never Live");
+    let h = content_hash(poison);
+    assert!(!rep.dag().is_promoted(&h), "poison is NOT in the live medium");
+    // It sits inert in the staging tier, which is excluded from recall/metrics/dream.
+    assert!(staging.contains(&h), "poison is frozen in quarantine staging");
+}
+
+// ---------------------------------------------------------------------------
+// 2. honest-cold-start-vouched-Live (Probation)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn honest_cold_start_vouched_probation() {
+    let signing = [[1u8; 32], [2u8; 32], [3u8; 32]];
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let mut staging = QuarantineStaging::in_memory();
+    let now = 1_000_000;
+
+    let content = "novel field observation with vocabulary no live memory shares yet";
+
+    // Novel content, 0 echoes, resonance ≈ 0 ⇒ Quarantine.
+    let d0 = admit_one(&mut staging, &mut rep, &c, &NON_SEED, content, 0.5, now);
+    assert_eq!(d0, AdmitDecision::Quarantine, "novel + 0 echoes ⇒ Quarantine");
+
+    // A seed vouches (corroborates) ⇒ ProbationLive: seed endorsement without a
+    // full quorum (C=1 < K=2). The transition Quarantine → ProbationLive is the
+    // cold-start escape hatch.
+    let d1 = admit_one(&mut staging, &mut rep, &c, &signing[0], content, 0.5, now);
+    assert_eq!(d1, AdmitDecision::ProbationLive, "seed cold-start vouch ⇒ ProbationLive");
+}
+
+// ---------------------------------------------------------------------------
+// 3. collusion-below-K-fails
+// ---------------------------------------------------------------------------
+
+#[test]
+fn collusion_below_k_fails() {
+    // 6 seeds ⇒ K = 3, K_high = 4.
+    let signing: Vec<[u8; 32]> = (1u8..=6).map(|i| [i; 32]).collect();
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let seeds: Vec<PubKey> = signing.iter().map(|s| verifying_key_bytes(s)).collect();
+    assert_eq!(k_for(6), (3, 4));
+
+    // Two Sybil handles a, b, BOTH vouched by ONE seed ⇒ a single lineage.
+    let a = [50u8; 32];
+    let b = [51u8; 32];
+    rep.record_vouch(seeds[0], a);
+    rep.record_vouch(seeds[0], b);
+    bump_rep_above(&mut rep, a, &seeds[0..3], 0.65, &c);
+    bump_rep_above(&mut rep, b, &seeds[0..3], 0.65, &c);
+    assert!(rep.rep(&a) >= c.swarm_trust.trust_threshold);
+    assert!(rep.rep(&b) >= c.swarm_trust.trust_threshold);
+
+    let origin = [100u8; 32];
+
+    // Collusion: 2 pubkeys sharing one seed_root ⇒ C(M) saturates at 1 < K=3.
+    let corr_collude = vec![(a, rep.seed_root_of(&a)), (b, rep.seed_root_of(&b))];
+    let d_collude = rep.decide([9u8; 32], origin, &corr_collude, 1, 6, false, false, &c.swarm_trust);
+    assert_eq!(d_collude, Promotion::Quarantine, "one lineage (C=1) < K=3 ⇒ Quarantine");
+    assert_eq!(
+        distinct_lineage_count(
+            corr_collude.iter().map(|(pk, r)| (*pk, *r, rep.rep(pk))),
+            &c.swarm_trust
+        ),
+        1,
+        "two same-seed_root handles are ONE distinct lineage",
+    );
+
+    // Contrast: 3 seed-disjoint lineages ⇒ C=3 ≥ K=3 ⇒ Live.
+    let corr_disjoint: Vec<(PubKey, Option<PubKey>)> =
+        seeds[0..3].iter().map(|s| (*s, Some(*s))).collect();
+    let d_disjoint =
+        rep.decide([10u8; 32], origin, &corr_disjoint, 1, 6, false, false, &c.swarm_trust);
+    assert!(
+        matches!(d_disjoint, Promotion::Live { .. }),
+        "three seed-disjoint lineages (C=3) ≥ K=3 ⇒ Live, got {d_disjoint:?}",
+    );
+    assert_eq!(
+        distinct_lineage_count(
+            corr_disjoint.iter().map(|(pk, r)| (*pk, *r, rep.rep(pk))),
+            &c.swarm_trust
+        ),
+        3,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. echo-farm-earns-nothing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn echo_farm_earns_nothing() {
+    let signing = [[1u8; 32], [2u8; 32], [3u8; 32]];
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let mut staging = QuarantineStaging::in_memory();
+    let now = 1_000_000;
+    fresh_beacon(&mut staging, &signing, &c, now);
+
+    // Author + 2 seeds ⇒ Live (K=2 for a 3-seed roster).
+    let content = "a corroborated fact that an echo farm will try to re-mint for rep";
+    assert_eq!(
+        admit_one(&mut staging, &mut rep, &c, &NON_SEED, content, 0.5, now),
+        AdmitDecision::Quarantine
+    );
+    assert_eq!(
+        admit_one(&mut staging, &mut rep, &c, &signing[0], content, 0.5, now),
+        AdmitDecision::ProbationLive
+    );
+    assert_eq!(
+        admit_one(&mut staging, &mut rep, &c, &signing[1], content, 0.5, now),
+        AdmitDecision::Live
+    );
+
+    let h = content_hash(content);
+    let origin = verifying_key_bytes(&NON_SEED);
+    let rep_before = rep.rep(&origin);
+
+    // Echo farm: re-sign the already-Live content under 30 FRESH pubkeys.
+    for i in 0..30u8 {
+        let farmer = [100u8.wrapping_add(i); 32]; // distinct fresh non-seed keys
+        let dec = admit_one(&mut staging, &mut rep, &c, &farmer, content, 0.5, now);
+        assert_eq!(dec, AdmitDecision::Drop, "echo of already-Live content ⇒ Drop (no new memory)");
+        assert_eq!(rep.rep(&verifying_key_bytes(&farmer)), 0.0, "the echoer earns nothing");
+    }
+
+    assert_eq!(rep.rep(&origin), rep_before, "echo farm accrues nothing to the origin");
+    assert!(!staging.contains(&h), "already-Live content is never re-staged by echoes");
+}
+
+// ---------------------------------------------------------------------------
+// 5. whitewash-costs-rep (append-only ledger survives restart)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn whitewash_costs_rep() {
+    let signing: Vec<[u8; 32]> = (1u8..=3).map(|i| [i; 32]).collect();
+    let c = cfg(&signing);
+    let seeds: Vec<PubKey> = signing.iter().map(|s| verifying_key_bytes(s)).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let origin = [100u8; 32];
+
+    // Earn rep, then an operator hard-reject (poison) docks it.
+    let rep_after_poison;
+    {
+        let mut rep = RepStore::load(dir.path(), &c.swarm_trust);
+        bump_rep_above(&mut rep, origin, &seeds[0..3], 0.55, &c);
+        let before = rep.rep(&origin);
+        assert!(before >= 0.5, "origin earned real rep, got {before}");
+
+        rep.record_poison(origin, &c.swarm_trust);
+        let after = rep.rep(&origin);
+        assert!(after < before, "hard-reject drops the origin's rep: {before} -> {after}");
+        rep_after_poison = after;
+    }
+
+    // Survives a simulated restart (append-only, hash-chained ledger).
+    let reloaded = RepStore::load(dir.path(), &c.swarm_trust);
+    assert!(!reloaded.refuses_promotion(), "clean append-only log reloads (not fail-closed)");
+    assert!(
+        (reloaded.rep(&origin) - rep_after_poison).abs() < 1e-6,
+        "docked rep persists across restart — no restart-whitewash",
+    );
+    assert_eq!(
+        reloaded.record(&origin).map(|r| r.poison),
+        Some(1),
+        "the poison event is on the ledger after reload",
+    );
+
+    // A fresh whitewash pubkey starts at rep 0 ⇒ Quarantine-only (cannot self-promote).
+    let fresh = [222u8; 32];
+    assert_eq!(reloaded.rep(&fresh), 0.0, "a brand-new key is rep 0");
+    let d = reloaded.decide([7u8; 32], fresh, &[], 1, 3, false, false, &c.swarm_trust);
+    assert_eq!(d, Promotion::Quarantine, "rep-0 fresh key is Quarantine-only");
+}
+
+// ---------------------------------------------------------------------------
+// 6. seed-alone-cannot-satisfy-K_high
+// ---------------------------------------------------------------------------
+
+#[test]
+fn seed_alone_cannot_satisfy_k_high() {
+    // 6 seeds ⇒ K_high = 4.
+    let signing: Vec<[u8; 32]> = (1u8..=6).map(|i| [i; 32]).collect();
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let mut staging = QuarantineStaging::in_memory();
+    let now = 1_000_000;
+    // Fresh beacon present, so the freeze below is purely the K_high shortfall.
+    fresh_beacon(&mut staging, &signing, &c, now);
+    assert_eq!(k_for(6).1, 4);
+
+    // A lone seed authors a HIGH-IMPACT write (amp ≥ HIGH_IMPACT_AMPLITUDE).
+    let content = "a lone seed's irreversible high-impact directive with no second lineage";
+    let dec = admit_one(&mut staging, &mut rep, &c, &signing[0], content, 0.95, now);
+    assert_eq!(dec, AdmitDecision::Quarantine, "one seed (C=1) < K_high=4 ⇒ stays Quarantine");
+    let h = content_hash(content);
+    assert!(!rep.dag().is_promoted(&h), "lone-seed high-impact write is not promoted");
+}
+
+// ---------------------------------------------------------------------------
+// 7. beacon-eclipse-freezes-promotion (bonus)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn beacon_eclipse_freezes_promotion() {
+    let signing = [[1u8; 32], [2u8; 32], [3u8; 32]];
+    let c = cfg(&signing);
+    let mut rep = RepStore::in_memory(&c.swarm_trust);
+    let mut staging = QuarantineStaging::in_memory(); // NO beacon ⇒ eclipsed
+    let now = 1_000_000;
+
+    let content = "a fact that WOULD promote, but this node is eclipsed / partitioned";
+
+    // author → Quarantine; seed0 → ProbationLive; seed1 → would be Live (C=2 ≥ K=2)…
+    assert_eq!(
+        admit_one(&mut staging, &mut rep, &c, &NON_SEED, content, 0.5, now),
+        AdmitDecision::Quarantine
+    );
+    assert_eq!(
+        admit_one(&mut staging, &mut rep, &c, &signing[0], content, 0.5, now),
+        AdmitDecision::ProbationLive
+    );
+    let frozen = admit_one(&mut staging, &mut rep, &c, &signing[1], content, 0.5, now);
+
+    // …but with stale/absent beacons the promotion FREEZES to Quarantine (not Drop).
+    assert_eq!(frozen, AdmitDecision::Quarantine, "eclipse freezes an otherwise-Live promotion");
+    let h = content_hash(content);
+    assert!(!rep.dag().is_promoted(&h), "frozen: not promoted to live");
+    assert!(staging.contains(&h), "frozen content is preserved in staging (never dropped)");
+
+    // Beacons resume ⇒ the SAME content promotes on the next corroboration.
+    fresh_beacon(&mut staging, &signing, &c, now);
+    let thawed = admit_one(&mut staging, &mut rep, &c, &signing[2], content, 0.5, now);
+    assert_eq!(thawed, AdmitDecision::Live, "a fresh seed beacon thaws promotion");
+    assert!(rep.dag().is_promoted(&h), "promoted once beacons resumed");
+}


### PR DESCRIPTION
Builds on the deployed Increment 0 read-side gate (#507). Where inc-0 stopped the *live* metric poisoning from the anonymous AIID injection, this is the durable **absorb-side** trust model. Publish stays **OPEN**; every defense is on what a node chooses to internalize.

> **Identity says *who*. Corroboration proves *what*.** A signature is only a stable handle + integrity proof — it grants no trust. A memory earns **Live** status by *corroborated behavior*: distinct trusted nodes, tracing to seed-disjoint roots, independently recording the same content. A Sybil's many masks all trace to one root and count as one vote.

## Ships DORMANT
Everything here is inert until an operator runs a **seed key ceremony** (`kannaka identity keygen` + `enroll-seed`) and flips `corroboration_gate_enabled`. With no seeds, `admit()` early-returns the inc-0 behavior **plus** an unconditional field-sanitization bugfix — so merging changes nothing at runtime. Safe to land now; activation is a deliberate, separate step.

## The model
- **Provenance substrate** (ed25519): domain-separated, length-prefixed canonical bytes; replay-protected; node key at rest.
- **Reputation** keyed on verified pubkey (never a wire string): `decide()` re-resolves lineage + rep from the store (a peer can't inflate `C(M)` by claiming lineage); echo-of-Live earns 0; per-epoch accrual cap; **no vote time-decay**.
- **Promotion**: `C(M) ≥ K` over **distinct seed-root lineages** (K=clamp(⌈seeds/2⌉,2,4)); quarantine-by-default; **refutation dropped** (operator M-of-N hard-reject is the only poison lever); rep-staked **seed vouch** is the cold-start escape.
- **Beacons**: signed seed heartbeats; stale/absent ⇒ promotion **freezes closed** (anti-eclipse). Fail-closed from birth.
- **The two pre-existing bugs the reviews found are fixed**: the two ungated absorb paths, and the wire-settable `hallucinated`/amplitude fields.

## Commits
`ce26b9b` provenance · `5634589` reputation core · `0d4c71b` admit() chokepoint · `3f7c662` identity/reputation CLI · `79f8186` beacons + 7 e2e tests · `e43e820` release-gate fixes.

## Review rigor
- **Two pre-build adversarial design reviews** caught load-bearing flaws before code: the planned Lamport identity anchor had *no pinned root* (forgeable); "resonance = corroboration" was *backwards* (the encoder skips high-resonance duplicates and lands novel truth orthogonal → cold-start death). Both cut.
- **Post-build adversarial diff review** (29 agents, refute-each-finding verify): 22 confirmed findings. The 3 merge-blockers (one fail-open + two test-integrity gaps) are fixed in `e43e820`. ~60 tests pass (provenance/reputation/absorb_gate/beacon/CLI + 7 e2e); full suite green.

## Pre-activation checklist (gates the seed ceremony, NOT this merge)
All fail-closed and unreachable in the dormant default; must land before flipping the gate on:
- [ ] **#5 wire beacons through NATS** (critical — an armed gate can't promote until beacons are ingested from the swarm; today `ingest_beacon` is test/CLI-only)
- [ ] **#4 sign the reputation snapshot** with the node key (unsigned snapshot could inject seeds/reps)
- [ ] **#8** promote only after the live-medium insert returns Ok (ledger/medium divergence)
- [ ] **#9** seed high-impact branch: add the `k_high.max(2)` floor
- [ ] **#10** persist/rebuild the per-epoch accrual cap across restart
- [ ] **#11** widen replay-`ts` math to i128 on the disk path · **#12** re-apply staging cap/TTL on load
- [ ] **#6/#7/#14** add admit-level invalid-sig, exemplar round-trip, and replay tests

## Later (separate)
Observatory needs its own read-side gate (Node service, computes Φ from raw wire); QuantumOS gets one pinned key per instance (Increment 2) so `qos-*` can corroborate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
