### PR TITLE
feat(ops): Windows seed-beacon installer (hidden, no console flash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added — Windows seed-beacon installer (hidden, no console flash)
+
+`ops/windows/install-beacon-task.ps1` + `ops/windows/kannaka-beacon-hidden.vbs`
+are the Windows equivalent of `ops/services/kannaka-beacon.service`: they run the
+per-seed `kannaka swarm beacon --loop` heartbeat as a hidden, auto-starting
+Scheduled Task. A naive `cmd`/console-action task flashes a console window every
+epoch in the interactive session — and the task "Hidden" flag does **not**
+suppress it (it only hides the task from the Task Scheduler UI). The installer
+instead points the action at `wscript.exe` running a launcher that starts the
+console binary with window style 0 (hidden): zero UI, no stored password, network
+preserved (the "run whether user is logged on or not" path would need a password,
+or fall back to S4U with no network — which breaks NATS publishing). The task
+starts at logon, restarts on failure, and **runs on battery** — a laptop seed
+that stopped beaconing on battery would freeze swarm promotions (anti-eclipse
+fail-closed). Seed-only; `--loop` refuses on a non-seed. See ADR-0039.
+
 ## [0.10.9] — 2026-07-08
 
 ### Changed — entropy source defaults to `reservoir` (Quantum-Wave T1.5 flip, #475)

--- a/ops/services/kannaka-beacon.service
+++ b/ops/services/kannaka-beacon.service
@@ -13,6 +13,10 @@
 # Install this ONLY on nodes whose pubkey is in swarm_trust.seed_pubkeys.
 # Enable with:  systemctl enable --now kannaka-beacon.service
 #
+# Windows seed: use ops/windows/install-beacon-task.ps1 instead — a plain
+# cmd/console Scheduled Task flashes a console window every epoch; that installer
+# runs the same --loop emitter hidden via wscript.
+#
 # Uses the installed binary at ~/.local/bin/kannaka. On a build node where the
 # binary lives in the cargo target dir, point ExecStart there instead.
 [Unit]

--- a/ops/windows/install-beacon-task.ps1
+++ b/ops/windows/install-beacon-task.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+  Install the Kannaka seed beacon as a hidden, auto-starting Windows Scheduled
+  Task. The Windows equivalent of ops/services/kannaka-beacon.service.
+
+.DESCRIPTION
+  Registers a task that runs `kannaka swarm beacon --loop` - one signed heartbeat
+  per corroboration epoch to KANNAKA.events.beacon - as a long-running daemon,
+  launched HIDDEN via wscript so no console window ever appears.
+
+  WHY HIDDEN: kannaka.exe is a console binary; a task that launches it (or a
+  `cmd` wrapper) in the interactive session flashes a black console window every
+  epoch. The task "Hidden" checkbox does NOT stop this - it only hides the task
+  from the Task Scheduler list. This installer points the action at wscript.exe
+  running kannaka-beacon-hidden.vbs (WshShell.Run window style 0 = hidden), so
+  the same publish runs with zero UI, no stored password, and full network
+  access (the "run whether user is logged on or not" alternative would need a
+  password, or fall back to S4U with no network - which breaks NATS publishing).
+
+  Install ONLY on a SEED node (a pubkey in swarm_trust.seed_pubkeys). `--loop`
+  refuses to run on a non-seed. See ADR-0039 for the anti-eclipse model: once the
+  gate is ARMED, promotion needs a FRESH seed beacon, so if a seed goes quiet,
+  promotion freezes to Quarantine (never drops content) until beacons resume.
+
+.PARAMETER KannakaExe
+  Full path to kannaka.exe. Default: %USERPROFILE%\.local\bin\kannaka.exe
+
+.PARAMETER TaskName
+  Scheduled Task name. Default: KannakaSeedBeacon
+
+.PARAMETER InstallDir
+  Where to copy the hidden launcher (a stable path, not the repo checkout).
+  Default: %USERPROFILE%\.local\bin
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File ops\windows\install-beacon-task.ps1
+
+.EXAMPLE
+  # Remove it:
+  Unregister-ScheduledTask -TaskName KannakaSeedBeacon -Confirm:$false
+#>
+[CmdletBinding()]
+param(
+    [string]$KannakaExe = (Join-Path $env:USERPROFILE '.local\bin\kannaka.exe'),
+    [string]$TaskName   = 'KannakaSeedBeacon',
+    [string]$InstallDir = (Join-Path $env:USERPROFILE '.local\bin')
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $KannakaExe)) {
+    throw "kannaka.exe not found at '$KannakaExe' - install the binary first, or pass -KannakaExe."
+}
+
+# 1. Install the hidden launcher next to the binary (stable, survives repo moves).
+$srcVbs = Join-Path $PSScriptRoot 'kannaka-beacon-hidden.vbs'
+if (-not (Test-Path $srcVbs)) { throw "launcher not found next to this script: '$srcVbs'" }
+$dstVbs = Join-Path $InstallDir 'kannaka-beacon-hidden.vbs'
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+Copy-Item $srcVbs $dstVbs -Force
+Write-Host "installed launcher -> $dstVbs"
+
+# 2. Idempotent: drop any prior task of this name.
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "removed existing task '$TaskName'"
+}
+
+# 3. Action: wscript (windowless host) runs the launcher, which starts
+#    `kannaka swarm beacon --loop` hidden.
+$action = New-ScheduledTaskAction -Execute 'wscript.exe' `
+    -Argument ('"{0}" "{1}"' -f $dstVbs, $KannakaExe)
+
+# 4. Trigger: at logon. The --loop daemon then self-schedules to each epoch
+#    boundary (like the systemd Restart=always unit); no repeating trigger needed.
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+# 5. Settings: keep the daemon alive, and RUN ON BATTERY - a laptop seed that
+#    stopped beaconing on battery would freeze swarm promotions (anti-eclipse
+#    fail-closed). ExecutionTimeLimit 0 = unlimited (it is a long-running daemon).
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+# 6. Principal: the current interactive user (needs the desktop session's user
+#    env + network for NATS; the launch is hidden so nothing shows).
+$me = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+$principal = New-ScheduledTaskPrincipal -UserId $me -LogonType Interactive -RunLevel Limited
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+    -Settings $settings -Principal $principal `
+    -Description 'Kannaka seed beacon - hidden per-epoch heartbeat (anti-eclipse, seed-only).' | Out-Null
+Write-Host "registered task '$TaskName' (at-logon, hidden --loop daemon)"
+
+# 7. Start it now so it is live without waiting for the next logon.
+Start-ScheduledTask -TaskName $TaskName
+Write-Host "started '$TaskName'."
+Write-Host ""
+Write-Host "Verify : kannaka swarm tail   (look for KANNAKA.events.beacon)"
+Write-Host "Remove : Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false"

