### PR TITLE
fix(medium): flat-save temp-path race + recall phase-difference (hunt round 2)

### DIFF
--- a/src/medium/core.rs
+++ b/src/medium/core.rs
@@ -364,6 +364,20 @@ impl Medium {
         let query_line: Option<u8> = None;
         let mut line_cache: std::collections::HashMap<usize, u8> = std::collections::HashMap::new();
 
+        // Query born phase for phase-DIFFERENCE resonance. Recall must compare the
+        // query's phase to each stored phase — using the stored phase ABSOLUTELY
+        // (`store.phase[i].cos()`) negates any memory whose born phase lands in
+        // (π/2, 3π/2), so under the belief substrate an exact match (phase π,
+        // cos=-1) scored -1 and sorted LAST — inverting recall. Every other phase
+        // interaction (apply_interference, dynamics) uses the difference, and
+        // content_born_phase is documented "recall-safe" precisely on that basis.
+        // Inert in the default text path (both phases 0 ⇒ cos(0)=1).
+        let query_phase = if crate::medium::chiral::belief_phase_enabled() {
+            crate::medium::chiral::content_born_phase(&query_vector)
+        } else {
+            0.0
+        };
+
         for &i in cand_slice {
             if i >= safe_count { continue; } // guard against stale beam indices / section desync
             let wavefront = self.store.wavefronts.row(i);
@@ -377,7 +391,8 @@ impl Medium {
 
             // Modulate by wave dynamics (energy, phase, temporal decay)
             let effective_strength = effective_strengths[i];
-            let phase_modulation = self.store.phase[i].cos(); // Phase affects resonance
+            // Phase DIFFERENCE (constructive interference), not absolute phase.
+            let phase_modulation = (self.store.phase[i] - query_phase).cos();
             let mut resonance_strength = similarity * effective_strength * phase_modulation;
 
             #[cfg(feature = "glyph")]
@@ -414,7 +429,7 @@ impl Medium {
                 let boosted_sim = xi_diversity_boost(r.similarity, &query_xi, &wf_xi);
                 r.similarity = boosted_sim;
                 let mut rs = boosted_sim * r.effective_strength
-                    * self.store.phase[i].cos();
+                    * (self.store.phase[i] - query_phase).cos();
                 // Re-apply glyph-gravity after the xi re-rank so it survives
                 // into the final ordering (line cached from stage 1).
                 #[cfg(feature = "glyph")]

--- a/src/medium/persistence.rs
+++ b/src/medium/persistence.rs
@@ -22,7 +22,18 @@ impl Medium {
     /// #362.)
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), MediumError> {
         let path_ref = path.as_ref();
-        let tmp_path = path_ref.with_extension("hrm.tmp");
+        // Per-writer-private temp file (pid + nanos), mirroring the chiral save
+        // path. A FIXED shared `.hrm.tmp` let two concurrent writers truncate each
+        // other mid-stream; blake3 was then hashed over the interleaved bytes and
+        // the rename landed a checksum-VALID-but-corrupt .hrm (Oracle 2026-05-26).
+        // The chiral path + the reactivation atomic_write were hardened; this flat
+        // path (fresh-bootstrap first save + v1-fallback stores) was missed.
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp_path = path_ref.with_extension(format!("hrm.tmp.{}.{}", pid, nanos));
         let file = File::create(&tmp_path)?;
         let mut writer = BufWriter::new(file);
 

--- a/src/medium/tests.rs
+++ b/src/medium/tests.rs
@@ -13,6 +13,50 @@ fn make_test_pipeline() -> EncodingPipeline {
     EncodingPipeline::new(Box::new(encoder), codebook)
 }
 
+// hunt: recall must score by the phase DIFFERENCE (query vs stored), not the
+// absolute stored phase. Under the belief substrate an exact-content match's born
+// phase can land in (π/2, 3π/2), so cos(absolute) < 0 negated its resonance and
+// buried the exact match. #[ignore] because it sets process-global
+// KANNAKA_BELIEF_PHASE (run with --ignored --nocapture).
+#[test]
+#[ignore = "sets KANNAKA_BELIEF_PHASE (process-global)"]
+fn recall_ranks_exact_match_first_under_belief() {
+    std::env::set_var("KANNAKA_BELIEF_PHASE", "1");
+    let pipeline = make_test_pipeline();
+
+    // Pick content whose born phase has cos < 0 — exactly the case the absolute-
+    // phase bug buries (a same-content match got resonance sim*energy*cos<0, so it
+    // sorted BELOW an unrelated positive-phase memory). This makes the test
+    // anti-vacuous: it reddens on the absolute-phase code and passes on the fix.
+    let candidates = [
+        "alpha target trace", "beta memory node", "gamma concept anchor",
+        "delta recall probe", "epsilon signal marker", "zeta phase test",
+    ];
+    let target_content = candidates
+        .iter()
+        .copied()
+        .find(|c| {
+            let v = pipeline.encode_text(c).unwrap();
+            crate::medium::chiral::content_born_phase(&v).cos() < 0.0
+        })
+        .expect("some candidate has a cos<0 born phase under the default encoder");
+
+    let mut medium = Medium::new();
+    let target = pipeline.encode_text(target_content).unwrap();
+    medium.add_wavefront(&target, target_content.to_string(), 1.0).unwrap();
+    let other = pipeline.encode_text("an utterly different subject").unwrap();
+    medium.add_wavefront(&other, "an utterly different subject".to_string(), 1.0).unwrap();
+
+    let results = medium.recall(target_content, 1, &pipeline).unwrap();
+    std::env::remove_var("KANNAKA_BELIEF_PHASE");
+
+    assert_eq!(
+        results.first().map(|r| r.content.as_str()),
+        Some(target_content),
+        "exact match must rank first under belief (phase DIFFERENCE, not absolute phase)"
+    );
+}
+
 #[test]
 fn new_medium_is_empty() {
     let medium = Medium::new();


### PR DESCRIPTION
Two confirmed bugs from a second adversarial hunt (persistence + recall core).

**1 (major, data-integrity) — flat save temp-path race.** `Medium::save` wrote to a **fixed shared** temp path (`<path>.hrm.tmp`), so two concurrent writers truncate each other mid-stream; blake3 then hashes the interleaved bytes and the atomic rename lands a **checksum-valid-but-corrupt** .hrm that fails/mis-parses every later load — silent whole-HRM loss. This is the exact Oracle 2026-05-26 corruption the chiral save path + the reactivation `atomic_write` were hardened against (per-pid temp); the flat path (fresh-bootstrap first save + v1-fallback) was missed. **Fix:** per-writer tmp `hrm.tmp.{pid}.{nanos}`, mirroring chiral; rename stays atomic. Roundtrip tests pass.

**2 (major, correctness) — recall used absolute phase.** `recall_against` scored with the **absolute** stored phase (`store.phase[i].cos()`) instead of the query-vs-stored **difference**, at both the score (core.rs:380) and xi re-rank (core.rs:417). Under belief, a memory's born phase can land in (π/2, 3π/2), so an **exact-content match** (born phase π ⇒ cos −1) scored −1 and sorted **last** — inverting recall. Every other phase interaction uses the difference, and `content_born_phase` is documented "recall-safe" only on that basis. **Fix:** compute the query's born phase once (belief-guarded, matching the store) and use `(store.phase[i] - query_phase).cos()`. Inert in the default text path (both phases 0). `#[ignore]` test `recall_ranks_exact_match_first_under_belief` (**revert-confirmed**).

Both reachability-narrowed (flat path: fresh-bootstrap/v1-fallback; recall: flat + belief) but both are genuine, verified defects with the failure mode of *silent corruption* / *inverted recall*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)