### PR TITLE
feat(entropy): T1.5 flip — default source prng→reservoir (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.10.9] — 2026-07-08
+
+### Changed — entropy source defaults to `reservoir` (Quantum-Wave T1.5 flip, #475)
+
+The default `[entropy].source` flips from `prng` to `reservoir` after 5 clean
+days of the T1.5 reservoir dogfood. What this does and does NOT change:
+
+- **Source only.** The independent T1.4 consumption gate
+  (`[entropy].dream_perturbation` / `KANNAKA_DREAM_ENTROPY`) stays **default
+  false**, so no deployment starts drawing from the reservoir — or grows a
+  `kannaka-quantum` CLI dependency — from this flip alone. Selecting the source
+  is inert until consumption is explicitly opted in.
+- **Fails loud, never silent PRNG.** When a deployment does turn consumption on,
+  a reservoir draw fails loudly on an empty or missing CLI
+  (`CliUnavailable`/`ReservoirEmpty`) rather than silently falling back to the
+  PRNG — every stamped provenance chain stays TRUE.
+- **Opt back out** any time with `[entropy].source = "prng"` (or
+  `KANNAKA_ENTROPY_SOURCE=prng`).
+
+### Fixed — deterministic revelation proof-of-work test (#517)
+
+`test_execute_revelation_publishes_hint` was a ~1.8%-per-run flake (bounded PoW
+search over a random salt); the test glyph is now sealed with a fixed salt so
+the reveal search is deterministic. Production `seal` behaviour is unchanged.
+
 ## [0.10.8] — 2026-07-08
 
 ### Added — guided seed-ceremony helpers for the corroboration gate

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,10 +176,16 @@ pub struct CouplingConfig {
 /// Quantum-Wave T1.3 (#473): which entropy source seeds dreams / Ξ. env
 /// `KANNAKA_ENTROPY_SOURCE` OVERRIDES this; `apply_entropy_env_from_config`
 /// bridges config→env at startup only when the env var is unset. **Default
-/// `prng`** — the reservoir source is opt-in until T1.5 dogfood passes.
+/// `reservoir`** as of the T1.5 flip (#475) — Nick approved it on 5 clean
+/// dogfood days. Flipping the SOURCE alone changes nothing observable: the
+/// separate `dream_perturbation` consumption gate stays **default false**, so
+/// no dream draws from the reservoir (and no `kannaka-quantum` CLI dependency
+/// is introduced) until a deployment explicitly opts in. When it IS on, the
+/// reservoir fails LOUDLY on an empty/missing CLI — never a silent PRNG
+/// fallback. Set `source = "prng"` to opt back out.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntropyConfig {
-    /// `"prng"` (default) or `"reservoir"`.
+    /// `"reservoir"` (default, T1.5) or `"prng"`.
     #[serde(default = "default_entropy_source")]
     pub source: String,
     /// T1.4: whether dreams/Ξ actually CONSUME entropy from `source` (and record
@@ -196,7 +202,10 @@ impl Default for EntropyConfig {
 }
 
 fn default_entropy_source() -> String {
-    "prng".to_string()
+    // T1.5 flip (#475): reservoir is now the default source. The
+    // dream_perturbation gate (default false) still governs whether anything
+    // is actually drawn, so this default is inert until a deployment opts in.
+    "reservoir".to_string()
 }
 
 /// SECURITY (increment-0): read-side trust gate for the OPEN NATS swarm.
@@ -3994,6 +4003,41 @@ mod config_field_tests {
         let cfg = KannakaConfig::default();
         assert!(!cfg.belief.enabled, "belief must default OFF (byte-identical field)");
         assert_eq!(cfg.belief.max_n, 6000);
+    }
+
+    // Quantum-Wave T1.5 flip (#475): the entropy SOURCE default is now
+    // `reservoir` (was `prng`). The CONSUMPTION gate is independent and stays
+    // OFF, so the flip draws nothing / adds no CLI dependency on its own.
+    #[test]
+    fn entropy_source_defaults_to_reservoir() {
+        let cfg = KannakaConfig::default();
+        assert_eq!(
+            cfg.entropy.source, "reservoir",
+            "T1.5 flip: entropy source defaults to reservoir"
+        );
+        assert_eq!(EntropyConfig::default().source, "reservoir");
+    }
+
+    #[test]
+    fn dream_perturbation_still_defaults_false() {
+        // The T1.5 flip touches only the SOURCE. The consumption gate must stay
+        // default-OFF so no deployment starts drawing (or grows a kannaka-quantum
+        // dependency) from the flip alone.
+        let cfg = KannakaConfig::default();
+        assert!(
+            !cfg.entropy.dream_perturbation,
+            "dream_perturbation must remain default false after the T1.5 flip"
+        );
+    }
+
+    #[test]
+    fn entropy_source_prng_opt_out_roundtrips() {
+        // A deployment can still pin the PRNG explicitly.
+        let mut cfg = KannakaConfig::default();
+        cfg.entropy.source = "prng".to_string();
+        let toml = toml::to_string(&cfg).expect("serialize config");
+        let back: KannakaConfig = toml::from_str(&toml).expect("deserialize config");
+        assert_eq!(back.entropy.source, "prng");
     }
 
     #[test]

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -272,9 +272,18 @@ fn bits_to_bytes(bitstr: &str, n_bits: usize) -> Vec<u8> {
 // Selection / factory
 // ---------------------------------------------------------------------------
 
-/// Which entropy source the engine uses. **Default `Prng`** — zero behavior
-/// change and no Python/CLI dependency until a deployment opts in (after T1.5
-/// dogfood).
+/// Which entropy source the engine uses. **Default `Reservoir`** as of the T1.5
+/// flip (#475): a fresh config's `[entropy].source` is `reservoir` and
+/// `apply_entropy_env_from_config` bridges it into `KANNAKA_ENTROPY_SOURCE`
+/// before any dream runs, so the engine selects [`ReservoirSource`]. This is
+/// inert on its own — the independent `dream_perturbation` gate
+/// ([`dream_entropy_enabled`], default OFF) governs whether a dream actually
+/// DRAWS, so the flip introduces no Python/CLI dependency and no behavior change
+/// until a deployment opts consumption in; when it does, a draw fails LOUDLY on
+/// an empty/missing reservoir rather than silently falling back to the PRNG.
+/// [`from_env`](EntropySelection::from_env) still falls back to `Prng` only in a
+/// bare context where NEITHER config nor env set a source (library/tests) — a
+/// zero-dependency safety net, not the deployment default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntropySelection {
     Prng,
@@ -283,8 +292,12 @@ pub enum EntropySelection {
 
 impl EntropySelection {
     /// Resolve from `KANNAKA_ENTROPY_SOURCE` (config bridges into this env, env
-    /// wins — mirrors the belief/cluster/coupling config bridges). Anything other
-    /// than an explicit reservoir selection is `Prng`.
+    /// wins — mirrors the belief/cluster/coupling config bridges). An explicit
+    /// `prng`/`software` opts back out to the PRNG; anything else (including the
+    /// bridged-in `reservoir` default) selects `Reservoir`. The bare fallback
+    /// when the var is UNSET is `Prng` — see the note on [`EntropySelection`]:
+    /// real deployments never hit it because the config bridge sets the var
+    /// (`reservoir` by default) at startup.
     pub fn from_env() -> Self {
         match std::env::var("KANNAKA_ENTROPY_SOURCE")
             .unwrap_or_default()
@@ -332,7 +345,11 @@ pub fn seed_from_bytes(bytes: &[u8]) -> u64 {
     seed
 }
 
-/// The configured entropy source. Defaults to [`PrngSource`].
+/// The configured entropy source. In a real deployment this is
+/// [`ReservoirSource`] (the T1.5 default, bridged config→env before startup);
+/// in a bare no-config/no-env context it falls back to [`PrngSource`]. Only
+/// invoked from the `dream_perturbation`-gated dream path, so with the gate off
+/// (default) it is never built.
 pub fn default_source() -> Box<dyn EntropySource> {
     EntropySelection::from_env().build()
 }
@@ -439,10 +456,12 @@ mod tests {
     }
 
     #[test]
-    fn selection_defaults_to_prng() {
-        // Unset / unknown → Prng (the from_env default). We don't mutate the
-        // process env here (parallel-test safety); just assert the mapping via a
-        // direct match on the documented tokens.
+    fn selection_builds_expected_sources() {
+        // Each variant builds the source it names. We don't mutate the process
+        // env here (parallel-test safety); the DEPLOYMENT default (reservoir,
+        // T1.5 #475) is asserted on the config in config.rs. from_env's bare
+        // fallback (no config, no env) remains Prng — a zero-dependency safety
+        // net, not the deployment default.
         assert_eq!(EntropySelection::Prng.build().kind(), "prng");
         assert_eq!(EntropySelection::Reservoir.build().kind(), "reservoir");
     }


### PR DESCRIPTION
## Summary

Executes the **T1.5 flip** — Nick approved it on 5 clean dogfood days. `default_entropy_source()` returns `reservoir` instead of `prng`; a fresh config's `[entropy].source` bridges into `KANNAKA_ENTROPY_SOURCE` (`apply_entropy_env_from_config`, runs at startup before any dream), so the engine selects `ReservoirSource`. Closes the `#475` acceptance item "engine default flipped to ReservoirSource".

## Semantics preserved (important)

- **Source only — inert until opt-in.** The T1.4 consumption gate `[entropy].dream_perturbation` (`KANNAKA_DREAM_ENTROPY`) stays **default false**. `default_source()` is invoked *only* inside the `dream_entropy_enabled()`-gated dream path (`hrm_store.rs`), and the QUBO solver seeds from `PrngSource` explicitly — so **no deployment starts drawing, and no `kannaka-quantum` CLI dependency appears, from this flip alone.** `ReservoirSource::new()` does no I/O.
- **Fails loud, never silent PRNG.** When consumption *is* opted in, a reservoir draw errors on an empty/missing CLI (`CliUnavailable`/`ReservoirEmpty`) — it never silently claims `prng://`.
- **Opt back out** with `[entropy].source = "prng"` (or `KANNAKA_ENTROPY_SOURCE=prng`).
- **`from_env()` bare fallback stays `Prng`** — only when *neither* config nor env sets a source (library/tests). A real deployment never hits it because the config bridge always sets the var (`reservoir` by default) first. I kept the resolver logic and documented both layers rather than changing the bare fallback; happy to also flip it if you'd prefer the resolver itself default to reservoir.

## Tests
- `entropy_source_defaults_to_reservoir` — asserts the new default.
- `dream_perturbation_still_defaults_false` — the consumption gate is untouched.
- `entropy_source_prng_opt_out_roundtrips` — the PRNG opt-out still round-trips.
- Stale "defaults to prng" selection-test comment + `EntropySelection`/`default_source` docs updated.

CHANGELOG: `[0.10.9]` entry (also notes the #517 flake fix that merged post-v0.10.8). Zero new clippy findings; config + entropy suites green.

Fleet note: does NOT require redeploying the 3 armed swarm nodes — their dream gates are off, so the flip changes nothing for them.