### PR TITLE
test(revelation): kill ~1.8% flake in the revelation PoW test (deterministic salt)

### DIFF
--- a/src/collective/privacy.rs
+++ b/src/collective/privacy.rs
@@ -463,7 +463,18 @@ pub fn seal_with_commitments(
     difficulty: u32,
     agent_id: &str,
 ) -> SealResult {
-    let glyph = seal(memory, difficulty, agent_id);
+    seal_with_commitments_salt(memory, difficulty, agent_id, random_bytes_32())
+}
+
+/// Like [`seal_with_commitments`] but with a caller-supplied salt (test seam;
+/// see [`seal_with_salt`]).
+pub(crate) fn seal_with_commitments_salt(
+    memory: &HyperMemory,
+    difficulty: u32,
+    agent_id: &str,
+    salt: [u8; 32],
+) -> SealResult {
+    let glyph = seal_with_salt(memory, difficulty, agent_id, salt);
 
     // Generate Pedersen commitments for wave properties
     let vec_hash = hash_vector(&memory.vector);
@@ -493,9 +504,20 @@ pub fn seal(
     difficulty: u32,
     agent_id: &str,
 ) -> PrivacyGlyph {
-    // Generate salt
-    let salt = random_bytes_32();
+    seal_with_salt(memory, difficulty, agent_id, random_bytes_32())
+}
 
+/// Like [`seal`] but with a caller-supplied salt. Production always seals with
+/// a fresh random salt (via [`seal`]); this seam exists so tests can pin the
+/// salt and get a fully deterministic glyph_hash (and therefore a deterministic
+/// hashcash reveal search in [`create_hint`]) — see the flake note in the
+/// revelation tests. Not a public API.
+pub(crate) fn seal_with_salt(
+    memory: &HyperMemory,
+    difficulty: u32,
+    agent_id: &str,
+    salt: [u8; 32],
+) -> PrivacyGlyph {
     // Serialize the memory payload
     let payload = serialize_payload(memory);
 

--- a/src/collective/revelation.rs
+++ b/src/collective/revelation.rs
@@ -312,7 +312,7 @@ pub fn group_effective_difficulty(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collective::privacy::seal_with_commitments;
+    use crate::collective::privacy::seal_with_commitments_salt;
     use crate::memory::HyperMemory;
     use chrono::Duration;
 
@@ -322,8 +322,23 @@ mod tests {
 
     fn setup_store_with_glyph(difficulty: u32) -> (GlyphStore, String) {
         let mut store = GlyphStore::new();
-        let mem = test_memory("classified data");
-        let result = seal_with_commitments(&mem, difficulty, "alice");
+        let mut mem = test_memory("classified data");
+        // Pin the memory identity + timestamp and seal with a FIXED salt so the
+        // whole glyph (its glyph_hash is sha256 of salt/id/timestamp-derived
+        // ciphertext) is deterministic. Why this matters: the reveal path
+        // `create_hint` searches only `4 * 2^new_difficulty` nonces (1024 at
+        // difficulty 8) for a hash with >= new_difficulty leading zero bits.
+        // Over a RANDOM salt it finds none — and returns None — with probability
+        // (1 - 2^-8)^1024 ≈ e^-4 ≈ 1.8%, a real ~1.8%-per-run flake in
+        // `test_execute_revelation_publishes_hint`. Pinning the inputs removes
+        // the randomness at the source; the fixed values below are verified to
+        // yield a solvable difficulty-8 reveal. Do NOT "fix" a future flake by
+        // widening create_hint's production search bound — that would weaken the
+        // real proof-of-work; keep the determinism here in the test instead.
+        mem.id = uuid::Uuid::from_u128(0x5EED_0000_0000_0000_0000_0000_0000_0001);
+        mem.created_at =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let result = seal_with_commitments_salt(&mem, difficulty, "alice", [0x5a; 32]);
         let hash = result.glyph.glyph_hash.clone();
         store.insert(result);
         (store, hash)


### PR DESCRIPTION
## Summary

`collective::revelation::tests::test_execute_revelation_publishes_hint` is a genuine ~1.8%-per-run flake (it failed once on PR #515's CI, unrelated to that change).

**Root cause.** `create_hint` (`src/collective/privacy.rs`) does a bounded proof-of-work search: `4 * 2^new_difficulty` nonces (1024 at difficulty 8) for a hash with `>= new_difficulty` leading zero bits. `setup_store_with_glyph` sealed the test glyph with a **random** salt, so the derived `glyph_hash` was random per run and `create_hint` found no solution — returning `None` — with probability `(1 - 2^-8)^1024 ≈ e^-4 ≈ 1.8%`. The test then trips `assert!(hint.is_some())`.

**Fix — at the source, not the bound.** Pin the test memory's `id` + `created_at` and seal with a **fixed salt**, so the glyph (and its reveal search) is fully deterministic and verified solvable at difficulty 8. A comment records the 1.8% math and warns against "fixing" a future flake by widening `create_hint`'s production search bound — that would weaken the real PoW; keep the determinism in the test.

Adds a `pub(crate)` salt seam (`seal_with_salt`, `seal_with_commitments_salt`); the public `seal` / `seal_with_commitments` are unchanged — they still pass `random_bytes_32()`, so **production behaviour is identical**.

## Verification
- Revelation suite: **5/5 green** across repeated runs (was probabilistic).
- Privacy suite: green — the `seal` refactor is a pure behavior-preserving delegation.
- Clippy (`--lib --bin kannaka -D warnings`): **zero new findings** over master.

Follow-up to the #515 CI investigation; requested by the team lead as a standalone fix so it stayed out of the NATS-liveness PR.