### PR TITLE
fix(#497): preserve a ghost's updated_at across rebuild_cache

### DIFF
--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -443,9 +443,20 @@ impl HrmStore {
         // tier promotion. rebuild_cache runs after every dream/absorb, so without
         // this snapshot the count would reset to 0 on each rebuild. Preserve it
         // across the clear, exactly like connections above.
+        //
+        // #497: ALSO preserve the updated_at of a GHOST — a memory with
+        // retrieval_count 0 but a real ADR-0037 ghosting stamp (updated_at !=
+        // created_at). rebuild reconstructs from the medium's WavefrontMeta (which
+        // has no updated_at) and defaults it to created_at; if we don't restore the
+        // stamp, the next deep dream's stage_compact_ghosts sees the ghost past the
+        // 7-day horizon and hard-deletes it with zero recovery window — re-opening
+        // the 295→88 over-prune loss the stamp exists to prevent.
         let saved_reactivation: std::collections::HashMap<uuid::Uuid, (u32, Option<DateTime<Utc>>)> =
             self.memory_cache.iter()
-                .filter(|(_, m)| m.retrieval_count > 0)
+                .filter(|(_, m)| {
+                    m.retrieval_count > 0
+                        || (m.updated_at.is_some() && m.updated_at != Some(m.created_at))
+                })
                 .map(|(id, m)| (*id, (m.retrieval_count, m.updated_at)))
                 .collect();
 
@@ -685,7 +696,13 @@ impl HrmStore {
                 .unwrap_or_default();
 
         for (id, m) in &self.memory_cache {
-            if m.retrieval_count == 0 {
+            // #497: persist a GHOST's updated_at too — a memory with retrieval_count
+            // 0 but a real ADR-0037 ghosting stamp (updated_at != created_at) — so
+            // the stamp survives a restart and stage_compact_ghosts doesn't
+            // hard-delete the ghost past the horizon. Skip only truly-untouched
+            // memories (no recalls AND no real update).
+            let real_update = m.updated_at.is_some() && m.updated_at != Some(m.created_at);
+            if m.retrieval_count == 0 && !real_update {
                 continue;
             }
             let entry = merged.entry(id.to_string()).or_insert((0, None));
@@ -2318,6 +2335,38 @@ mod tests {
         assert!(
             hits2.iter().all(|(id, _)| *id != idb),
             "an id absent from the live cache must not appear (dead ids must not eat the k-budget)"
+        );
+    }
+
+    // #497: rebuild_cache reconstructs memories from the medium (which has no
+    // updated_at), so a GHOST — retrieval_count 0 but a real ADR-0037 ghosting
+    // stamp — used to have its stamp reset to created_at and get hard-deleted past
+    // the 7-day horizon. rebuild must now PRESERVE the ghost's stamp.
+    #[test]
+    fn rebuild_preserves_ghost_updated_at() {
+        let temp = NamedTempFile::new().unwrap();
+        let mut store = HrmStore::new(make_test_pipeline(), temp.path().to_path_buf());
+        let id = store
+            .insert(HyperMemory::new(vec![0.3f32; WAVEFRONT_DIM], "ghost".into()))
+            .unwrap();
+
+        // Ghost it: a distinct recent stamp, and NO recalls — the exact shape that
+        // used to lose its stamp on rebuild.
+        let ghost_time = Utc::now() - chrono::Duration::days(1);
+        {
+            let m = store.get_mut(&id).unwrap().unwrap();
+            m.updated_at = Some(ghost_time);
+            assert_eq!(m.retrieval_count, 0, "precondition: a ghost has no recalls");
+            assert_ne!(m.updated_at, Some(m.created_at), "precondition: stamp != created_at");
+        }
+
+        store.rebuild_cache().unwrap();
+
+        let m = store.get(&id).unwrap().expect("memory survives rebuild");
+        assert_eq!(
+            m.updated_at,
+            Some(ghost_time),
+            "#497: rebuild must preserve a ghost's ADR-0037 stamp, not reset it to created_at"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the data-loss in **#497**. `rebuild_cache` reconstructs memories from the medium's `WavefrontMeta` (no `updated_at` → defaults to `created_at`), then restored the real `updated_at` **only for `retrieval_count > 0`** memories. A **ghost** — pruned by `stage_prune` with a real ADR-0037 `updated_at` stamp but zero recalls — fell through: its stamp snapped back to `created_at` on any absorb/dream rebuild or restart, and the next deep dream's `stage_compact_ghosts` saw it **past the 7-day horizon → hard-deleted with zero recovery window** (re-opening the 295→88 over-prune loss the stamp prevents).

## Fix (no sidecar format change)

Preserve `updated_at` for a genuinely-updated memory (`updated_at.is_some() && updated_at != created_at`), not just recalled ones, in **both** places that gated on `retrieval_count > 0`:
- the in-session `rebuild_cache` snapshot (every absorb/dream rebuild), and
- `save_reactivation_merge` (restart; `load_reactivation` already restores `updated_at` after `rebuild_cache` resets it).

The `.reactivation.json` tuple `(u32, Option<DateTime>)` is unchanged — no migration risk.

## Test

`rebuild_preserves_ghost_updated_at`: a `retrieval_count`-0 memory with a distinct stamp keeps it through `rebuild_cache`. **Anti-vacuous** — restoring the `retrieval_count > 0`-only filter reddens it. `hrm_store` module (26 tests, incl. `reactivation_persists_across_reload`) passes.

## Scope

Fixes the **`updated_at` data loss** (the hard-delete — #497's headline) for both in-session and restart. The secondary resets the issue notes — `layer_depth` (stage_transfer promotions) and `last_consolidated_at` (consolidate_incremental watermark) — are functional degradations, not data loss; persisting them across **restart** needs a sidecar-format migration (dual-format read to avoid wiping counts), left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
