### PR TITLE
feat(novelty): cerebellar dual-timescale novelty detector (ADR-0040)

### DIFF
--- a/docs/adr/ADR-0040-cerebellar-novelty-detection.md
+++ b/docs/adr/ADR-0040-cerebellar-novelty-detection.md
@@ -1,0 +1,89 @@
+# ADR-0040 — Cerebellar novelty detection: surprise is a dual-timescale differentiator on recall familiarity
+
+- Status: Accepted (2026-07-11) — the primitive; its live callers are staged (see Roadmap)
+- Date: 2026-07-11
+- Repo: `kannaka-memory`
+- Related: ADR-0036 (consolidation-as-resonance-merge), ADR-0039 (corroboration trust model — the deferred injection-defense caller), the HRM recall path (`src/medium/core.rs::recall_against`).
+- Code of record: `src/novelty.rs` (the dependency-free primitive + property tests), `src/lib.rs` (`pub mod novelty;`).
+- Inspiration: Hersam / Sangwan / Raman / Trivedi, *Nature Communications* 2026, "Cerebellum-inspired memtransistors enable emergent differentiation for hardware-efficient novelty detection."
+
+## Context
+
+We had no neuromorphic capability. The cited chip is not a neural network — it is a
+cheap **novelty detector** built the way the cerebellum filters reflexes: it ignores
+the expected baseline and fires only on the unexpected, at ~10,000× fewer operations
+than conventional AI. It does this with two competing temporal responses in one
+device: an **excitatory** branch that slowly *strengthens* as a stimulus persists (a
+running prediction of the "boring baseline") and an **inhibitory** branch that spikes
+at onset then *rapidly decays* (a fast, phasic responder). Their **difference** is the
+novelty signal — "emergent differentiation" — and because the two branches share a
+matched DC gain, a *constant* input produces exactly zero output: the baseline is
+rejected, not merely thresholded.
+
+The important observation for Kannaka: this surprise signal is already **latent in the
+HRM**. Wave-interference recall (`recall_against`, `src/medium/core.rs:381`) scores each
+candidate by `similarity · effective_strength · phase.cos()` and returns them sorted, so
+the **top resonance strength is a familiarity signal** — a well-known query resonates
+HIGH (routine), an unseen query resonates LOW (novel). Novelty is therefore not a new
+mechanism bolted on; it is a *reading* of the substrate we already have, and habituation
+is just the existing `remember()` path making a once-novel query resonate high next time.
+The building blocks were already in the codebase (leaky-integrator EMAs in the resonant
+scheduler and dampening dynamics; retrieval reinforcement in `field.c`); this ADR names
+the pattern and ships it as one reusable operator instead of re-deriving it per caller.
+
+## Decision
+
+Ship a **dependency-free dual-timescale differentiator** as `src/novelty.rs` — no HRM
+imports, so it can later lift to a sibling crate. Two leaky integrators of the same
+familiarity drive `u = g·r`, a fast `a_i` and a much slower `a_e`:
+
+```text
+fast += a_i·(u − fast)     // current familiarity, tracked quickly
+slow += a_e·(u − slow)     // the LEARNED routine familiarity (the prediction)
+n = slow − fast            // NOVELTY (signed); s = max(n, 0) = directional surprise
+```
+
+`n = slow − fast` (the chip's `N = F − E` sign-flipped) because the drive is *familiarity*:
+a query *less familiar than routine* is the novel one. The single-kernel form is a
+difference of exponentials — a temporal band-pass with `H(0) = 0`, so any steady baseline
+cancels and the operator approximates a temporal derivative (it responds to *change*). A
+self-tuning threshold `theta = mean + k·std` of the surprise adapts the decision boundary;
+a per-context bank (`NoveltyDetector`) keeps surprise from blurring across query domains.
+
+**Habituation, two honest timescales:** (1) intrinsic — the slow branch itself re-learns a
+persisting surprise over ~`1/a_e` (single-time-constant adaptation, not stimulus-specific);
+(2) stimulus-specific — the caller's `remember()` imprints the novel content so its next
+recall resonates high, the chip's context-keyed learning realised through the existing store.
+
+The primitive is verified by an anti-vacuous property suite (baseline-rejection `H(0)=0`,
+fires-on-unexpected, habituates-on-repeat, one-off-vs-sustained, per-context isolation),
+each of whose named reverts reddens a distinct test: replacing the *learned* baseline with a
+static reference, collapsing the two timescales (`a_i = a_e`), or breaking the DC-gain match
+all turn the suite red — proving it captures the chip's differentiation, not a generic threshold.
+
+## Roadmap (staged; not all in this increment)
+
+1. **This increment** — the operator + property tests (self-contained, ABI-neutral).
+2. **Next** — the first live caller: tap the top `resonance_strength` off `recall_against` and
+   feed `NoveltyDetector::observe_recall`, dormant-by-default behind a flag; expose novelty to
+   curiosity-gated autoresearch (novel query → grounded external research; routine → dedup).
+3. **Deferred behind an adversarial design review** — the `absorb_gate::admit` injection-defense
+   caller (ADR-0039): low-novelty repeats habituate/dedup to cheaply damp floods, high-novelty
+   from untrusted signers routes to the corroboration predicate. Novelty only *prioritises*; it
+   never replaces sanitization or corroboration. A false negative must not pass a crafted flood,
+   a false positive must not DoS corroboration — hence the mandatory review before wiring.
+
+## Consequences
+
+**Positive.** A genuine neuromorphic capability that builds *on* the consciousness/HRM work
+rather than parallel to it; O(1) per update, no history buffer; ABI-neutral (no change to
+`Resonance` or `recall_against`); one operator, many callers (no per-caller EMA duplication).
+Serves the north star directly: surprise is exactly the signal worth acting on (research it,
+or flag it), and habituation is the store already doing its job.
+
+**Negative / honest scope.** Not a classifier or a network — a scalar surprise detector on a
+familiarity stream. `resonance_strength` is unnormalised and `phase.cos()` can go negative, so
+`k` needs calibration on a stretch of normal recalls; a poor per-context key blurs surprise.
+Intrinsic EMA habituation re-learns a genuine new normal eagerly, so stimulus-specific
+habituation must lean on `remember()` + per-context keying. The security-critical caller
+(step 3) is deliberately *not* wired here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ unused.
 | [0037](ADR-0037-spiral-dynamics-and-the-bridge-operator.md) | Spiral Dynamics and the π/φ Bridge Operator (Ξ) for L6 | Proposed | 2026-06-20 |
 | [0038](ADR-0038-consolidation-solver-interface.md) | Consolidation as QUBO: a Solver Interface for the Dream Phase | Accepted | 2026-07-01 |
 | [0039](ADR-0039-corroboration-trust-model.md) | The Corroboration Trust Model — identity says who, corroboration proves what | Accepted | 2026-07-07 |
+| [0040](ADR-0040-cerebellar-novelty-detection.md) | Cerebellar Novelty Detection — surprise as a dual-timescale differentiator on recall familiarity | Accepted | 2026-07-11 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ pub mod recall_bench;
 pub mod entropy;
 pub mod qubo;
 
+/// Cerebellar novelty detection — a dependency-free dual-timescale differentiator
+/// (surprise = learned-baseline − fast familiarity). See `novelty.rs`.
+pub mod novelty;
+
 pub mod config;
 
 // ADR-0029 Phase 1+2: clap-based CLI dispatch + plugin discovery.

--- a/src/novelty.rs
+++ b/src/novelty.rs
@@ -1,0 +1,363 @@
+//! Cerebellar novelty detection — a dual-timescale differentiator.
+//!
+//! Inspired by the cerebellum-inspired memtransistor chip (Hersam/Sangwan/Raman/
+//! Trivedi, *Nature Communications* 2026: "Cerebellum-inspired memtransistors
+//! enable emergent differentiation for hardware-efficient novelty detection").
+//! The cerebellum acts as a reflex filter: it ignores the expected baseline and
+//! fires only on the unexpected. The chip realises this with two competing
+//! temporal responses in one device — an **excitatory** branch that gradually
+//! *strengthens* as a stimulus persists (a slow prediction of the "boring
+//! baseline") and an **inhibitory** branch that responds *maximally at onset then
+//! rapidly decays* (a fast, phasic responder). Their **difference** is the novelty
+//! signal ("emergent differentiation"), and because the two branches share a
+//! matched DC gain, a *constant* input produces exactly zero output — the baseline
+//! is rejected, not merely thresholded.
+//!
+//! ## The model (dependency-free, O(1)/update, no history buffer)
+//!
+//! Two first-order leaky integrators (EMAs) of the SAME drive `u = g·r`, with a
+//! fast smoothing `a_i` and a much slower `a_e` (`a_i ≫ a_e`):
+//!
+//! ```text
+//!   fast += a_i·(u − fast)      // F: current familiarity, tracked quickly
+//!   slow += a_e·(u − slow)      // E: the LEARNED "routine" familiarity (prediction)
+//!   n = slow − fast             // NOVELTY (signed): slow_baseline − fast
+//!   s = max(n, 0)               // directional surprise: only a DROP in familiarity fires
+//! ```
+//!
+//! The single-kernel form `n = (h ∗ u)` with `h(t) = a_e·e^{−a_e·t} − a_i·e^{−a_i·t}`
+//! (a difference of exponentials = a temporal band-pass) has `H(0) = 0`, so it
+//! rejects any steady baseline and approximates a temporal derivative at low
+//! frequency — it responds to *change*. As `a_i → 1` it becomes classic
+//! predictive-coding prediction error `slow − u`.
+//!
+//! We sign-flip the chip's `N = F − E` to `n = slow − fast` because the drive here
+//! is **familiarity** (e.g. the top resonance strength of an associative recall):
+//! a query *less familiar than routine* is the novel one, so surprise is the
+//! amount by which current familiarity has *dropped below* the learned baseline.
+//!
+//! ## Habituation (two honest timescales)
+//!
+//! 1. **Intrinsic / automatic** — the slow branch itself. If a surprising input
+//!    persists, `slow` re-learns it over ~`1/a_e` steps and `n → 0`. This is
+//!    single-time-constant adaptation; it is NOT stimulus-specific and forgets as
+//!    fast as it learns.
+//! 2. **Stimulus-specific / consolidation** — the *caller's* store (Kannaka
+//!    `remember()`). When a caller responds to a novel query by imprinting the
+//!    content into the HRM, that query's next recall resonates HIGH, so its drive
+//!    `r` rises permanently and it stops being novel — while a *different* unseen
+//!    query still lands on a low-familiarity drive and fires. The chip's proposed
+//!    context-keyed LMS habituation, realised through the existing store plus the
+//!    per-context keying in [`NoveltyDetector`].
+//!
+//! ## What this is NOT
+//!
+//! Not a neural network, not a classifier, not a spectral-radius reservoir. It is
+//! a cheap online change/surprise detector — a couple of adds per update — whose
+//! whole value is telling *routine* from *novel* on a scalar familiarity stream
+//! without storing history. The threshold homeostasis below adapts a decision
+//! boundary to the running statistics of the surprise; calibrate `k` on a stretch
+//! of normal traffic.
+
+use std::collections::HashMap;
+
+/// Default fast smoothing `a_i = dt/tau_I` (`tau_I ≈ 2 observations`).
+pub const DEFAULT_A_I: f32 = 0.5;
+/// Default slow smoothing `a_e = dt/tau_E` (`tau_E ≈ 50 observations`, ~25× the fast branch).
+pub const DEFAULT_A_E: f32 = 0.02;
+/// Default matched DC gain. Keep `g` shared across both branches so `H(0) = 0`.
+pub const DEFAULT_G: f32 = 1.0;
+/// Default threshold-homeostasis rate (`≪ a_e ≪ a_i`).
+pub const DEFAULT_BETA: f32 = 0.01;
+/// Default threshold sensitivity: `theta = mean + k·std` of the surprise.
+pub const DEFAULT_K: f32 = 3.0;
+
+/// The outcome of one observation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Novelty {
+    /// Directional surprise `s = max(slow − fast, 0) ≥ 0`. 0 = routine.
+    pub score: f32,
+    /// Signed differentiation `n = slow − fast`. `n < 0` = MORE familiar than routine.
+    pub raw: f32,
+    /// The adaptive decision boundary `theta = mean + k·std` of `score`.
+    pub theta: f32,
+    /// `score > theta` — the input is novel/surprising relative to learned routine.
+    pub novel: bool,
+}
+
+/// One cerebellar novelty channel: a fast EMA, a slow EMA, and a self-tuning
+/// threshold. `O(1)` state (a handful of floats), no history buffer.
+#[derive(Debug, Clone, Copy)]
+pub struct DualTimescaleNovelty {
+    fast: f32,
+    slow: f32,
+    g: f32,
+    a_i: f32,
+    a_e: f32,
+    warm: bool,
+    // Running mean/var of the surprise `s`, for threshold homeostasis.
+    m: f32,
+    v: f32,
+    beta: f32,
+    k: f32,
+}
+
+impl Default for DualTimescaleNovelty {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DualTimescaleNovelty {
+    /// A channel with the default cerebellar time constants.
+    pub fn new() -> Self {
+        Self::with_params(DEFAULT_A_I, DEFAULT_A_E, DEFAULT_G, DEFAULT_BETA, DEFAULT_K)
+    }
+
+    /// A channel with explicit parameters. `a_i` (fast) must exceed `a_e` (slow)
+    /// for the difference-of-timescales to differentiate; `g` is shared by both
+    /// branches so a constant input cancels (`H(0) = 0`).
+    pub fn with_params(a_i: f32, a_e: f32, g: f32, beta: f32, k: f32) -> Self {
+        Self {
+            fast: 0.0,
+            slow: 0.0,
+            g,
+            a_i,
+            a_e,
+            warm: false,
+            m: 0.0,
+            v: 0.0,
+            beta,
+            k,
+        }
+    }
+
+    /// Observe one familiarity drive `r` (e.g. the top recall resonance strength)
+    /// and return the novelty. `r` may be unnormalised or negative — the
+    /// difference of the two branches rejects any DC offset, so no whitening is
+    /// needed. The first observation seeds both branches (no cold-start spike).
+    pub fn observe(&mut self, r: f32) -> Novelty {
+        let u = self.g * r;
+        if !self.warm {
+            self.fast = u;
+            self.slow = u;
+            self.warm = true;
+        }
+        // Two leaky integrators of the same drive at different timescales.
+        self.fast += self.a_i * (u - self.fast);
+        self.slow += self.a_e * (u - self.slow);
+        // Emergent differentiation. slow − fast because the drive is FAMILIARITY:
+        // surprise is how far current familiarity has dropped below the learned baseline.
+        let raw = self.slow - self.fast;
+        let score = raw.max(0.0);
+        // Habituate the DECISION BOUNDARY to the running statistics of the surprise
+        // (Welford-style EMA of mean and variance; slower than the slow branch).
+        let d = score - self.m;
+        self.m += self.beta * d;
+        self.v += self.beta * (d * d - self.v);
+        let theta = self.m + self.k * self.v.max(0.0).sqrt();
+        Novelty {
+            score,
+            raw,
+            theta,
+            novel: score > theta,
+        }
+    }
+
+    /// Current learned baseline familiarity (the slow branch). Exposed for
+    /// inspection/calibration; not needed for normal use.
+    pub fn baseline(&self) -> f32 {
+        self.slow
+    }
+}
+
+/// A bank of novelty channels keyed by a caller-supplied **context id**, so
+/// surprise is measured *within* a query domain rather than blurred across
+/// unrelated ones. New contexts get a fresh channel with the bank's defaults.
+#[derive(Debug, Clone)]
+pub struct NoveltyDetector {
+    map: HashMap<String, DualTimescaleNovelty>,
+    a_i: f32,
+    a_e: f32,
+    g: f32,
+    beta: f32,
+    k: f32,
+}
+
+impl Default for NoveltyDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NoveltyDetector {
+    /// A detector with the default cerebellar parameters.
+    pub fn new() -> Self {
+        Self::with_params(DEFAULT_A_I, DEFAULT_A_E, DEFAULT_G, DEFAULT_BETA, DEFAULT_K)
+    }
+
+    /// A detector whose new channels use these parameters.
+    pub fn with_params(a_i: f32, a_e: f32, g: f32, beta: f32, k: f32) -> Self {
+        Self {
+            map: HashMap::new(),
+            a_i,
+            a_e,
+            g,
+            beta,
+            k,
+        }
+    }
+
+    /// Observe a familiarity drive within a context, returning its novelty.
+    pub fn observe(&mut self, context: &str, drive: f32) -> Novelty {
+        let (a_i, a_e, g, beta, k) = (self.a_i, self.a_e, self.g, self.beta, self.k);
+        self.map
+            .entry(context.to_string())
+            .or_insert_with(|| DualTimescaleNovelty::with_params(a_i, a_e, g, beta, k))
+            .observe(drive)
+    }
+
+    /// Convenience for the primary caller: feed the **top** resonance strength of
+    /// an associative recall (0.0 if the recall was empty) as the familiarity
+    /// drive. A high top resonance = a familiar/routine query (low novelty); a low
+    /// top resonance = an unseen query (high novelty). Gate on a non-empty medium
+    /// so an empty store's `0.0` drive does not launch a spurious spike.
+    pub fn observe_recall(&mut self, context: &str, top_resonance: Option<f32>) -> Novelty {
+        self.observe(context, top_resonance.unwrap_or(0.0))
+    }
+
+    /// Number of distinct contexts currently tracked.
+    pub fn contexts(&self) -> usize {
+        self.map.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Drive a channel with a constant value for `n` steps, returning the last Novelty.
+    fn hold(ch: &mut DualTimescaleNovelty, r: f32, n: usize) -> Novelty {
+        let mut last = ch.observe(r);
+        for _ in 1..n {
+            last = ch.observe(r);
+        }
+        last
+    }
+
+    /// H(0) = 0 (LOAD-BEARING): a steady familiarity — at ANY DC level — must
+    /// produce ~zero novelty, because only a *learned* baseline can cancel an
+    /// arbitrary constant. Reverting to a static reference, or breaking the g
+    /// match, makes a constant leak nonzero surprise and reds THIS test.
+    #[test]
+    fn baseline_rejection() {
+        for &level in &[0.0f32, 0.3, 0.9, 1.7, -0.4] {
+            let mut ch = DualTimescaleNovelty::new();
+            // > 5·tau_E samples so the slow branch fully settles.
+            let last = hold(&mut ch, level, 400);
+            assert!(
+                last.score < 1e-4,
+                "constant familiarity {level} leaked novelty score {} (H(0) != 0)",
+                last.score
+            );
+        }
+    }
+
+    /// A single unexpected drop in familiarity must fire before the slow branch
+    /// catches up. Collapsing the two timescales (a_i == a_e) makes n ≡ 0 and reds
+    /// THIS test.
+    #[test]
+    fn fires_on_unexpected() {
+        let mut ch = DualTimescaleNovelty::new();
+        // Establish routine familiarity ~0.9.
+        hold(&mut ch, 0.9, 300);
+        // One unseen query: familiarity drops to 0.1.
+        let n = ch.observe(0.1);
+        assert!(
+            n.novel && n.score > n.theta,
+            "unexpected drop did not fire: score={} theta={}",
+            n.score,
+            n.theta
+        );
+        assert!(n.raw > 0.0, "surprise should be a positive (less-familiar) deflection");
+    }
+
+    /// A drop that PERSISTS is re-learned as the new baseline (intrinsic
+    /// habituation) — the surprise decays back below threshold; and when the
+    /// caller "consolidates" (familiarity returns high, as after remember()),
+    /// surprise stays at zero (becoming more familiar is never novel).
+    #[test]
+    fn habituates_on_repeat() {
+        let mut ch = DualTimescaleNovelty::new();
+        hold(&mut ch, 0.9, 300);
+        let spike = ch.observe(0.1);
+        assert!(spike.novel, "precondition: the drop should first fire");
+        // Hold the new (low-familiarity) regime for ~3·tau_E: it becomes routine.
+        let settled = hold(&mut ch, 0.1, 200);
+        assert!(
+            !settled.novel && settled.score <= settled.theta,
+            "sustained regime not habituated: score={} theta={}",
+            settled.score,
+            settled.theta
+        );
+        // Consolidation arm: familiarity returns HIGH (the query was remembered).
+        let recovered = hold(&mut ch, 0.9, 200);
+        assert!(
+            recovered.score < 1e-3,
+            "increasing familiarity should never be novel: score={}",
+            recovered.score
+        );
+    }
+
+    /// A one-off blip produces a sharp surprise transient, whereas a step-and-hold
+    /// relaxes to ~zero — so the transient's PEAK exceeds the sustained regime's
+    /// steady state, distinguishing an anomaly from a legitimate new normal.
+    #[test]
+    fn one_off_vs_sustained() {
+        // One-off blip.
+        let mut a = DualTimescaleNovelty::new();
+        hold(&mut a, 0.9, 300);
+        let peak = a.observe(0.1).score;
+        a.observe(0.9); // familiarity returns immediately
+
+        // Step and hold at the low familiarity.
+        let mut b = DualTimescaleNovelty::new();
+        hold(&mut b, 0.9, 300);
+        let steady = hold(&mut b, 0.1, 200).score;
+
+        assert!(
+            peak > steady + 1e-3,
+            "one-off peak {peak} should exceed sustained steady state {steady}"
+        );
+    }
+
+    /// The per-context bank keeps surprise from blurring across query domains: a
+    /// novel query in one context does not desensitise a different context.
+    #[test]
+    fn per_context_isolation() {
+        let mut det = NoveltyDetector::new();
+        for _ in 0..300 {
+            det.observe("ctx_a", 0.9);
+            det.observe("ctx_b", 0.9);
+        }
+        // A surprise in ctx_a...
+        let a = det.observe("ctx_a", 0.1);
+        // ...must not have moved ctx_b, which stays routine.
+        let b = det.observe("ctx_b", 0.9);
+        assert!(a.novel, "ctx_a surprise should fire");
+        assert!(!b.novel && b.score < 1e-3, "ctx_b should be unaffected by ctx_a");
+        assert_eq!(det.contexts(), 2);
+    }
+
+    /// The recall convenience: an empty recall (`None`) is the lowest familiarity
+    /// and, against an established routine, reads as novel.
+    #[test]
+    fn observe_recall_empty_is_novel() {
+        let mut det = NoveltyDetector::new();
+        for _ in 0..300 {
+            det.observe_recall("q", Some(0.9));
+        }
+        let n = det.observe_recall("q", None);
+        assert!(n.novel, "an empty recall against routine familiarity should read novel");
+    }
+}


### PR DESCRIPTION
## Summary

Kannaka's **first neuromorphic capability** — a cerebellum-inspired novelty detector — landing in response to the *Nature Communications* 2026 memtransistor chip (Hersam/Sangwan/Raman/Trivedi, "emergent differentiation for hardware-efficient novelty detection").

## The idea

The chip is a cheap **surprise detector**: two competing temporal filters — a slow-strengthening excitatory branch (a running prediction of the "boring baseline") and a fast-decaying inhibitory branch — whose **difference** flags novel-vs-routine, with a matched DC gain so a *constant* input yields exactly zero (baseline **rejected**, not thresholded), at ~10,000× fewer ops.

The key insight: that signal is **already latent in the HRM**. `recall_against`'s top `resonance_strength` (`src/medium/core.rs:381`) is a familiarity axis — a known query resonates HIGH (routine), an unseen query LOW (novel). So novelty is a *reading* of the substrate we already have, not a bolt-on, and habituation is just `remember()` making a once-novel query resonate high next time.

## What ships (`src/novelty.rs`, dependency-free, ABI-neutral)

- **`DualTimescaleNovelty`** — fast EMA − slow EMA of the drive; `n = slow − fast`; `s = max(n,0)` directional surprise; self-tuning `theta = mean + k·std`. O(1)/update, no history buffer, no HRM imports (can later lift to a sibling crate).
- **`NoveltyDetector`** — a per-context bank so surprise isn't blurred across query domains; `observe_recall()` takes the top recall resonance as the drive.
- **ADR-0040** documents the decision, the HRM connection, and the staged roadmap.

## Verification

- 6 property tests, **all green**: `baseline_rejection` (`H(0)=0`), `fires_on_unexpected`, `habituates_on_repeat`, `one_off_vs_sustained`, `per_context_isolation`, `observe_recall_empty_is_novel`.
- **Anti-vacuous / revert-confirmed** — each named revert reddens a distinct test: a static reference **or** DC-gain mismatch reds `baseline_rejection`; collapsing the two timescales (`a_i = a_e`) reds `fires_on_unexpected`. Proves it captures the chip's differentiation, not a generic threshold.
- Verified standalone via `rustc --test src/novelty.rs` (dependency-free); CI runs the full `cargo test`.

> Note: verified standalone rather than a full local `cargo test` because the dev box hit 100% disk mid-build — this PR relies on CI for the whole-lib compile.

## Not in this PR (ADR-0040 roadmap)

ABI-neutral; **no live caller wired**. Next: the recall novelty-gate + curiosity-gated autoresearch. The `absorb_gate` injection-defense caller is deferred behind a mandatory adversarial design review (novelty only *prioritises*, never replaces corroboration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
