### PR TITLE
refactor(clippy): remove redundant closures

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -957,7 +957,7 @@ pub fn ask_with_opts(
     // O(N²·dim) passes), so keep the seams instrumented.
     let timing = std::env::var("KANNAKA_TIME").map(|v| v == "1").unwrap_or(false);
     let mut t = std::time::Instant::now();
-    let mut lap = move |label: &str, t: &mut std::time::Instant| {
+    let lap = move |label: &str, t: &mut std::time::Instant| {
         if timing {
             eprintln!("[time] {label}: {:.2}s", t.elapsed().as_secs_f64());
         }

--- a/src/collective/glyph_spec.rs
+++ b/src/collective/glyph_spec.rs
@@ -445,7 +445,7 @@ pub fn decode_wire(bytes: &[u8]) -> Result<Glyph, GlyphError> {
     let ts_millis = i64::from_le_bytes(bytes[pos..pos + 8].try_into().map_err(|_| GlyphError::TooShort)?);
     pos += 8;
     let created_at = DateTime::from_timestamp_millis(ts_millis)
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
 
     // Parents
     let parent_count = u16::from_le_bytes(bytes[pos..pos + 2].try_into().map_err(|_| GlyphError::TooShort)?) as usize;

--- a/src/medium/chiral_persistence.rs
+++ b/src/medium/chiral_persistence.rs
@@ -280,7 +280,7 @@ impl ChiralMedium {
 
         // Write callosum state (bincode)
         let callosum_bytes = bincode::serialize(&self.callosum)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         w.write_all(&(callosum_bytes.len() as u32).to_le_bytes())?;
         w.write_all(&callosum_bytes)?;
 
@@ -288,7 +288,7 @@ impl ChiralMedium {
         let scales_vec: Vec<(uuid::Uuid, ChiralScale)> =
             self.scales.iter().map(|(&k, &v)| (k, v)).collect();
         let scales_bytes = bincode::serialize(&scales_vec)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         w.write_all(&(scales_bytes.len() as u32).to_le_bytes())?;
         w.write_all(&scales_bytes)?;
 
@@ -296,7 +296,7 @@ impl ChiralMedium {
         let lr_vec: Vec<(uuid::Uuid, uuid::Uuid)> =
             self.left_to_right.iter().map(|(&k, &v)| (k, v)).collect();
         let lr_bytes = bincode::serialize(&lr_vec)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         w.write_all(&(lr_bytes.len() as u32).to_le_bytes())?;
         w.write_all(&lr_bytes)?;
 
@@ -425,7 +425,7 @@ impl ChiralMedium {
         let mut callosum_bytes = vec![0u8; callosum_len];
         reader.read_exact(&mut callosum_bytes)?;
         let callosum: CorpusCallosum = bincode::deserialize(&callosum_bytes)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
 
         // Read scales
         reader.read_exact(&mut len_bytes)?;
@@ -434,7 +434,7 @@ impl ChiralMedium {
         let mut scales_bytes = vec![0u8; scales_len];
         reader.read_exact(&mut scales_bytes)?;
         let scales_vec: Vec<(uuid::Uuid, ChiralScale)> = bincode::deserialize(&scales_bytes)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         let scales: HashMap<uuid::Uuid, ChiralScale> = scales_vec.into_iter().collect();
 
         // Read ID mappings
@@ -444,7 +444,7 @@ impl ChiralMedium {
         let mut lr_bytes = vec![0u8; lr_len];
         reader.read_exact(&mut lr_bytes)?;
         let lr_vec: Vec<(uuid::Uuid, uuid::Uuid)> = bincode::deserialize(&lr_bytes)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         let left_to_right: HashMap<uuid::Uuid, uuid::Uuid> = lr_vec.iter().cloned().collect();
         let right_to_left: HashMap<uuid::Uuid, uuid::Uuid> =
             lr_vec.into_iter().map(|(l, r)| (r, l)).collect();
@@ -510,7 +510,7 @@ impl ChiralMedium {
 
         // Metadata (bincode)
         let meta_bytes = bincode::serialize(&h.metadata)
-            .map_err(|e| MediumError::Serialization(e))?;
+            .map_err(MediumError::Serialization)?;
         w.write_all(&(meta_bytes.len() as u32).to_le_bytes())?;
         w.write_all(&meta_bytes)?;
 

--- a/src/medium/persistence.rs
+++ b/src/medium/persistence.rs
@@ -236,11 +236,11 @@ impl Medium {
 
                 {
                     let mut temp_file =
-                        File::create(&temp_path).map_err(|e| MediumError::Io(e))?;
+                        File::create(&temp_path).map_err(MediumError::Io)?;
                     temp_file
                         .write_all(&output.stdout)
-                        .map_err(|e| MediumError::Io(e))?;
-                    temp_file.flush().map_err(|e| MediumError::Io(e))?;
+                        .map_err(MediumError::Io)?;
+                    temp_file.flush().map_err(MediumError::Io)?;
                 }
 
                 let result = Medium::load(&temp_path);

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -442,7 +442,7 @@ impl KannakaMemorySystem {
 
     pub fn recall(&mut self, query: &str, top_k: usize) -> Result<Vec<RecallResult>, SystemError> {
         let results = self.engine.store.resonate_query(query, top_k)
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
         let now = Utc::now();
 
         let mut out = Vec::new();
@@ -539,7 +539,7 @@ impl KannakaMemorySystem {
             .map(|t| t.to_string())
             .collect();
         let memories = self.engine.store.all_memories()
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
         let now = Utc::now();
         let mut scored: Vec<SearchResult> = Vec::new();
         for m in memories {
@@ -617,7 +617,7 @@ impl KannakaMemorySystem {
         top_k: usize,
     ) -> Result<Vec<RecallResult>, SystemError> {
         let results = self.engine.store.resonate_query_with_beam(beam, query, top_k)
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
         let now = Utc::now();
 
         let mut out = Vec::with_capacity(results.len());
@@ -869,7 +869,7 @@ impl KannakaMemorySystem {
         // Phase 1: Wave-native dream (eigenstructure annealing on holographic medium)
         let chiral_eta = self.dream_state.engine.chiral_perturbation;
         let wave_report = self.engine.store.dream_native(3, Some(1.0), chiral_eta)
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
 
         eprintln!("[dream] Wave-native dream complete: {} cycles, {} dissolved, {} strengthened, {} hallucinated",
             wave_report.cycles_completed, wave_report.wavefronts_dissolved,
@@ -1064,7 +1064,7 @@ impl KannakaMemorySystem {
         let before = self.bridge.assess(&self.engine);
 
         let report = self.engine.store.dream_native(1, Some(0.5), 0.0)
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
 
         let after = self.bridge.assess(&self.engine);
         self.mark_dreamed();
@@ -1316,7 +1316,7 @@ impl KannakaMemorySystem {
 
         // Absorb through the HRM-native path (low importance for hallucinations)
         let id = self.engine.store.absorb(content, 0.3, Some(&category))
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
 
         // Collect valid parent IDs before taking mutable borrow
         let found_parents: Vec<String> = parent_ids.iter()
@@ -1502,7 +1502,7 @@ impl KannakaMemorySystem {
 
         // Absorb through HRM-native path
         let id = self.engine.store.absorb(&content, 0.6, Some("experience"))
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
 
         if self.auto_save {
             self.save()?;
@@ -1547,7 +1547,7 @@ impl KannakaMemorySystem {
         
         // Absorb through HRM-native path
         let id = self.engine.store.absorb(&content, 0.7, Some("experience"))
-            .map_err(|e| SystemError::Store(e))?;
+            .map_err(SystemError::Store)?;
         
         if self.auto_save {
             self.save()?;


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup of `clippy::redundant_closure` — a lint the `[auto-maintainer]` bot's `uninlined_format_args` PRs (#510-512) don't cover, so it's complementary, not duplicative.

All changes are the canonical **constructor-as-function** idiom, verified equivalent by the type checker (a passing compile *is* the proof they're identical):

- `.map_err(|e| MediumError::Serialization(e))` → `.map_err(MediumError::Serialization)`
- `.map_err(|e| MediumError::Io(e))` → `.map_err(MediumError::Io)`
- `.map_err(|e| SystemError::Store(e))` → `.map_err(SystemError::Store)`
- `.unwrap_or_else(|| Utc::now())` → `.unwrap_or_else(Utc::now)`

Plus one adjacent unused `mut` on the `lap` timing closure.

Scoped auto-fix (`cargo clippy --fix --lib -- -A clippy::all -W clippy::redundant_closure`), 5 files, 20/20 lines. chiral module tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
