### PR TITLE
feat(#107): kannaka-recompute-encoding — re-encode wavefronts after the #106 fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,10 @@ name = "kannaka-recompute-geometry"
 path = "src/bin/recompute_geometry.rs"
 
 [[bin]]
+name = "kannaka-recompute-encoding"
+path = "src/bin/recompute_encoding.rs"
+
+[[bin]]
 name = "dump_xi_pairs"
 path = "src/bin/dump_xi_pairs.rs"
 

--- a/src/bin/recompute_encoding.rs
+++ b/src/bin/recompute_encoding.rs
@@ -1,0 +1,56 @@
+//! One-shot tool: re-encode every wavefront's content through the current
+//! pipeline, fixing HRM files whose vectors were written by the broken #106
+//! encoder (#107). Chiral (v2) HRMs only.
+//!
+//! Usage: kannaka-recompute-encoding [data-dir] [--dry-run]
+//!
+//! SNAPSHOT the HRM first (the #107 rollout gate), run with --dry-run to see the
+//! count, then run for real and verify recall before adopting.
+
+use kannaka_memory::hrm_store::HrmStore;
+use kannaka_memory::openclaw::make_pipeline;
+use std::path::PathBuf;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+    let data_dir = args
+        .iter()
+        .skip(1)
+        .find(|a| !a.starts_with("--"))
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("KANNAKA_DATA_DIR").ok().map(PathBuf::from))
+        .unwrap_or_else(|| {
+            let home = std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+                .unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".kannaka")
+        });
+
+    let hrm_path = data_dir.join("kannaka.hrm");
+    eprintln!("HRM: {}", hrm_path.display());
+    if dry_run {
+        eprintln!("(dry run — no changes will be written)");
+    }
+
+    let pipeline = make_pipeline();
+    let mut store = HrmStore::load(pipeline, hrm_path).unwrap_or_else(|e| {
+        eprintln!("Failed to load HRM: {}", e);
+        std::process::exit(1);
+    });
+
+    match store.recompute_encoding(dry_run) {
+        Ok((scanned, updated)) => {
+            if dry_run {
+                eprintln!("[dry-run] would re-encode {updated} of {scanned} memories");
+            } else {
+                eprintln!("Re-encoded {updated} of {scanned} memories through the current pipeline");
+                eprintln!("Cluster sidecar invalidated; verify recall before rolling out further.");
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/bin/recompute_encoding.rs
+++ b/src/bin/recompute_encoding.rs
@@ -1,15 +1,36 @@
-//! One-shot tool: re-encode every wavefront's content through the current
+//! One-shot tool: re-encode every TEXT wavefront's content through the current
 //! pipeline, fixing HRM files whose vectors were written by the broken #106
 //! encoder (#107). Chiral (v2) HRMs only.
 //!
 //! Usage: kannaka-recompute-encoding [data-dir] [--dry-run]
 //!
-//! SNAPSHOT the HRM first (the #107 rollout gate), run with --dry-run to see the
-//! count, then run for real and verify recall before adopting.
+//! SCOPE / SAFETY:
+//!   - TEXT HRMs only. Dream-hallucinated wavefronts and non-text (audio/visual)
+//!     modalities are skipped automatically. But do NOT run this on a SUBSTRATE
+//!     HRM (ADR-0027): its raw one-hot anchors are Modality::Unknown, which is
+//!     indistinguishable from pre-ADR-0042 text memories, so they WOULD be
+//!     re-encoded and their orthogonal Kuramoto seed destroyed.
+//!   - Requires the real Ollama embedding model. If Ollama is unreachable, the
+//!     pipeline would silently fall back to the hash encoder and rewrite the whole
+//!     corpus with pseudo-embeddings — so a real run ABORTS unless Ollama answers.
+//!
+//! ROLLOUT: SNAPSHOT the HRM first, run --dry-run to see the count, then run for
+//! real and verify recall (#83 repro) before adopting / rolling to the next box.
 
 use kannaka_memory::hrm_store::HrmStore;
 use kannaka_memory::openclaw::make_pipeline;
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// The local Ollama endpoint `make_pipeline`'s OllamaEncoder::default_local uses.
+const OLLAMA_URL: &str = "http://localhost:11434";
+
+fn ollama_reachable() -> bool {
+    ureq::get(&format!("{OLLAMA_URL}/api/tags"))
+        .timeout(Duration::from_secs(3))
+        .call()
+        .is_ok()
+}
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -29,8 +50,24 @@ fn main() {
 
     let hrm_path = data_dir.join("kannaka.hrm");
     eprintln!("HRM: {}", hrm_path.display());
+    eprintln!(
+        "NOTE: TEXT HRMs only — hallucinations + non-text modalities are skipped; do NOT run on a \
+         substrate HRM (raw anchors would be corrupted)."
+    );
     if dry_run {
         eprintln!("(dry run — no changes will be written)");
+    }
+
+    // Refuse a real run when Ollama is down: otherwise make_pipeline's
+    // CompositeEncoder silently uses the hash fallback and we would overwrite every
+    // vector with pseudo-embeddings while reporting success. (A dry run only counts,
+    // so the probe is a real-run gate.)
+    if !dry_run && !ollama_reachable() {
+        eprintln!(
+            "ABORT: Ollama ({OLLAMA_URL}) is unreachable. Re-encoding needs the real embedding \
+             model — refusing to hash-rewrite the corpus. Start Ollama and retry (or --dry-run)."
+        );
+        std::process::exit(1);
     }
 
     let pipeline = make_pipeline();
@@ -42,7 +79,7 @@ fn main() {
     match store.recompute_encoding(dry_run) {
         Ok((scanned, updated)) => {
             if dry_run {
-                eprintln!("[dry-run] would re-encode {updated} of {scanned} memories");
+                eprintln!("[dry-run] would re-encode {updated} of {scanned} memories (text only)");
             } else {
                 eprintln!("Re-encoded {updated} of {scanned} memories through the current pipeline");
                 eprintln!("Cluster sidecar invalidated; verify recall before rolling out further.");

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -1693,6 +1693,41 @@ impl HrmStore {
         }
     }
 
+    /// Re-encode every memory's content through the current pipeline, fixing
+    /// wavefronts written by the broken #106 encoder (#107). Chiral-only for now
+    /// (production HRMs are v2 chiral). Returns `(scanned, updated)`. With
+    /// `dry_run`, computes the counts and touches nothing on disk. On a real run
+    /// it re-encodes in place — preserving wave-state, ghost stamps, and ids via
+    /// `ChiralMedium::re_encode_all` — then rebuilds the cache, invalidates the now
+    /// stale `.clusters.json` sidecar, and persists. Snapshot the HRM first
+    /// (the deployment gate #107 specifies) and verify recall before adopting.
+    pub fn recompute_encoding(&mut self, dry_run: bool) -> Result<(usize, usize), StoreError> {
+        let scanned = self.count();
+        if self.chiral.is_none() {
+            return Err(StoreError::Other(
+                "recompute_encoding supports chiral (v2) HRMs only; this store is flat".to_string(),
+            ));
+        }
+        let updated = {
+            let pipeline = &self.pipeline;
+            let chiral = self.chiral.as_mut().unwrap();
+            chiral
+                .re_encode_all(pipeline)
+                .map_err(|e| StoreError::Other(format!("re-encode failed: {}", e)))?
+        };
+        if dry_run {
+            return Ok((scanned, updated));
+        }
+        self.rebuild_cache()?;
+        self.mark_dirty();
+        self.save_medium()?;
+        // The cluster sidecar was computed from the OLD vectors — drop it so
+        // bridge::assess recomputes clusters against the corrected embeddings.
+        let clusters = self.hrm_path.with_extension("clusters.json");
+        let _ = std::fs::remove_file(&clusters);
+        Ok((scanned, updated))
+    }
+
     /// Get chiral consciousness summary (bilateral metrics).
     pub fn chiral_consciousness(&self) -> Option<ChiralConsciousness> {
         self.chiral.as_ref().map(|c| c.consciousness_summary())
@@ -2368,6 +2403,43 @@ mod tests {
             Some(ghost_time),
             "#497: rebuild must preserve a ghost's ADR-0037 stamp, not reset it to created_at"
         );
+    }
+
+    // #107: recompute_encoding re-encodes chiral wavefronts in place. dry-run
+    // reports the counts without writing; a real run rewrites the corrupted right
+    // vector to match a fresh encoding of the same content.
+    #[test]
+    fn recompute_encoding_chiral_fixes_vectors() {
+        let temp = NamedTempFile::new().unwrap();
+        let mut store = HrmStore::new(make_test_pipeline(), temp.path().to_path_buf());
+        store.upgrade_to_chiral();
+        let content = "resonance and standing waves";
+        // Seed with broken-encoder junk (the all-negative corner #106 produced).
+        let bad = vec![-0.9f32; WAVEFRONT_DIM];
+        let id = store.insert_raw_wavefront(bad, content.into(), 0.7).unwrap();
+
+        // What a correct encoding of this content lands as in a fresh right slot.
+        let want = {
+            let tmp2 = NamedTempFile::new().unwrap();
+            let mut refs = HrmStore::new(make_test_pipeline(), tmp2.path().to_path_buf());
+            refs.upgrade_to_chiral();
+            let good = make_test_pipeline().encode_text(content).unwrap();
+            let rid = refs.insert_raw_wavefront(good, content.into(), 0.7).unwrap();
+            let cm = refs.chiral_medium().unwrap();
+            let ridx = *cm.right.id_to_index.get(&rid).unwrap();
+            cm.right.wavefronts.row(ridx).to_vec()
+        };
+
+        // dry-run: counts only, nothing written.
+        assert_eq!(store.recompute_encoding(true).unwrap(), (1, 1));
+
+        // real run fixes the corrupted vector.
+        assert_eq!(store.recompute_encoding(false).unwrap(), (1, 1));
+        let cm = store.chiral_medium().unwrap();
+        let idx = *cm.right.id_to_index.get(&id).unwrap();
+        let got = cm.right.wavefronts.row(idx).to_vec();
+        let cos = crate::wave::cosine_similarity(&got, &want);
+        assert!(cos > 0.999, "recompute_encoding fixed the right vector (cos={cos})");
     }
 
     #[test]

--- a/src/hrm_store.rs
+++ b/src/hrm_store.rs
@@ -1711,8 +1711,10 @@ impl HrmStore {
         let updated = {
             let pipeline = &self.pipeline;
             let chiral = self.chiral.as_mut().unwrap();
+            // dry_run makes re_encode_all COUNT eligible wavefronts without mutating
+            // the in-memory hemispheres, so a dry run leaves the store untouched.
             chiral
-                .re_encode_all(pipeline)
+                .re_encode_all(pipeline, dry_run)
                 .map_err(|e| StoreError::Other(format!("re-encode failed: {}", e)))?
         };
         if dry_run {

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -527,10 +527,33 @@ impl ChiralMedium {
     /// is not re-applied — the refreshed left is a clean fold of the corrected
     /// right. Returns the count of right-hemisphere wavefronts re-encoded; the
     /// caller must rebuild derived caches and invalidate cluster sidecars.
-    pub fn re_encode_all(&mut self, pipeline: &EncodingPipeline) -> Result<usize, MediumError> {
+    pub fn re_encode_all(
+        &mut self,
+        pipeline: &EncodingPipeline,
+        dry_run: bool,
+    ) -> Result<usize, MediumError> {
         let mut updated = 0usize;
         for i in 0..self.right.count() {
+            // Only re-encode genuine TEXT wavefronts. SKIP:
+            //  - dream HALLUCINATIONS (metadata.hallucinated): their vectors are
+            //    synthetic cross-cluster superpositions, NOT encoder output —
+            //    re-encoding their "HALLUCINATION: ..." debug label pollutes recall.
+            //  - non-text MODALITIES (audio/visual/network/mixed): re-encoding their
+            //    content string as text corrupts the perceptual embedding.
+            // NOTE Modality::Unknown covers BOTH pre-ADR-0042 text memories AND raw
+            // substrate anchors (insert_raw_wavefront), which are indistinguishable
+            // for existing data — this tool is for TEXT HRMs; do NOT run it on a
+            // substrate HRM (the binary warns loudly).
+            let hallucinated = self.right.metadata[i].hallucinated;
+            let modality = self.right.metadata[i].modality;
+            if hallucinated || !matches!(modality, Modality::Semantic | Modality::Unknown) {
+                continue;
+            }
             let content = self.right.metadata[i].content.clone();
+            if dry_run {
+                updated += 1;
+                continue;
+            }
             let new_vec = pipeline.encode_text(&content).map_err(|e| {
                 MediumError::Serialization(bincode::Error::from(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -1427,7 +1450,7 @@ mod tests {
         cm.right.wavefronts.row_mut(idx).assign(&ndarray::Array1::from(vec![-0.9f32; cols]));
         let cos_bad = crate::wave::cosine_similarity(&cm.right.wavefronts.row(idx).to_vec(), &want);
 
-        let n = cm.re_encode_all(&pipeline).unwrap();
+        let n = cm.re_encode_all(&pipeline, false).unwrap();
         assert!(n >= 1, "re-encoded at least the stored memory");
 
         let got = cm.right.wavefronts.row(idx).to_vec();
@@ -1438,6 +1461,52 @@ mod tests {
         );
         assert_eq!(cm.right.energy[idx], energy_before, "energy (wave-state) preserved");
         assert_eq!(cm.right.metadata[idx].content, content, "content preserved");
+    }
+
+    // #532 review: re_encode_all must NOT clobber dream-hallucinated wavefronts
+    // (their vectors are synthetic superpositions, not text encodings). A
+    // hallucinated wavefront's vector must survive re_encode_all untouched.
+    #[test]
+    fn re_encode_all_skips_hallucinated() {
+        let pipeline = test_pipeline();
+        let text = "a genuine text memory";
+
+        // Reference: the correct stored (reduced-dims) encoding of the text.
+        let mut ref_cm = ChiralMedium::new();
+        let rid = ref_cm.store(text, 0.8, &pipeline).unwrap();
+        let want = ref_cm
+            .right
+            .wavefronts
+            .row(*ref_cm.right.id_to_index.get(&rid).unwrap())
+            .to_vec();
+
+        let mut cm = ChiralMedium::new();
+        let text_id = cm.store(text, 0.8, &pipeline).unwrap();
+        let hall_id = cm
+            .store("HALLUCINATION: superposition of patterns 1-2", 0.6, &pipeline)
+            .unwrap();
+        let cols = cm.right.wavefronts.ncols();
+
+        // Corrupt BOTH (as #106 would), and mark the second a dream hallucination
+        // with a distinctive synthetic vector (NOT the text encoding of its label).
+        let tidx = *cm.right.id_to_index.get(&text_id).unwrap();
+        cm.right.wavefronts.row_mut(tidx).assign(&ndarray::Array1::from(vec![-0.9f32; cols]));
+        let hidx = *cm.right.id_to_index.get(&hall_id).unwrap();
+        cm.right.metadata[hidx].hallucinated = true;
+        let synthetic = vec![0.42f32; cols];
+        cm.right.wavefronts.row_mut(hidx).assign(&ndarray::Array1::from(synthetic.clone()));
+
+        let n = cm.re_encode_all(&pipeline, false).unwrap();
+        assert_eq!(n, 1, "only the genuine text wavefront is re-encoded, not the hallucination");
+
+        // Hallucination byte-preserved; text fixed to the correct encoding.
+        assert_eq!(
+            cm.right.wavefronts.row(hidx).to_vec(),
+            synthetic,
+            "#532: hallucinated wavefront must NOT be re-encoded"
+        );
+        let cos = crate::wave::cosine_similarity(&cm.right.wavefronts.row(tidx).to_vec(), &want);
+        assert!(cos > 0.999, "the genuine text wavefront IS re-encoded (cos={cos})");
     }
 
     #[test]

--- a/src/medium/chiral.rs
+++ b/src/medium/chiral.rs
@@ -516,6 +516,56 @@ impl ChiralMedium {
         results
     }
 
+    /// Re-encode every stored memory's content through `pipeline`, replacing the
+    /// wavefront vectors IN PLACE while preserving all wave-state (energy, phase,
+    /// frequency) and metadata (#107). This fixes an HRM whose vectors were written
+    /// by a broken encoder (#106) without disturbing dream energies, ghost stamps,
+    /// or ids. The RIGHT hemisphere (authoritative) is re-encoded from its stored
+    /// content; each paired LEFT wavefront is re-derived as the Fano fold of the
+    /// corrected right vector on the SAME line it was stored on (read from the left
+    /// slot's `fano_group`), so left stays geometrically consistent. Callosal noise
+    /// is not re-applied — the refreshed left is a clean fold of the corrected
+    /// right. Returns the count of right-hemisphere wavefronts re-encoded; the
+    /// caller must rebuild derived caches and invalidate cluster sidecars.
+    pub fn re_encode_all(&mut self, pipeline: &EncodingPipeline) -> Result<usize, MediumError> {
+        let mut updated = 0usize;
+        for i in 0..self.right.count() {
+            let content = self.right.metadata[i].content.clone();
+            let new_vec = pipeline.encode_text(&content).map_err(|e| {
+                MediumError::Serialization(bincode::Error::from(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("encoding failed: {}", e),
+                )))
+            })?;
+            // Replace the right wavefront in place (adapts to dims like
+            // add_wavefront; energy/phase/frequency/metadata untouched).
+            self.right.set_wavefront_vector(i, &new_vec);
+            updated += 1;
+
+            // Re-derive the paired LEFT wavefront (if any) as a clean fold of the
+            // corrected right vector, on the fold line recorded for that left slot.
+            let right_id = self.right.metadata[i].id;
+            if let Some(&left_id) = self.right_to_left.get(&right_id) {
+                if let Some(&left_idx) = self.left.id_to_index.get(&left_id) {
+                    let fano_point = self.left.metadata[left_idx]
+                        .fano_group
+                        .or(self.right.metadata[i].fano_group)
+                        .unwrap_or(0);
+                    if let Some(&line) = self.fano.lines_through_point(fano_point).first() {
+                        let folded = self.fano.fold(
+                            &new_vec,
+                            self.right.dims,
+                            self.left.dims,
+                            line as usize,
+                        );
+                        self.left.set_wavefront_vector(left_idx, &folded);
+                    }
+                }
+            }
+        }
+        Ok(updated)
+    }
+
     /// Dream: mode-specific hemispheric refinement (ADR-0024 CS-7).
     ///
     /// Deep dreams refine the holistic hemisphere (right):
@@ -1349,6 +1399,45 @@ mod tests {
 
         // Should have a scale entry
         assert!(cm.scales.contains_key(&id));
+    }
+
+    // #107: re_encode_all rewrites the RIGHT wavefront to the fresh encoding of its
+    // stored content (fixing the #106 bad-subspace vectors) while preserving energy
+    // and metadata; the paired LEFT is re-folded without panic.
+    #[test]
+    fn re_encode_all_refreshes_right_preserving_state() {
+        let pipeline = test_pipeline();
+        let content = "a memory about resonance and standing waves";
+
+        // Reference: what a fresh store of this content yields in the right slot
+        // (same reduced dims as the wavefronts we'll compare against).
+        let mut ref_cm = ChiralMedium::new();
+        let ref_id = ref_cm.store(content, 0.8, &pipeline).unwrap();
+        let ref_idx = *ref_cm.right.id_to_index.get(&ref_id).unwrap();
+        let want = ref_cm.right.wavefronts.row(ref_idx).to_vec();
+
+        let mut cm = ChiralMedium::new();
+        let id = cm.store(content, 0.8, &pipeline).unwrap();
+        let idx = *cm.right.id_to_index.get(&id).unwrap();
+        let energy_before = cm.right.energy[idx];
+
+        // Simulate a broken-encoder vector: overwrite the right wavefront with the
+        // all-negative-corner junk #106 produced, keeping content + energy intact.
+        let cols = cm.right.wavefronts.ncols();
+        cm.right.wavefronts.row_mut(idx).assign(&ndarray::Array1::from(vec![-0.9f32; cols]));
+        let cos_bad = crate::wave::cosine_similarity(&cm.right.wavefronts.row(idx).to_vec(), &want);
+
+        let n = cm.re_encode_all(&pipeline).unwrap();
+        assert!(n >= 1, "re-encoded at least the stored memory");
+
+        let got = cm.right.wavefronts.row(idx).to_vec();
+        let cos_fixed = crate::wave::cosine_similarity(&got, &want);
+        assert!(
+            cos_fixed > 0.999,
+            "right wavefront re-encoded to the fresh vector (cos {cos_bad:.3} -> {cos_fixed:.3})"
+        );
+        assert_eq!(cm.right.energy[idx], energy_before, "energy (wave-state) preserved");
+        assert_eq!(cm.right.metadata[idx].content, content, "content preserved");
     }
 
     #[test]

--- a/src/medium/hemisphere.rs
+++ b/src/medium/hemisphere.rs
@@ -165,6 +165,22 @@ impl Hemisphere {
         Ok(id)
     }
 
+    /// Replace the vector at `index` IN PLACE, adapting it to this hemisphere's
+    /// `dims` exactly as `add_wavefront` does (truncate/zero-pad), without touching
+    /// energy/phase/frequency/metadata/id. Used by the re-encode migration (#107)
+    /// to refresh wavefronts written by a broken encoder. No-op if out of range.
+    pub(crate) fn set_wavefront_vector(&mut self, index: usize, vector: &[f32]) {
+        if index >= self.len {
+            return;
+        }
+        let adapted = Self::adapt_vector(vector, self.dims);
+        for (i, &val) in adapted.iter().enumerate() {
+            if i < self.dims {
+                self.wavefronts[[index, i]] = val;
+            }
+        }
+    }
+
     /// Remove a wavefront from this hemisphere using swap-remove (O(1) tensor op).
     pub fn remove_wavefront(&mut self, id: &Uuid) -> bool {
         let index = match self.id_to_index.get(id) {

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -173,7 +173,11 @@ pub fn build_consciousness_payload(
     })
 }
 
-fn make_pipeline() -> EncodingPipeline {
+/// Construct the production encoding pipeline (Ollama all-minilm with a
+/// deterministic hash fallback). Public so one-shot data tools — e.g. the #107
+/// re-encode migration binary — refresh wavefronts with the SAME pipeline the
+/// running system uses, not a test stand-in.
+pub fn make_pipeline() -> EncodingPipeline {
     let ollama = OllamaEncoder::default_local(); // all-minilm, 384-dim
     let hash_fallback = SimpleHashEncoder::new(CODEBOOK_INPUT_DIM, CODEBOOK_SEED);
     let composite = CompositeEncoder::new(Box::new(ollama), Box::new(hash_fallback));


### PR DESCRIPTION
## Summary

Implements **#107** — a one-shot, snapshot-gated tool to re-encode HRM wavefronts after the #106 encoder fix. Existing HRMs (Oracle prod, witness) still hold vectors in the all-negative subspace #106 collapsed text into; recall over a mixed store is inconsistent. This re-encodes every memory's **stored content** through the current pipeline **in place**, preserving all wave-state, ghost stamps, ids, connections, and reactivation counts — only the vector changes.

## Pieces

- **`ChiralMedium::re_encode_all(pipeline)`** — re-encodes the RIGHT hemisphere (authoritative) from content; re-derives each paired LEFT wavefront as a clean Fano fold of the corrected right vector, on the **same line** it was stored on (read from the left slot's `fano_group`). Callosal noise is not re-applied.
- **`Hemisphere::set_wavefront_vector(idx, vec)`** — the missing "iterate-and-re-encode surface" #107 named: replace a wavefront in place, adapting to the hemisphere's (reduced) dims exactly as `add_wavefront` does.
- **`HrmStore::recompute_encoding(dry_run) -> (scanned, updated)`** — chiral-only (prod is v2). Re-encodes, rebuilds the cache, invalidates the stale `.clusters.json`, persists. `dry_run` touches nothing.
- **`bin kannaka-recompute-encoding [data-dir] [--dry-run]`** — thin wrapper using the **production** pipeline (`openclaw::make_pipeline` made `pub`) so vectors match the running system.

## Rollout (as #107 specifies)

1. Snapshot the HRM (`kannaka events snapshot`)
2. `kannaka-recompute-encoding --dry-run` (reports the count)
3. `kannaka-recompute-encoding` (re-encodes; invalidates the cluster sidecar)
4. **Verify recall** (the #83 repro) before adopting / rolling to the next box

## Safety / review notes

- **Preserves everything but the vector** — energy, phase, frequency, ghost `updated_at`, ids, links, reactivation. No on-disk format change.
- **Chiral-only**; a flat/v1 store returns a clear error rather than half-migrating.
- **Left is re-folded without callosal noise** (clean fold of the corrected right) — a deliberate, documented choice; flag if you'd rather re-apply noise.
- **Anti-vacuous tests**: `re_encode_all_refreshes_right_preserving_state` (corrupt right wavefront with #106 junk → re-encode → cos ~1.0 vs fresh; energy/content preserved) and `recompute_encoding_chiral_fixes_vectors` (dry-run reports (1,1) + writes nothing; real run fixes the vector). Full chiral (16) + hrm_store (27) suites green.

**Not auto-merged** — this rewrites production memory vectors, so it's yours to review and roll out per the snapshot gate above.

Refs #107, #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