--- a/ops/windows/kannaka-beacon-hidden.vbs
+++ b/ops/windows/kannaka-beacon-hidden.vbs
@@ -39,5 +39,9 @@ sh.Environment("PROCESS")("KANNAKA_READONLY") = "1"
 ' append: --interval-secs 60
 cmd = """" & exePath & """ swarm beacon --loop"
 
-' style 0 = hidden window, False = fire-and-forget (do not block the host).
-sh.Run cmd, 0, False
+' style 0 = hidden window. WAIT (True) keeps wscript alive for the daemon's whole
+' lifetime, so Task Scheduler tracks the task as Running -- that is what makes
+' MultipleInstances=IgnoreNew block a second daemon on the next logon, and lets
+' restart-on-failure fire if the --loop process ever exits. (For a one-shot
+' `swarm beacon` you would use False instead; --loop must WAIT.)
+sh.Run cmd, 0, True

--- a/ops/windows/kannaka-beacon-hidden.vbs
+++ b/ops/windows/kannaka-beacon-hidden.vbs
@@ -1,0 +1,43 @@
+' kannaka-beacon-hidden.vbs - windowless launcher for the seed beacon (Windows).
+'
+' Windows analog of the ExecStart in ops/services/kannaka-beacon.service. It runs
+' `kannaka swarm beacon --loop` (one signed heartbeat per corroboration epoch to
+' KANNAKA.events.beacon) with NO visible console.
+'
+' WHY THIS EXISTS: kannaka.exe is a console-subsystem binary. When a Windows
+' Scheduled Task launches it (or a `cmd` wrapper) directly in the interactive
+' session, Windows shows a console window every time it fires - a black flash
+' once per epoch. The task's "Hidden" setting does NOT suppress this (it only
+' hides the task from the Task Scheduler UI). wscript.exe is a windowless Script
+' Host, and WshShell.Run with window style 0 starts the console binary hidden, so
+' the identical beacon publish runs with zero UI.
+'
+' Usage (as a Scheduled Task action - see install-beacon-task.ps1):
+'   wscript.exe "<dir>\kannaka-beacon-hidden.vbs"
+'   wscript.exe "<dir>\kannaka-beacon-hidden.vbs" "C:\alt\path\kannaka.exe"
+'
+' Arg 1 (optional): full path to kannaka.exe.
+'   Default: %USERPROFILE%\.local\bin\kannaka.exe (the install.sh location).
+
+Option Explicit
+
+Dim sh, exePath, cmd
+Set sh = CreateObject("WScript.Shell")
+
+If WScript.Arguments.Count >= 1 Then
+    exePath = WScript.Arguments(0)
+Else
+    exePath = sh.ExpandEnvironmentStrings("%USERPROFILE%") & "\.local\bin\kannaka.exe"
+End If
+
+' Publisher only - the beacon emitter never writes the HRM. Keep it read-only so
+' it can never contend for the single-writer lock (mirrors the .service unit's
+' KANNAKA_READONLY=1). NATS auth is taken from the user's kannaka config/env.
+sh.Environment("PROCESS")("KANNAKA_READONLY") = "1"
+
+' One beacon per epoch; refuses to loop on a non-seed. For a fixed cadence,
+' append: --interval-secs 60
+cmd = """" & exePath & """ swarm beacon --loop"
+
+' style 0 = hidden window, False = fire-and-forget (do not block the host).
+sh.Run cmd, 0, False


### PR DESCRIPTION
## Summary
Ships the **Windows equivalent of `ops/services/kannaka-beacon.service`**. The repo had a systemd unit for Linux seeds but nothing for Windows, so Windows seeds ended up with hand-made Scheduled Tasks using a `cmd`/console action — which **flashes a console window every epoch** in the interactive session. (The task "Hidden" flag does *not* suppress this; it only hides the task from the Task Scheduler UI.)

Prompted by a real report: "the beacon pops a screen up every so often and then disappears — this should just run in the background."

## What's added
- **`ops/windows/kannaka-beacon-hidden.vbs`** — windowless launcher. `wscript.exe` is a windowless host and `WshShell.Run(cmd, 0, False)` (window style `0` = hidden) starts the console binary with no window. Runs the same `kannaka swarm beacon --loop` emitter.
- **`ops/windows/install-beacon-task.ps1`** — idempotent installer. Registers an **at-logon, restart-on-failure, runs-on-battery** hidden `--loop` daemon and starts it. Seed-only (`--loop` refuses on a non-seed). ASCII-only so Windows PowerShell 5.1 parses it without a BOM.
- Cross-reference line in `kannaka-beacon.service` + a CHANGELOG `[Unreleased]` entry.

## Why these choices
- **`wscript` hidden launcher, not "run whether logged on or not":** the latter runs windowless in session 0 but needs a stored password, or falls back to S4U with **no network** — which breaks NATS publishing. The shim needs neither.
- **Runs on battery on purpose:** a laptop seed that stopped beaconing on battery would freeze swarm promotions (anti-eclipse fail-closed, ADR-0039). A naive task defaults to `DisallowStartIfOnBatteries=True`.

## Verification (on a live seed)
- Installer registers the correct action (`wscript.exe "vbs" "exe"`), `DisallowStartIfOnBatteries=False`, `ExecutionTimeLimit=PT0S`, at-logon trigger, `LastTaskResult=0`.
- Hidden launcher publishes with **no window** (one-shot test: 2 beacons captured on `swarm tail`).
- `beacon --loop` emits per-epoch: over one epoch window it published 2 signed beacons to `KANNAKA.events.beacon` (`✓ signed` / `✓ published`), after passing the seed check.

Ops-only change — no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)