### PR TITLE
refactor(clippy): use i32::rem_euclid for positive-modulo in geometry

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -233,7 +233,7 @@ impl Z4Element {
 
     /// Power r^k
     pub fn power(k: i32) -> Self {
-        let index = ((k % 4 + 4) % 4) as usize;
+        let index = k.rem_euclid(4) as usize;
         let mut coefficients = [0.0; 4];
         coefficients[index] = 1.0;
         Self::new(coefficients)
@@ -386,7 +386,7 @@ impl Z3Element {
 
     /// Power τ^k
     pub fn power(k: i32) -> Self {
-        let index = ((k % 3 + 3) % 3) as usize;
+        let index = k.rem_euclid(3) as usize;
         let mut coefficients = [0.0; 3];
         coefficients[index] = 1.0;
         Self::new(coefficients)
@@ -703,7 +703,7 @@ pub fn transform_d(element: &SgaElement, k: i32) -> SgaElement {
 
 /// Apply T transform k times: permute basis vectors in 8-cycle
 pub fn transform_t(element: &SgaElement, k: i32) -> SgaElement {
-    let k_mod = ((k % 8 + 8) % 8) as u8;
+    let k_mod = k.rem_euclid(8) as u8;
     
     if k_mod == 0 {
         return element.clone();


### PR DESCRIPTION
Replaces the manual `((k % n) + n) % n` positive-modulo idiom with `k.rem_euclid(n)` at three SGA transform sites in `geometry.rs` (`Z4Element::power`, `Z3Element::power`, `transform_t`). Provably equivalent for i32 with a positive divisor. geometry tests (15) green.

The 9 `clamp-like` sites clippy also flags are **intentionally left** — clippy marks `manual_clamp` MaybeIncorrect (the `.max().min()` form differs from `clamp` on NaN), so it's not auto-fixed and warrants per-site review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)