### PR TITLE
feat(ops): Windows beacon uninstaller (task + daemon + launcher teardown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ starts at logon, restarts on failure, and **runs on battery** — a laptop seed
 that stopped beaconing on battery would freeze swarm promotions (anti-eclipse
 fail-closed). Seed-only; `--loop` refuses on a non-seed. See ADR-0039.
 
+`ops/windows/uninstall-beacon-task.ps1` is the matching teardown: a bare
+`Unregister-ScheduledTask` leaves the running `--loop` daemon and the copied
+launcher behind, so the uninstaller stops the task, kills exactly this launcher's
+process tree (matched by launcher path, so a second beacon on the host is never
+touched), and removes the copied `.vbs`.
+
 ## [0.10.9] — 2026-07-08
 
 ### Changed — entropy source defaults to `reservoir` (Quantum-Wave T1.5 flip, #475)

--- a/ops/windows/install-beacon-task.ps1
+++ b/ops/windows/install-beacon-task.ps1
@@ -101,4 +101,4 @@ Start-ScheduledTask -TaskName $TaskName
 Write-Host "started '$TaskName'."
 Write-Host ""
 Write-Host "Verify : kannaka swarm tail   (look for KANNAKA.events.beacon)"
-Write-Host "Remove : Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false"
+Write-Host "Remove : ops\windows\uninstall-beacon-task.ps1  (task + daemon + launcher)"

--- a/ops/windows/uninstall-beacon-task.ps1
+++ b/ops/windows/uninstall-beacon-task.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+  Cleanly remove the Kannaka seed-beacon Scheduled Task installed by
+  install-beacon-task.ps1 (task + running daemon + copied launcher).
+
+.DESCRIPTION
+  `Unregister-ScheduledTask` alone is NOT a complete uninstall: the launcher
+  starts the `swarm beacon --loop` daemon, and depending on how it was launched
+  that process can outlive the task, and the copied kannaka-beacon-hidden.vbs is
+  left behind. This script does all three, precisely:
+
+    1. Stop + unregister the task.
+    2. Kill exactly THIS launcher's process tree (the wscript running this
+       task's own .vbs, plus its beacon child) - matched by the launcher path so
+       a second, unrelated beacon on the machine is never touched.
+    3. Remove the copied launcher.
+
+  Safe to run when the task is already gone (idempotent).
+
+.PARAMETER TaskName
+  Scheduled Task name to remove. Default: KannakaSeedBeacon
+
+.PARAMETER InstallDir
+  Directory the launcher was copied to (matches the installer default).
+  Default: %USERPROFILE%\.local\bin
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File ops\windows\uninstall-beacon-task.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$TaskName   = 'KannakaSeedBeacon',
+    [string]$InstallDir = (Join-Path $env:USERPROFILE '.local\bin')
+)
+
+$ErrorActionPreference = 'Stop'
+$vbs = Join-Path $InstallDir 'kannaka-beacon-hidden.vbs'
+
+# 1. Stop + unregister the task. Stopping first asks Task Scheduler to end the
+#    task's process tree; the precise kill below is a fallback for any survivor.
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 500
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "removed task '$TaskName'"
+} else {
+    Write-Host "no task '$TaskName' (already removed)"
+}
+
+# 2. Kill exactly this launcher's tree: the wscript.exe running THIS .vbs and its
+#    children. Matching on the launcher path (not a blanket 'swarm beacon --loop'
+#    sweep) means another beacon on the same host is never collateral-killed.
+$all    = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
+$hosts  = @($all | Where-Object { $_.Name -eq 'wscript.exe' -and $_.CommandLine -and $_.CommandLine.Contains($vbs) })
+$killed = 0
+foreach ($h in $hosts) {
+    foreach ($kid in @($all | Where-Object { $_.ParentProcessId -eq $h.ProcessId })) {
+        try { Stop-Process -Id $kid.ProcessId -Force -ErrorAction Stop; $killed++ } catch {}
+    }
+    try { Stop-Process -Id $h.ProcessId -Force -ErrorAction Stop; $killed++ } catch {}
+}
+Write-Host "stopped $killed leftover launcher process(es)"
+
+# 3. Remove the copied launcher.
+if (Test-Path $vbs) {
+    Remove-Item $vbs -Force
+    Write-Host "removed launcher $vbs"
+} else {
+    Write-Host "no launcher at $vbs"
+}
+
+Write-Host "uninstall complete."


### PR DESCRIPTION
## Summary
Completes the beacon ops toolkit shipped in #546. A bare `Unregister-ScheduledTask` is **not** a full uninstall — the `--loop` daemon and the copied `kannaka-beacon-hidden.vbs` are left behind. `ops/windows/uninstall-beacon-task.ps1` is the matching teardown.

## What it does
1. **Stop + unregister** the task (`Stop-ScheduledTask` ends the WAIT=True task's whole process tree via the scheduler job object).
2. **Kill exactly this launcher's tree** as a fallback — matched by the launcher `.vbs` path in the `wscript` command line, so a *second, unrelated* beacon on the same host is never collateral-killed.
3. **Remove** the copied launcher.

Idempotent (safe when the task is already gone). The installer's "Remove" hint now points here instead of the incomplete one-liner; CHANGELOG updated.

## Why path-matched (not a blanket kill)
A naive `Get-Process | where cmdline -match 'swarm beacon --loop' | kill` would take down every beacon on the host. Matching the specific launcher path makes uninstall surgical.

## Verification (on a live host running the real beacon)
Installed a throwaway beacon in a scratch dir, then uninstalled it:

| Check | Result |
|---|---|
| TEST task removed | gone |
| TEST daemon stopped | 0 hosts |
| TEST `.vbs` removed | yes |
| **REAL daemon (different launcher path)** | **still 1 host, untouched** |
| **REAL task** | **still Running** |

Ops-only — no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)