### PR TITLE
fix(collective): widen create_hint reveal search 4x->64x (fixes ~1.8% miss + CI flake)

### DIFF
--- a/src/collective/privacy.rs
+++ b/src/collective/privacy.rs
@@ -652,8 +652,14 @@ pub fn create_hint(
 
     // Solve at the reduced difficulty to produce a partial solution
     let target_zeros = new_difficulty;
-    // Search up to 4x the expected work (2^difficulty) to handle variance
-    let search_bound = 4u64.saturating_mul(1u64 << new_difficulty.min(40));
+    // Search up to 64x the expected 2^difficulty work. The reveal MUST find a
+    // solution or the whole hint path silently breaks; at Nx the expected work the
+    // miss probability is ~e^-N, so the old 4x bound missed ~e^-4 ≈ 1.8% of random
+    // salts — a real production hint-failure rate AND a recurring CI flake
+    // (test_bloom_with_hint / test_execute_revelation_publishes_hint). 64x
+    // (~e^-64 ≈ 0, matching seal's cap) makes it reliable for any salt; the search
+    // still returns as soon as it finds a solution, so the common cost is unchanged.
+    let search_bound = 64u64.saturating_mul(1u64 << new_difficulty.min(40));
     let mut nonce_counter: u64 = 0;
 
     loop {
@@ -1019,6 +1025,22 @@ mod tests {
         // Bloom with hint — should work at reduced cost
         let solution = bloom_with_hint(&glyph, &hint, 4);
         assert!(solution.is_some(), "Should bloom with hint at reduced difficulty");
+    }
+
+    // Regression: create_hint must reliably find a low-difficulty solution across
+    // independent (random-salt) glyphs. The old 4x search bound missed ~1.8% of
+    // salts, intermittently flaking test_bloom_with_hint (and the revelation hint
+    // test) in CI. With the 64x bound it must not miss across many glyphs.
+    #[test]
+    fn create_hint_reliable_across_random_salts() {
+        for i in 0..400 {
+            let mem = test_memory(&format!("salt probe {i}"));
+            let glyph = seal(&mem, 6, "agent-1");
+            assert!(
+                create_hint(&glyph, 4, "agent-1").is_some(),
+                "create_hint(difficulty 4) must find a solution for glyph {i}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`create_hint` solves a reduced-difficulty hashcash reveal but searched only **4× the expected 2^difficulty work**. At Nx the miss probability is ~e⁻ᴺ, so 4× missed **~e⁻⁴ ≈ 1.8%** of random salts — spuriously returning `None`. Production seals with a **fresh random salt**, so this is a real ~1.8% hint-creation failure rate *and* the recurring CI flake (`test_bloom_with_hint`'s `.unwrap()`, `test_execute_revelation_publishes_hint`'s `hint.is_some()`) — both of which spuriously failed my PR merges twice today.

**Fix:** raise the bound to **64×** (matching `seal`'s cap; miss prob ~e⁻⁶⁴ ≈ 0). The search returns as soon as it finds a solution, so common-case cost is unchanged — only the safety cap moves.

Regression test `create_hint_reliable_across_random_salts` (**revert-confirmed** — the 4× bound reddens it within the first ~400 random-salt glyphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)